### PR TITLE
✅ [CHORE] 시간 처리 함수 추가

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
@@ -1453,7 +1453,7 @@
 				CODE_SIGN_ENTITLEMENTS = "NadoSunbae-iOS/NadoSunbae-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 397WA8BG8W;
+				DEVELOPMENT_TEAM = 2ZS26WP93H;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "NadoSunbae-iOS/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "나도선배";
@@ -1483,7 +1483,7 @@
 				CODE_SIGN_ENTITLEMENTS = "NadoSunbae-iOS/NadoSunbae-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 397WA8BG8W;
+				DEVELOPMENT_TEAM = 2ZS26WP93H;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "NadoSunbae-iOS/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "나도선배";

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/String+.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/String+.swift
@@ -30,4 +30,38 @@ extension String {
         }
     }
     
+    /// serverTimeToString의 용도 정의
+    enum TimeStringCase {
+        case forNotification
+        case forDefault
+    }
+    
+    /// 서버에서 들어온 Date String을 UI에 적용 가능한 String 타입으로 반환하는 메서드
+    func serverTimeToString(forUse: TimeStringCase) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yy/MM/dd"
+        
+        let currentTime = Int(Date().timeIntervalSince1970)
+        
+        switch forUse {
+        case .forNotification:
+            let getTime = self.toDate().timeIntervalSince1970
+            let displaySec = currentTime - Int(getTime)
+            let displayMin = displaySec / 60
+            let displayHour = displayMin / 60
+            let displayDay = displayHour / 24
+            
+            if displayDay >= 1 {
+                return dateFormatter.string(from: self.toDate())
+            } else if displayHour >= 1 {
+                return "\(displayHour)시간 전"
+            } else if displayMin >= 1 {
+                return "\(displayMin)분 전"
+            } else {
+                return "1분 전"
+            }
+        case .forDefault:
+            return dateFormatter.string(from: self.toDate())
+        }
+    }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/String+.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/String+.swift
@@ -16,4 +16,18 @@ extension String {
         }
         return nil
     }
