### PR TITLE
✨ [FEAT] 회원가입 - 종료 시 alert 띄우기

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/AgreeTerms/VC/AgreeTermsVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/AgreeTerms/VC/AgreeTermsVC.swift
@@ -70,7 +70,15 @@ class AgreeTermsVC: BaseVC {
     }
     
     @IBAction func tapDismissBtn(_ sender: UIButton) {
-        self.dismiss(animated: true, completion: nil)
+        guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+        alert.cancelBtn.press {
+            self.dismiss(animated: true, completion: nil)
+        }
+        alert.showNadoAlert(vc: self, message: """
+페이지를 나가면
+회원가입이 취소돼요.
+"""
+                            , confirmBtnTitle: "계속 작성", cancelBtnTitle: "나갈래요")
     }
     
     @IBAction func tapOpenTermBtn(_ sender: UIButton) {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/SignUpMajorInfo/VC/SignUpMajorInfoVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/SignUpMajorInfo/VC/SignUpMajorInfoVC.swift
@@ -111,7 +111,15 @@ class SignUpMajorInfoVC: BaseVC {
     }
     
     @IBAction func tapDismissBtn(_ sender: UIButton) {
-        self.dismiss(animated: true, completion: nil)
+        guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+        alert.cancelBtn.press {
+            self.dismiss(animated: true, completion: nil)
+        }
+        alert.showNadoAlert(vc: self, message: """
+페이지를 나가면
+회원가입이 취소돼요.
+"""
+                            , confirmBtnTitle: "계속 작성", cancelBtnTitle: "나갈래요")
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/SignUpUserInfo/VC/SignUpUserInfoVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/SignUpUserInfo/VC/SignUpUserInfoVC.swift
@@ -223,6 +223,14 @@ class SignUpUserInfoVC: BaseVC {
     }
     
     @IBAction func tapDismissBtn(_ sender: UIButton) {
-        self.dismiss(animated: true, completion: nil)
+        guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+        alert.cancelBtn.press {
+            self.dismiss(animated: true, completion: nil)
+        }
+        alert.showNadoAlert(vc: self, message: """
+페이지를 나가면
+회원가입이 취소돼요.
+"""
+                            , confirmBtnTitle: "계속 작성", cancelBtnTitle: "나갈래요")
     }
 }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #29 

## 🍎 변경 사항 및 이유
* 회원가입 과정의 모든 엑스(X) 버튼에서 Alert View가 나오도록 하여 화면 전환 적용

## 🍎 PR Point
* 근데 이 Alert 나오게 하는 메소드 언젠가 BaseVC에 추가할까봐여
은근 귀찮네

## 📸 ScreenShot

https://user-images.githubusercontent.com/43312096/149086808-53021e66-b8b1-4f82-93ab-95974c092028.MP4


