### PR TITLE
✅ [CHORE] Contents가 화면 상단에 닿았을 때 scroll disabled 되도록 수정

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
@@ -136,6 +136,13 @@ extension ReviewDetailVC {
             self.navigationController?.popViewController(animated: true)
         }
     }
+    
+    /// 화면 상단에 닿으면 스크롤 disable
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if scrollView.contentOffset.y < 0 {
+            scrollView.contentOffset.y = 0
+        }
+    }
 }
 
 // MARK: - UITableViewDelegate

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
@@ -127,6 +127,13 @@ extension ReviewMainVC {
         
         present(alert, animated: true, completion: nil)
     }
+    
+    /// 화면 상단에 닿으면 스크롤 disable
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if scrollView.contentOffset.y < 0 {
+            scrollView.contentOffset.y = 0
+        }
+    }
 }
 
 // MARK: - @objc Function Part


### PR DESCRIPTION
## 🍎 관련 이슈
closed #78

## 🍎 변경 사항 및 이유
- 위로 스크롤시 bounce 효과처럼 scroll이 되어서 배경 이미지 뒤의 화면이 보이는 문제가 있었습니다.

## 🍎 PR Point
- 컨텐츠가 화면 상단에 닿을 시 스크롤이 안되게 하여 배경 이미지가 고정되도록 기능을 수정하였습니다.

## 📸 ScreenShot