+    
+    /// 서버에서 들어온 Date String을 Date 타입으로 반환하는 메서드
+    private func toDate() -> Date {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        dateFormatter.timeZone = TimeZone(identifier: "KST")
+        if let date = dateFormatter.date(from: self) {
+            return date
+        } else {
+            print("toDate() convert error")
+            return Date()
+        }
+    }
+    
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/MypageMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/MypageMainVC.swift
@@ -22,8 +22,8 @@ class MypageMainVC: UIViewController {
     // MARK: Properties
     var isQuestionable = false
     var questionList = [
-        MypageQuestionModel(title: "에스파는나야둘이될수없어", content: "예예예예질문내용입니다ㅏㅏㅏㅏ", nickName: "윈터내거", writeTime: "오후 5:33", commentCount: 2, likeCount: 5),
-        MypageQuestionModel(title: "에스파는나야둘이될수없어", content: "예예예예질문내용입니다예예예예질문내용입니다예예예예질문내용입니다예예예예질문내용입니다", nickName: "윈터내거", writeTime: "오후 5:33", commentCount: 2, likeCount: 5)
+        MypageQuestionModel(title: "에스파는나야둘이될수없어", content: "예예예예질문내용입니다ㅏㅏㅏㅏ", nickName: "윈터내거", writeTime: "2022-01-18T19:00:42.040Z", commentCount: 2, likeCount: 5),
+        MypageQuestionModel(title: "에스파는나야둘이될수없어", content: "예예예예질문내용입니다예예예예질문내용입니다예예예예질문내용입니다예예예예질문내용입니다", nickName: "윈터내거", writeTime: "2022-01-18T19:20:42.040Z", commentCount: 2, likeCount: 5)
     ]
     
     // MARK: LifeCycle

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/Cell/MypageQuestionTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/Cell/MypageQuestionTVC.swift
@@ -31,7 +31,7 @@ class MypageQuestionTVC: BaseTVC {
         titleLabel.text = data.title
         contentLabel.text = data.content
         nickNameLabel.text = data.nickName
-        timeLabel.text = data.writeTime
+        timeLabel.text = data.writeTime.serverTimeToString(forUse: .forDefault)
         commentCountLabel.text = "\(data.commentCount)"
         likeCountLabel.text = "\(data.likeCount)"
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC.swift
@@ -32,8 +32,8 @@ class MypageUserVC: BaseVC {
     // MARK: Properties
     var isQuestionable = true
     var questionList = [
-        MypageQuestionModel(title: "에스파는나야둘이될수없어", content: "예예예예질문내용입니다ㅏㅏㅏㅏ", nickName: "윈터내거", writeTime: "오후 5:33", commentCount: 2, likeCount: 5),
-        MypageQuestionModel(title: "에스파는나야둘이될수없어", content: "예예예예질문내용입니다예예예예질문내용입니다예예예예질문내용입니다예예예예질문내용입니다", nickName: "윈터내거", writeTime: "오후 5:33", commentCount: 2, likeCount: 5)
+        MypageQuestionModel(title: "에스파는나야둘이될수없어", content: "예예예예질문내용입니다ㅏㅏㅏㅏ", nickName: "윈터내거", writeTime: "2022-01-18T19:00:42.040Z", commentCount: 2, likeCount: 5),
+        MypageQuestionModel(title: "에스파는나야둘이될수없어", content: "예예예예질문내용입니다예예예예질문내용입니다예예예예질문내용입니다예예예예질문내용입니다", nickName: "윈터내거", writeTime: "2022-01-18T19:00:42.040Z", commentCount: 2, likeCount: 5)
     ]
     
     // MARK: LifeCycle

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Notification/Cell/NotificationTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Notification/Cell/NotificationTVC.swift
@@ -64,6 +64,6 @@ extension NotificationTVC {
         titleLabel.attributedText = mintAttributeStr
 
         contentLabel.text = "\(data.content)"
-        timeLabel.text = "\(data.time)"
+        timeLabel.text = data.time.serverTimeToString(forUse: .forNotification)
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Notification/VC/NotificationMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Notification/VC/NotificationMainVC.swift
@@ -33,13 +33,13 @@ class NotificationMainVC: BaseVC {
     
     // MARK: Properties
     var notificationList = [
-        NotificationModel(senderNickName: "최숙주", notiType: .mypageQuestion, time: "1시간 전", isRead: false, title: "확인해", content: "알림읽어용~!!&^^"),
-        NotificationModel(senderNickName: "정정숙", notiType: .answerQuestion, time: "1시간 전", isRead: true, title: "확인해", content: "알림읽어용~!!&^^"),
-        NotificationModel(senderNickName: "황정숙", notiType: .notiInfo, time: "1시간 전", isRead: false, title: "확인해", content: "알림읽어용~!!&^^"),
-        NotificationModel(senderNickName: "김두숙", notiType: .writtenInfo, time: "1시간 전", isRead: false, title: "확인해", content: "알림읽어용~!!&^^"),
-        NotificationModel(senderNickName: "김나도", notiType: .notiQuestion, time: "1시간 전", isRead: true, title: "확인해", content: "알림읽어용~!!&^^"),
-        NotificationModel(senderNickName: "이선배", notiType: .answerInfo, time: "1시간 전", isRead: true, title: "확인해", content: "알림읽어용~!!&^^"),
-        NotificationModel(senderNickName: "김나도", notiType: .answerQuestion, time: "1시간 전", isRead: false, title: "확인해", content: "알림읽어용~!!&^^")
+        NotificationModel(senderNickName: "최숙주", notiType: .mypageQuestion, time: "2022-01-18T19:29:42.040Z", isRead: false, title: "확인해", content: "알림읽어용~!!&^^"),
+        NotificationModel(senderNickName: "정정숙", notiType: .answerQuestion, time: "2022-01-18T14:56:42.040Z", isRead: true, title: "확인해", content: "알림읽어용~!!&^^"),
+        NotificationModel(senderNickName: "황정숙", notiType: .notiInfo, time: "2022-01-14T18:56:42.040Z", isRead: false, title: "확인해", content: "알림읽어용~!!&^^"),
+        NotificationModel(senderNickName: "김두숙", notiType: .writtenInfo, time: "2022-01-16T18:56:42.040Z", isRead: false, title: "확인해", content: "알림읽어용~!!&^^"),
+        NotificationModel(senderNickName: "김나도", notiType: .notiQuestion, time: "2022-01-12T18:56:42.040Z", isRead: true, title: "확인해", content: "알림읽어용~!!&^^"),
+        NotificationModel(senderNickName: "이선배", notiType: .answerInfo, time: "2022-01-18T18:56:42.040Z", isRead: true, title: "확인해", content: "알림읽어용~!!&^^"),
+        NotificationModel(senderNickName: "김나도", notiType: .answerQuestion, time: "2022-01-12T19:00:42.040Z", isRead: false, title: "확인해", content: "알림읽어용~!!&^^")
     ]
     
     /// TableView 투명한 header, footer를 위한 empty View


### PR DESCRIPTION
## 🍎 관련 이슈
closed #70 

## 🍎 변경 사항 및 이유
* String+ `serverTimeToString()` 추가
* String+ `toDate()` 추가
* 마이페이지, 선배페이지, 알림탭에서 시간 처리 적용

## 🍎 PR Point

* String+ `serverTimeToString()` 사용법
`timeLabel.text = data.writeTime.serverTimeToString(forUse: .forDefault)`

    위와 같이 사용하심 됩니다~! 대신 `data.writeTime`은 `String` 타입, `"2021-11-28T18:56:42.040Z"` 의 형태로 들어가 있어야 함!! API docs 보니까 서버에서 시간을 저 형태로 주더라구여~

    `.forDefault`: 알림 탭 제외 모두, 19/12/11의 형태로 반환
    `.forNotification`: 알림 탭에서 요구하는 형태로 반환

* String+ 의 `toDate()` 함수는 UI 내에서 쓸 일 없어 보여서 private 처리해 놨는데... 혹시 써야 한다면 private 빼면 됩니다...!
```
 private func toDate() -> Date {
    }
```


## 📸 ScreenShot
![Group 90](https://user-images.githubusercontent.com/43312096/149921675-b3fb962d-9f6a-4a0c-a66c-5245b43d9da2.png)

