### PR TITLE
✨ [FEAT] 과방탭 - 질문 작성뷰 UI 구현

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
@@ -25,7 +25,6 @@
 		3313645E2785AA2B00E0C118 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3313645D2785AA2B00E0C118 /* UIButton+.swift */; };
 		331364602785AA6B00E0C118 /* UITableView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3313645F2785AA6B00E0C118 /* UITableView+.swift */; };
 		331364642785ADFE00E0C118 /* BaseVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331364632785ADFE00E0C118 /* BaseVC.swift */; };
-		331364662785AE3B00E0C118 /* BaseCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331364652785AE3B00E0C118 /* BaseCVC.swift */; };
 		331364682785AE6500E0C118 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331364672785AE6500E0C118 /* UIColor+.swift */; };
 		3313646A2785AED600E0C118 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331364692785AED600E0C118 /* UIFont+.swift */; };
 		3313646C2785AEE000E0C118 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3313646B2785AEE000E0C118 /* String+.swift */; };
@@ -57,7 +56,6 @@
 		331364C3278623C800E0C118 /* NetworkLoggerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331364C2278623C800E0C118 /* NetworkLoggerPlugin.swift */; };
 		331364C5278623EC00E0C118 /* s.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331364C4278623EC00E0C118 /* s.swift */; };
 		334D2E0427914C8800A4CA23 /* WriteQuestionSB.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 334D2E0327914C8800A4CA23 /* WriteQuestionSB.storyboard */; };
-		334D2E0727914CB200A4CA23 /* WriteQuestionVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334D2E0627914CB200A4CA23 /* WriteQuestionVC.swift */; };
 		33856370278DC74D003C60A6 /* BaseTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3385636F278DC74D003C60A6 /* BaseTVC.swift */; };
 		338CDAFF278C939B00F8227A /* TVCContentUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338CDAFE278C939B00F8227A /* TVCContentUpdate.swift */; };
 		338CDB02278C9F8600F8227A /* ClassroomCommentEditTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338CDB00278C9F8600F8227A /* ClassroomCommentEditTVC.swift */; };
@@ -74,6 +72,8 @@
 		33BE2D4727897DD1000FB6C8 /* NadoSunbaeNaviBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BE2D4627897DD1000FB6C8 /* NadoSunbaeNaviBar.swift */; };
 		33BE2D49278982E0000FB6C8 /* BaseNC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BE2D48278982E0000FB6C8 /* BaseNC.swift */; };
 		33BE2D6A2789D605000FB6C8 /* NadoSunbaeBtn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F02A8A278889650078F9B7 /* NadoSunbaeBtn.swift */; };
+		33DAB83A27914EAD00214CA8 /* WriteQuestionVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DAB83927914EAD00214CA8 /* WriteQuestionVC.swift */; };
+		33DAB83C279153A400214CA8 /* BaseCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DAB83B279153A400214CA8 /* BaseCVC.swift */; };
 		5C485F242789661F00FCA5DF /* NadoTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C485F232789661F00FCA5DF /* NadoTextField.swift */; };
 		5C4ED92A278949AC001EA6BB /* SignInSB.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5C4ED929278949AC001EA6BB /* SignInSB.storyboard */; };
 		5C4ED92C278949C4001EA6BB /* SignInVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4ED92B278949C4001EA6BB /* SignInVC.swift */; };
@@ -132,7 +132,6 @@
 		3313645D2785AA2B00E0C118 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		3313645F2785AA6B00E0C118 /* UITableView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+.swift"; sourceTree = "<group>"; };
 		331364632785ADFE00E0C118 /* BaseVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseVC.swift; sourceTree = "<group>"; };
-		331364652785AE3B00E0C118 /* BaseCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCVC.swift; sourceTree = "<group>"; };
 		331364672785AE6500E0C118 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		331364692785AED600E0C118 /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
 		3313646B2785AEE000E0C118 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
@@ -164,7 +163,6 @@
 		331364C2278623C800E0C118 /* NetworkLoggerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkLoggerPlugin.swift; sourceTree = "<group>"; };
 		331364C4278623EC00E0C118 /* s.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = s.swift; sourceTree = "<group>"; };
 		334D2E0327914C8800A4CA23 /* WriteQuestionSB.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = WriteQuestionSB.storyboard; sourceTree = "<group>"; };
-		334D2E0627914CB200A4CA23 /* WriteQuestionVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteQuestionVC.swift; sourceTree = "<group>"; };
 		3385636F278DC74D003C60A6 /* BaseTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTVC.swift; sourceTree = "<group>"; };
 		338CDAFE278C939B00F8227A /* TVCContentUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVCContentUpdate.swift; sourceTree = "<group>"; };
 		338CDB00278C9F8600F8227A /* ClassroomCommentEditTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassroomCommentEditTVC.swift; sourceTree = "<group>"; };
@@ -180,6 +178,8 @@
 		33BAFD06278C2D6100BFF6BE /* DefaultQuestionDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultQuestionDataModel.swift; sourceTree = "<group>"; };
 		33BE2D4627897DD1000FB6C8 /* NadoSunbaeNaviBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NadoSunbaeNaviBar.swift; sourceTree = "<group>"; };
 		33BE2D48278982E0000FB6C8 /* BaseNC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseNC.swift; sourceTree = "<group>"; };
+		33DAB83927914EAD00214CA8 /* WriteQuestionVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteQuestionVC.swift; sourceTree = "<group>"; };
+		33DAB83B279153A400214CA8 /* BaseCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCVC.swift; sourceTree = "<group>"; };
 		33F02A8A278889650078F9B7 /* NadoSunbaeBtn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NadoSunbaeBtn.swift; sourceTree = "<group>"; };
 		5C485F21278965D000FCA5DF /* NadoTextField.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NadoTextField.xib; sourceTree = "<group>"; };
 		5C485F232789661F00FCA5DF /* NadoTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NadoTextField.swift; sourceTree = "<group>"; };
@@ -329,9 +329,9 @@
 			isa = PBXGroup;
 			children = (
 				331364632785ADFE00E0C118 /* BaseVC.swift */,
-				331364652785AE3B00E0C118 /* BaseCVC.swift */,
 				33BE2D48278982E0000FB6C8 /* BaseNC.swift */,
 				3385636F278DC74D003C60A6 /* BaseTVC.swift */,
+				33DAB83B279153A400214CA8 /* BaseCVC.swift */,
 			);
 			path = Class;
 			sourceTree = "<group>";
@@ -514,9 +514,9 @@
 		3313649B2785D8A800E0C118 /* VC */ = {
 			isa = PBXGroup;
 			children = (
-				334D2E0627914CB200A4CA23 /* WriteQuestionVC.swift */,
 				331364A12785D8DD00E0C118 /* ClassroomMainVC.swift */,
 				33BAFD04278C061C00BFF6BE /* DefaultQuestionChatVC.swift */,
+				33DAB83927914EAD00214CA8 /* WriteQuestionVC.swift */,
 			);
 			path = VC;
 			sourceTree = "<group>";
@@ -989,10 +989,11 @@
 				331364602785AA6B00E0C118 /* UITableView+.swift in Sources */,
 				3313645E2785AA2B00E0C118 /* UIButton+.swift in Sources */,
 				777ABF80278C9584002D3214 /* ReviewMainPostTVC.swift in Sources */,
-				334D2E0727914CB200A4CA23 /* WriteQuestionVC.swift in Sources */,
+				33DAB83A27914EAD00214CA8 /* WriteQuestionVC.swift in Sources */,
 				331364BD27861CD300E0C118 /* UITextView+.swift in Sources */,
 				33BAFD05278C061C00BFF6BE /* DefaultQuestionChatVC.swift in Sources */,
 				338CDAFF278C939B00F8227A /* TVCContentUpdate.swift in Sources */,
+				33DAB83C279153A400214CA8 /* BaseCVC.swift in Sources */,
 				5C4ED92C278949C4001EA6BB /* SignInVC.swift in Sources */,
 				3313642A2784D3BD00E0C118 /* AppDelegate.swift in Sources */,
 				3391E497278B7AC50079EA31 /* ClassroomQuestionTVC.swift in Sources */,
@@ -1016,7 +1017,6 @@
 				33BAFD00278C004700BFF6BE /* ClassroomCommentTVC.swift in Sources */,
 				330DA4352790C3E300FE127F /* UIScrollView+.swift in Sources */,
 				331364902785D77100E0C118 /* ReviewMainVC.swift in Sources */,
-				331364662785AE3B00E0C118 /* BaseCVC.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
@@ -56,6 +56,8 @@
 		331364C12786217400E0C118 /* ReviewService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331364C02786217400E0C118 /* ReviewService.swift */; };
 		331364C3278623C800E0C118 /* NetworkLoggerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331364C2278623C800E0C118 /* NetworkLoggerPlugin.swift */; };
 		331364C5278623EC00E0C118 /* s.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331364C4278623EC00E0C118 /* s.swift */; };
+		334D2E0427914C8800A4CA23 /* WriteQuestionSB.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 334D2E0327914C8800A4CA23 /* WriteQuestionSB.storyboard */; };
+		334D2E0727914CB200A4CA23 /* WriteQuestionVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334D2E0627914CB200A4CA23 /* WriteQuestionVC.swift */; };
 		33856370278DC74D003C60A6 /* BaseTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3385636F278DC74D003C60A6 /* BaseTVC.swift */; };
 		338CDAFF278C939B00F8227A /* TVCContentUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338CDAFE278C939B00F8227A /* TVCContentUpdate.swift */; };
 		338CDB02278C9F8600F8227A /* ClassroomCommentEditTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338CDB00278C9F8600F8227A /* ClassroomCommentEditTVC.swift */; };
@@ -161,6 +163,8 @@
 		331364C02786217400E0C118 /* ReviewService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewService.swift; sourceTree = "<group>"; };
 		331364C2278623C800E0C118 /* NetworkLoggerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkLoggerPlugin.swift; sourceTree = "<group>"; };
 		331364C4278623EC00E0C118 /* s.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = s.swift; sourceTree = "<group>"; };
+		334D2E0327914C8800A4CA23 /* WriteQuestionSB.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = WriteQuestionSB.storyboard; sourceTree = "<group>"; };
+		334D2E0627914CB200A4CA23 /* WriteQuestionVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteQuestionVC.swift; sourceTree = "<group>"; };
 		3385636F278DC74D003C60A6 /* BaseTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTVC.swift; sourceTree = "<group>"; };
 		338CDAFE278C939B00F8227A /* TVCContentUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVCContentUpdate.swift; sourceTree = "<group>"; };
 		338CDB00278C9F8600F8227A /* ClassroomCommentEditTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassroomCommentEditTVC.swift; sourceTree = "<group>"; };
@@ -510,6 +514,7 @@
 		3313649B2785D8A800E0C118 /* VC */ = {
 			isa = PBXGroup;
 			children = (
+				334D2E0627914CB200A4CA23 /* WriteQuestionVC.swift */,
 				331364A12785D8DD00E0C118 /* ClassroomMainVC.swift */,
 				33BAFD04278C061C00BFF6BE /* DefaultQuestionChatVC.swift */,
 			);
@@ -520,6 +525,7 @@
 			isa = PBXGroup;
 			children = (
 				3313649F2785D8CB00E0C118 /* ClassroomSB.storyboard */,
+				334D2E0327914C8800A4CA23 /* WriteQuestionSB.storyboard */,
 			);
 			path = SB;
 			sourceTree = "<group>";
@@ -880,6 +886,7 @@
 				5C4ED92A278949AC001EA6BB /* SignInSB.storyboard in Resources */,
 				331364822785D60F00E0C118 /* Pretendard-Light.otf in Resources */,
 				3391E498278B7AC50079EA31 /* ClassroomQuestionTVC.xib in Resources */,
+				334D2E0427914C8800A4CA23 /* WriteQuestionSB.storyboard in Resources */,
 				33BAFD01278C004700BFF6BE /* ClassroomCommentTVC.xib in Resources */,
 				331364A82785D91800E0C118 /* NotificationSB.storyboard in Resources */,
 				3313647D2785BBAD00E0C118 /* Pretendard-Medium.otf in Resources */,
@@ -982,6 +989,7 @@
 				331364602785AA6B00E0C118 /* UITableView+.swift in Sources */,
 				3313645E2785AA2B00E0C118 /* UIButton+.swift in Sources */,
 				777ABF80278C9584002D3214 /* ReviewMainPostTVC.swift in Sources */,
+				334D2E0727914CB200A4CA23 /* WriteQuestionVC.swift in Sources */,
 				331364BD27861CD300E0C118 /* UITextView+.swift in Sources */,
 				33BAFD05278C061C00BFF6BE /* DefaultQuestionChatVC.swift in Sources */,
 				338CDAFF278C939B00F8227A /* TVCContentUpdate.swift in Sources */,

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/UITextView+.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/UITextView+.swift
@@ -24,4 +24,20 @@ extension UITextView {
         let positiveTopOffset = max(1, topOffset)
         contentOffset.y = -positiveTopOffset
     }
+    
+    /// line 수 카운트 메서드
+    func numberOfLines() -> Int {
+        let layoutManager = layoutManager
+        let numberOfGlyphs = layoutManager.numberOfGlyphs
+        var lineRange: NSRange = NSMakeRange(0, 1)
+        var index = 0
+        var numberOfLines = 0
+
+        while index < numberOfGlyphs {
+            layoutManager.lineFragmentRect(forGlyphAt: index, effectiveRange: &lineRange)
+            index = NSMaxRange(lineRange)
+            numberOfLines += 1
+        }
+        return numberOfLines
+    }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/Identifiers.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/Identifiers.swift
@@ -10,6 +10,7 @@ import Foundation
 struct Identifiers {
     static let ReviewSB = "ReviewSB"
     static let ClassroomSB = "ClassroomSB"
+    static let WriteQusetionSB = "WriteQuestionSB"
     static let NotificationSB = "NotificationSB"
     static let MypageSB = "MypageSB"
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Class/NadoSunbaeNaviBar.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Class/NadoSunbaeNaviBar.swift
@@ -33,6 +33,10 @@ enum NaviState {
 class NadoSunbaeNaviBar: UIView {
     
     // MARK: Properties
+    private lazy var backView = UIView().then {
+        $0.backgroundColor = .systemBackground
+    }
+    
     private lazy var titleLabel = UILabel().then {
         $0.setLabel(text: "제목", color: .black, size: 20, weight: .medium)
     }
@@ -73,7 +77,11 @@ extension NadoSunbaeNaviBar {
     // MARK: Private Methods
     /// 뒤로가기 버튼이 있는 디폴트 UI를 구성하는 메서드
     private func configureDefaultUI() {
-        self.addSubviews([backBtn, titleLabel])
+        self.addSubviews([backView, backBtn, titleLabel])
+        backView.snp.makeConstraints {
+            $0.top.leading.trailing.bottom.equalToSuperview()
+        }
+        
         backBtn.snp.makeConstraints {
             $0.top.leading.equalToSuperview()
             $0.height.width.equalTo(48)
@@ -87,7 +95,11 @@ extension NadoSunbaeNaviBar {
     
     /// 뒤로가기 버튼 + 나도선배 버튼 UI를 구성하는 메서드
     private func configureBackWithNadoBtnUI() {
-        self.addSubviews([backBtn, titleLabel, rightActivateBtn])
+        self.addSubviews([backView, backBtn, titleLabel, rightActivateBtn])
+        backView.snp.makeConstraints {
+            $0.top.leading.trailing.bottom.equalToSuperview()
+        }
+        
         backBtn.snp.makeConstraints {
             $0.top.leading.equalToSuperview()
             $0.height.width.equalTo(48)
@@ -108,7 +120,11 @@ extension NadoSunbaeNaviBar {
     
     /// 뒤로가기 버튼 + 중앙 텍스트 + 우측 커스텀 버튼 UI를 구성하는 메서드
     private func configureBackWithCenterUI() {
-        self.addSubviews([backBtn, titleLabel, rightCustomBtn])
+        self.addSubviews([backView, backBtn, titleLabel, rightCustomBtn])
+        backView.snp.makeConstraints {
+            $0.top.leading.trailing.bottom.equalToSuperview()
+        }
+        
         backBtn.snp.makeConstraints {
             $0.top.leading.equalToSuperview()
             $0.height.width.equalTo(48)
@@ -128,7 +144,11 @@ extension NadoSunbaeNaviBar {
     
     /// 취소 버튼 + 중앙 텍스트 + 우측 커스텀 버튼 UI를 구성하는 메서드
     private func configureDismissWithCustomRightBtnUI() {
-        self.addSubviews([dismissBtn, titleLabel, rightCustomBtn])
+        self.addSubviews([backView, dismissBtn, titleLabel, rightCustomBtn])
+        backView.snp.makeConstraints {
+            $0.top.leading.trailing.bottom.equalToSuperview()
+        }
+        
         dismissBtn.snp.makeConstraints {
             $0.top.equalTo(self).offset(4)
             $0.leading.equalTo(self).offset(4)
@@ -149,7 +169,11 @@ extension NadoSunbaeNaviBar {
     
     /// 취소 버튼 + 중앙 텍스트 + 나도선배 버튼 UI를 구성하는 메서드
     private func configureDismissWithNadoBtnUI() {
-        self.addSubviews([dismissBtn, titleLabel, rightActivateBtn])
+        self.addSubviews([backView, dismissBtn, titleLabel, rightActivateBtn])
+        backView.snp.makeConstraints {
+            $0.top.leading.trailing.bottom.equalToSuperview()
+        }
+        
         dismissBtn.snp.makeConstraints {
             $0.top.leading.equalToSuperview()
             $0.height.width.equalTo(48)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/SB/WriteQuestionSB.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/SB/WriteQuestionSB.storyboard
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17150" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17122"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController id="Y6W-OH-hqX" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/SB/WriteQuestionSB.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/SB/WriteQuestionSB.storyboard
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17150" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17122"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Write QuestionVC-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController id="Y6W-OH-hqX" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="WriteQuestionVC" id="Y6W-OH-hqX" customClass="WriteQuestionVC" customModule="NadoSunbae_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -20,6 +21,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="123" y="80"/>
         </scene>
     </scenes>
     <resources>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
@@ -14,6 +14,10 @@ import RxCocoa
 class WriteQuestionVC: UIViewController {
     
     // MARK: Properties
+    private let questionScrollView = UIScrollView()
+    private let contentView = UIView()
+    private let disposeBag = DisposeBag()
+    private var questionTextViewLineCount: Int = 1
     private let questionWriteNaviBar = NadoSunbaeNaviBar().then {
         $0.setUpNaviStyle(state: .dismissWithNadoBtn)
         $0.configureTitleLabel(title: "1:1 질문 작성")
@@ -41,11 +45,10 @@ class WriteQuestionVC: UIViewController {
         $0.setDefaultStyle(placeholderText: "선배에게 1:1 질문을 남겨보세요.\n선배가 답변해 줄 거에요!")
     }
     
-    let disposeBag = DisposeBag()
-    
     // MARK: LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.tabBarController?.tabBar.isHidden = true
         configureUI()
         setTextViewDelegate()
         setTapBtnAction()
@@ -57,17 +60,30 @@ extension WriteQuestionVC {
     
     /// UI 구성하는 메서드
     private func configureUI() {
-        view.addSubviews([questionWriteNaviBar, questionTitleTextField, textHighlightView, contentHeaderLabel, questionWriteTextView])
+        view.addSubviews([questionWriteNaviBar, questionScrollView])
+        questionScrollView.addSubview(contentView)
+        contentView.addSubviews([questionTitleTextField, textHighlightView, contentHeaderLabel, questionWriteTextView])
         
         questionWriteNaviBar.snp.makeConstraints {
             $0.top.leading.trailing.equalTo(view.safeAreaLayoutGuide)
             $0.height.equalTo(56)
         }
         
+        questionScrollView.snp.makeConstraints {
+            $0.top.equalTo(questionWriteNaviBar.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+        
+        contentView.snp.makeConstraints {
+            $0.width.equalToSuperview()
+            $0.height.equalToSuperview()
+            $0.centerX.top.bottom.equalToSuperview()
+        }
+        
         questionTitleTextField.snp.makeConstraints {
-            $0.top.equalTo(questionWriteNaviBar.snp.bottom).offset(24)
-            $0.leading.equalTo(view).offset(24)
-            $0.trailing.equalTo(view).offset(-24)
+            $0.top.equalToSuperview().offset(56)
+            $0.leading.equalToSuperview().offset(24)
+            $0.trailing.equalToSuperview().offset(-24)
         }
         
         textHighlightView.snp.makeConstraints {
@@ -84,7 +100,7 @@ extension WriteQuestionVC {
         questionWriteTextView.snp.makeConstraints {
             $0.top.equalTo(contentHeaderLabel.snp.bottom).offset(8)
             $0.leading.trailing.equalTo(questionTitleTextField)
-            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-58)
+            $0.bottom.equalTo(contentView.snp.bottom).offset(-102)
         }
         
         setHighlightViewState(textField: questionTitleTextField, highlightView: textHighlightView)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
@@ -1,0 +1,29 @@
+//
+//  WriteQuestionVC.swift
+//  NadoSunbae-iOS
+//
+//  Created by 황지은 on 2022/01/14.
+//
+
+import UIKit
+
+class WriteQuestionVC: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
@@ -181,15 +181,35 @@ extension WriteQuestionVC {
     
     /// btn Action set 메서드
     private func setTapBtnAction() {
+        
+        /// rightActivat Btn Press
         questionWriteNaviBar.rightActivateBtn.press {
-            print("press")
-            // TODO: Alert 띄우기
+            guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+            alert.showNadoAlert(vc: self, message:
+    """
+    글을 올리시겠습니까?
+    """
+                                , confirmBtnTitle: "네", cancelBtnTitle: "아니요")
+            alert.confirmBtn.press {
+                // TODO: 글 올리기 서버통신부
+            }
         }
         
+        /// dismissBtn Press
         questionWriteNaviBar.dismissBtn.press {
-            print("dismiss")
+            guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+            alert.showNadoAlert(vc: self, message:
+    """
+    페이지를 나가면
+    작성중인 글이 삭제돼요.
+    """
+                                , confirmBtnTitle: "계속 작성", cancelBtnTitle: "나갈래요")
+            alert.cancelBtn.press {
+                self.dismiss(animated: true, completion: nil)
+            }
         }
     }
+    
     
     /// textView의 상태에 따라 스크롤뷰를 Up, Down 하는 메서드
     private func scollByTextViewState(textView: UITextView) {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
@@ -209,7 +209,6 @@ extension WriteQuestionVC {
         }
     }
     
-    
     /// textView의 상태에 따라 스크롤뷰를 Up, Down 하는 메서드
     private func scollByTextViewState(textView: UITextView) {
         var contentOffsetY = questionScrollView.contentOffset.y

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
@@ -6,24 +6,148 @@
 //
 
 import UIKit
+import SnapKit
+import Then
+import RxSwift
+import RxCocoa
 
 class WriteQuestionVC: UIViewController {
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+    
+    // MARK: Properties
+    private let questionWriteNaviBar = NadoSunbaeNaviBar().then {
+        $0.setUpNaviStyle(state: .dismissWithNadoBtn)
+        $0.configureTitleLabel(title: "1:1 질문 작성")
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    private let questionTitleTextField = UITextField().then {
+        $0.borderStyle = .none
+        $0.backgroundColor = .white
+        $0.placeholder = "질문 제목을 입력하세요."
+        $0.textColor = .mainDefault
+        $0.font = .PretendardSB(size: 24.0)
     }
-    */
+    
+    private let textHighlightView = UIView().then {
+        $0.backgroundColor = .gray0
+    }
+    
+    private let contentHeaderLabel = UILabel().then {
+        $0.text = "내용"
+        $0.textColor = .black
+        $0.font = .PretendardM(size: 16.0)
+    }
+    
+    private let questionWriteTextView = NadoTextView().then {
+        $0.setDefaultStyle(placeholderText: "선배에게 1:1 질문을 남겨보세요.\n선배가 답변해 줄 거에요!")
+    }
+    
+    let disposeBag = DisposeBag()
+    
+    // MARK: LifeCycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+        setTextViewDelegate()
+        setTapBtnAction()
+    }
+}
 
+// MARK: - UI
+extension WriteQuestionVC {
+    private func configureUI() {
+        view.addSubviews([questionWriteNaviBar, questionTitleTextField, textHighlightView, contentHeaderLabel, questionWriteTextView])
+        
+        questionWriteNaviBar.snp.makeConstraints {
+            $0.top.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(56)
+        }
+        
+        questionTitleTextField.snp.makeConstraints {
+            $0.top.equalTo(questionWriteNaviBar.snp.bottom).offset(24)
+            $0.leading.equalTo(view).offset(24)
+            $0.trailing.equalTo(view).offset(-24)
+        }
+        
+        textHighlightView.snp.makeConstraints {
+            $0.top.equalTo(questionTitleTextField.snp.bottom).offset(4)
+            $0.leading.trailing.equalTo(questionTitleTextField)
+            $0.height.equalTo(1)
+        }
+        
+        contentHeaderLabel.snp.makeConstraints {
+            $0.top.equalTo(textHighlightView.snp.bottom).offset(72)
+            $0.leading.equalTo(textHighlightView)
+        }
+        
+        questionWriteTextView.snp.makeConstraints {
+            $0.top.equalTo(contentHeaderLabel.snp.bottom).offset(8)
+            $0.leading.trailing.equalTo(questionTitleTextField)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-58)
+        }
+    }
+}
+
+// MARK: - Custom Method
+extension WriteQuestionVC {
+    
+    private func setTextViewDelegate() {
+        questionWriteTextView.delegate = self
+    }
+    /// textField가 채워져 있는지에 따라 Btn 상태 변경하는 함수
+    private func setCheckBtnState(textField: UITextField, checkBtn: NadoSunbaeBtn) {
+        textField.rx.text
+            .orEmpty
+            .distinctUntilChanged()
+            .subscribe(onNext: { changedText in
+                //                self.changeNadoBtnState(isOn: changedText != "", btn: checkBtn)
+            })
+            .disposed(by: disposeBag)
+        
+        //        nickNameClearBtn.rx.tap
+        //            .bind {
+        //                self.changeNadoBtnState(isOn: false, btn: self.checkDuplicateBtn)
+        //            }
+        //            .disposed(by: disposeBag)
+        //
+        //        emailClearBtn.rx.tap
+        //            .bind {
+        //                self.changeNadoBtnState(isOn: false, btn: self.checkEmailBtn)
+        //            }
+        //            .disposed(by: disposeBag)
+    }
+    
+    private func setTapBtnAction() {
+        questionWriteNaviBar.rightActivateBtn.press {
+            print("press")
+            // TODO: Alert 띄우기
+        }
+        
+        questionWriteNaviBar.dismissBtn.press {
+            print("dismiss")
+            self.dismiss(animated: true, completion: nil)
+        }
+    }
+}
+
+// MARK: - UITextViewDelegate
+extension WriteQuestionVC: UITextViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        DispatchQueue.main.async() {
+            scrollView.scrollIndicators.vertical?.backgroundColor = .scrollMint
+        }
+    }
+    
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.textColor == .gray2 {
+            textView.text = nil
+            textView.textColor = .mainText
+        }
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.isEmpty {
+            textView.text = "선배에게 1:1 질문을 남겨보세요.\n선배가 답변해 줄 거에요!"
+            textView.textColor = .gray2
+        }
+    }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
@@ -144,7 +144,6 @@ extension WriteQuestionVC {
     
     /// 제목, 내용이 모두 채워져 있는지에 따라 상단 네비바 버튼 활성화/비활성화 하는 메서드
     private func setActivateBtnState(textField: UITextField, textView: NadoTextView) {
-        
         let a = BehaviorSubject<Bool>(value: false)
         let b = BehaviorSubject<Bool>(value: false)
         
@@ -238,7 +237,6 @@ extension WriteQuestionVC {
                     questionScrollView.setContentOffset(CGPoint(x: 0, y: 0), animated: true)
                 }
             }
-            
         }
         questionTextViewLineCount = textView.numberOfLines()
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
@@ -84,6 +84,8 @@ extension WriteQuestionVC {
             $0.leading.trailing.equalTo(questionTitleTextField)
             $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-58)
         }
+        
+        setHighlightViewState(textField: questionTitleTextField, highlightView: textHighlightView)
     }
 }
 
@@ -93,27 +95,20 @@ extension WriteQuestionVC {
     private func setTextViewDelegate() {
         questionWriteTextView.delegate = self
     }
-    /// textField가 채워져 있는지에 따라 Btn 상태 변경하는 함수
-    private func setCheckBtnState(textField: UITextField, checkBtn: NadoSunbaeBtn) {
+    /// textField가 채워져 있는지에 따라 highlightView 상태 변경하는 함수
+    private func setHighlightViewState(textField: UITextField, highlightView: UIView) {
         textField.rx.text
             .orEmpty
+            .skip(1)
             .distinctUntilChanged()
-            .subscribe(onNext: { changedText in
-                //                self.changeNadoBtnState(isOn: changedText != "", btn: checkBtn)
+            .subscribe(onNext: { [weak self] changedText in
+                if self?.questionTitleTextField.text?.isEmpty == true {
+                    self?.textHighlightView.backgroundColor = .gray0
+                } else {
+                    self?.textHighlightView.backgroundColor = .black
+                }
             })
             .disposed(by: disposeBag)
-        
-        //        nickNameClearBtn.rx.tap
-        //            .bind {
-        //                self.changeNadoBtnState(isOn: false, btn: self.checkDuplicateBtn)
-        //            }
-        //            .disposed(by: disposeBag)
-        //
-        //        emailClearBtn.rx.tap
-        //            .bind {
-        //                self.changeNadoBtnState(isOn: false, btn: self.checkEmailBtn)
-        //            }
-        //            .disposed(by: disposeBag)
     }
     
     private func setTapBtnAction() {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
@@ -54,6 +54,8 @@ class WriteQuestionVC: UIViewController {
 
 // MARK: - UI
 extension WriteQuestionVC {
+    
+    /// UI 구성하는 메서드
     private func configureUI() {
         view.addSubviews([questionWriteNaviBar, questionTitleTextField, textHighlightView, contentHeaderLabel, questionWriteTextView])
         
@@ -92,10 +94,12 @@ extension WriteQuestionVC {
 // MARK: - Custom Method
 extension WriteQuestionVC {
     
+    /// textView delegate 설정하는 메서드
     private func setTextViewDelegate() {
         questionWriteTextView.delegate = self
     }
-    /// textField가 채워져 있는지에 따라 highlightView 상태 변경하는 함수
+    
+    /// textField가 채워져 있는지에 따라 highlightView 상태 변경하는 메서드
     private func setHighlightViewState(textField: UITextField, highlightView: UIView) {
         textField.rx.text
             .orEmpty
@@ -111,6 +115,7 @@ extension WriteQuestionVC {
             .disposed(by: disposeBag)
     }
     
+    /// btn Action set 메서드
     private func setTapBtnAction() {
         questionWriteNaviBar.rightActivateBtn.press {
             print("press")
@@ -126,12 +131,15 @@ extension WriteQuestionVC {
 
 // MARK: - UITextViewDelegate
 extension WriteQuestionVC: UITextViewDelegate {
+    
+    /// scrollViewDidScroll
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         DispatchQueue.main.async() {
             scrollView.scrollIndicators.vertical?.backgroundColor = .scrollMint
         }
     }
     
+    /// textViewDidBeginEditing
     func textViewDidBeginEditing(_ textView: UITextView) {
         if textView.textColor == .gray2 {
             textView.text = nil
@@ -139,6 +147,7 @@ extension WriteQuestionVC: UITextViewDelegate {
         }
     }
     
+    /// textViewDidEndEditing
     func textViewDidEndEditing(_ textView: UITextView) {
         if textView.text.isEmpty {
             textView.text = "선배에게 1:1 질문을 남겨보세요.\n선배가 답변해 줄 거에요!"


### PR DESCRIPTION
## 🍎 관련 이슈
closed #44 

## 🍎 변경 사항 및 이유
- UITextView+에 lineCount를 return 하는 메서드를 추가했습니다!
- NadoSunbaeNaviBar에서 백그라운드 컬러가 투명하다는 민원을 받아 백그라운드뷰를 추가해두었습니다 ~~ 이제 백뷰 안만드셔도 돼 선배들,,

## 🍎 PR Point
- 과방탭 textView height가 굉장히 커서.. 키보드 액션땜에 고민을 마니 했는데..!
- 매끄러운 스크롤을 위해서 하단에 스크롤뷰를 깔아 구현해봤음 ~~
- 글고 재사용선배 진짜 짱조아.. 

## 📸 ScreenShot
- 시뮬 구동 영상
![Simulator Screen Recording - iPhone 12 - 2022-01-15 at 17 29 17](https://user-images.githubusercontent.com/63224278/149615310-ee4c9010-5d36-43c3-9875-e25c06d000ff.gif)

- 키보드 나올 때 구동 영상
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/63224278/149615343-5ad12b01-c3dd-4e2f-9848-72a39c6a98f8.gif)

