### PR TITLE
✨[FEAT] 학과 선택에 따라 게시글 리스트 바뀌도록 서버 통신 구현

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Review/ReviewPostDetailData.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Review/ReviewPostDetailData.swift
@@ -12,12 +12,12 @@ struct ReviewPostDetailData: Codable {
     var post: PostDetail = PostDetail()
     var writer: PostWriter = PostWriter()
     var like: PostLike = PostLike()
-    var backgroundImage: BackgroundImage = BackgroundImage()
+    var backgroundImage: BackgroundImage
 }
 
 // MARK: - BackgroundImage
 struct BackgroundImage: Codable {
-    let imageID: Int = 6
+    let imageID: Int
     let imageURL: String = ""
 
     enum CodingKeys: String, CodingKey {
@@ -30,6 +30,11 @@ struct BackgroundImage: Codable {
 struct PostLike: Codable {
     let isLiked: Bool = false
     let likeCount: String = ""
+    
+    enum CodingKeys: String, CodingKey {
+        case isLiked = "isLiked"
+        case likeCount = "likeCount"
+    }
 }
 
 // MARK: - PostDetail

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/ReviewService.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/ReviewService.swift
@@ -59,7 +59,7 @@ extension ReviewService: TargetType {
                 "nonRecommendLecture" : nonRecommendLecture,
                 "tip" : tip
             ]
-            return .requestParameters(parameters: body, encoding: URLEncoding.httpBody)
+            return .requestParameters(parameters: body, encoding: JSONEncoding.prettyPrinted)
             
         /// 후기 메인 뷰에서 리스트를 요청하는 경우
         case .getReviewMainPostList(let majorID, let writerFilter, let tagFilter, let sort):

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewDetailPostWithImgTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewDetailPostWithImgTVC.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SnapKit
 
 class ReviewDetailPostWithImgTVC: BaseTVC {
 
@@ -13,7 +14,12 @@ class ReviewDetailPostWithImgTVC: BaseTVC {
     @IBOutlet weak var bgImgView: UIImageView!
     @IBOutlet weak var postContentView: UIView!
     @IBOutlet weak var contentLabel: UILabel!
-    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var titleLabel: UILabel! {
+        didSet {
+            titleLabel.sizeToFit()
+        }
+    }
+    
     @IBOutlet weak var tagLabel: UILabel!
     
     // MARK: Life Cycle
@@ -31,6 +37,11 @@ class ReviewDetailPostWithImgTVC: BaseTVC {
 extension ReviewDetailPostWithImgTVC {
     private func configureUI() {
         postContentView.makeRounded(cornerRadius: 40.adjusted)
+        titleLabel.snp.makeConstraints {
+            $0.centerY.equalTo(bgImgView)
+            $0.centerX.equalTo(bgImgView.frame.size.height - 40)
+            $0.width.equalTo(312.adjusted)
+        }
     }  
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewDetailPostWithImgTVC.xib
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewDetailPostWithImgTVC.xib
@@ -73,8 +73,9 @@
                             <constraint firstAttribute="bottom" secondItem="i64-89-Zot" secondAttribute="bottom" constant="37" id="urd-2G-Jlt"/>
                         </constraints>
                     </view>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CLb-kY-18s">
-                        <rect key="frame" x="31" y="74" width="312" height="24.5"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CLb-kY-18s">
+                        <rect key="frame" x="162" y="113" width="50.5" height="24.5"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <fontDescription key="fontDescription" name="Pretendard-SemiBold" family="Pretendard" pointSize="20"/>
                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <nil key="highlightedColor"/>
@@ -82,16 +83,13 @@
                 </subviews>
                 <color key="backgroundColor" name="paleGray"/>
                 <constraints>
-                    <constraint firstAttribute="trailing" secondItem="CLb-kY-18s" secondAttribute="trailing" constant="32" id="8xl-vV-xYA"/>
                     <constraint firstItem="22y-a7-5o9" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="AMk-H6-DZF"/>
                     <constraint firstAttribute="trailing" secondItem="22y-a7-5o9" secondAttribute="trailing" id="GlJ-g8-3kb"/>
                     <constraint firstItem="22y-a7-5o9" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="L2C-sb-mHn"/>
-                    <constraint firstItem="CLb-kY-18s" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="74" id="SMl-eA-AZJ"/>
                     <constraint firstItem="Gi7-n0-Lnt" firstAttribute="top" secondItem="22y-a7-5o9" secondAttribute="bottom" constant="-40" id="VOd-tq-cSc"/>
                     <constraint firstAttribute="bottom" secondItem="Gi7-n0-Lnt" secondAttribute="bottom" constant="12" id="alJ-Zb-cwy"/>
                     <constraint firstAttribute="trailing" secondItem="Gi7-n0-Lnt" secondAttribute="trailing" constant="24" id="cZd-OW-brn"/>
                     <constraint firstItem="Gi7-n0-Lnt" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="23" id="iwH-W7-gOl"/>
-                    <constraint firstItem="CLb-kY-18s" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="31" id="yGY-Nt-ZlM"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewMainPostTVC.xib
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewMainPostTVC.xib
@@ -63,7 +63,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sJH-yj-Sga">
-                        <rect key="frame" x="16" y="34.5" width="40" height="19.5"/>
+                        <rect key="frame" x="16" y="34.5" width="311.5" height="19.5"/>
                         <fontDescription key="fontDescription" name="Pretendard-Medium" family="Pretendard" pointSize="16"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -125,6 +125,7 @@
                     <constraint firstItem="bya-cZ-gzh" firstAttribute="centerY" secondItem="6vD-vQ-dab" secondAttribute="centerY" id="Ezx-8h-lGG"/>
                     <constraint firstItem="Mwc-Fl-BXw" firstAttribute="centerY" secondItem="uE4-0F-UpK" secondAttribute="centerY" id="Fv4-4D-RHl"/>
                     <constraint firstItem="6vD-vQ-dab" firstAttribute="leading" secondItem="bya-cZ-gzh" secondAttribute="trailing" id="Iet-Vv-yJt"/>
+                    <constraint firstItem="sJH-yj-Sga" firstAttribute="trailing" secondItem="5Hi-d0-c0y" secondAttribute="trailing" id="K0d-Fr-CBj"/>
                     <constraint firstItem="mnz-fO-zkk" firstAttribute="centerY" secondItem="7QH-jM-GOf" secondAttribute="centerY" id="RLL-oB-Mcj"/>
                     <constraint firstItem="WTF-gu-mXm" firstAttribute="top" secondItem="u7e-V6-05r" secondAttribute="bottom" constant="8" id="Tq1-RT-lXR"/>
                     <constraint firstItem="mnz-fO-zkk" firstAttribute="leading" secondItem="7QH-jM-GOf" secondAttribute="trailing" constant="4" id="VJg-Wf-IPc"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/SB/ReviewSB.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/SB/ReviewSB.storyboard
@@ -50,13 +50,13 @@
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="CIU-m1-7pK" firstAttribute="leading" secondItem="wTe-n5-UNg" secondAttribute="leading" id="8Mw-Xu-p7G"/>
+                                    <constraint firstItem="B22-dF-dYf" firstAttribute="centerY" secondItem="wTe-n5-UNg" secondAttribute="centerY" id="Cdi-No-Xdz"/>
                                     <constraint firstAttribute="height" constant="104" id="FNk-9w-ZrK"/>
                                     <constraint firstItem="B22-dF-dYf" firstAttribute="leading" secondItem="wTe-n5-UNg" secondAttribute="trailing" id="Ib5-X3-7Gp"/>
                                     <constraint firstItem="CIU-m1-7pK" firstAttribute="bottom" secondItem="wTe-n5-UNg" secondAttribute="bottom" id="MV9-IM-GI7"/>
                                     <constraint firstItem="CIU-m1-7pK" firstAttribute="trailing" secondItem="B22-dF-dYf" secondAttribute="trailing" id="N8x-r1-yaL"/>
                                     <constraint firstItem="CIU-m1-7pK" firstAttribute="top" secondItem="wTe-n5-UNg" secondAttribute="top" id="ejU-l9-683"/>
                                     <constraint firstAttribute="bottom" secondItem="wTe-n5-UNg" secondAttribute="bottom" constant="24" id="oZa-Pg-14e"/>
-                                    <constraint firstAttribute="bottom" secondItem="B22-dF-dYf" secondAttribute="bottom" constant="12" id="uh3-PV-wst"/>
                                     <constraint firstItem="wTe-n5-UNg" firstAttribute="leading" secondItem="ulf-PI-yaI" secondAttribute="leading" constant="16" id="vfp-MN-eHo"/>
                                 </constraints>
                             </view>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/SB/ReviewWriteSB.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/SB/ReviewWriteSB.storyboard
@@ -455,6 +455,7 @@
                         <outlet property="essentialTagView" destination="5bs-Y4-zdY" id="ZtW-0W-Ydc"/>
                         <outlet property="futureTextView" destination="bdh-60-r4e" id="16y-hT-IVK"/>
                         <outlet property="learnInfoTextView" destination="iD4-XI-pAf" id="0eS-iQ-E7H"/>
+                        <outlet property="majorChangeBtn" destination="ugA-Kc-jFH" id="WX4-5h-hWh"/>
                         <outlet property="majorNameLabel" destination="3Cn-v9-Ivr" id="o3J-8Q-587"/>
                         <outlet property="majorNameView" destination="DKH-ET-dLt" id="zbI-Tb-aH2"/>
                         <outlet property="oneLineReviewTextView" destination="BIh-8P-r1P" id="uxH-6e-TDl"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
@@ -34,7 +34,6 @@ class ReviewDetailVC: UIViewController {
     // MARK: Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        setUpPostId()
         registerTVC()
         setUpTV()
         configureUI()
@@ -46,7 +45,7 @@ class ReviewDetailVC: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.tabBarController?.tabBar.isHidden = true
-        requestGetReviewPostDetail(postID: postId ?? 5)
+        requestGetReviewPostDetail(postID: postId ?? -1)
     }
 }
 
@@ -68,13 +67,6 @@ extension ReviewDetailVC {
 
 // MARK: - Custom Methods
 extension ReviewDetailVC {
-    private func setUpPostId() {
-//        if let postId = postId {
-//            // TODO: 서버통신 시 해당 PostId로 후기글 상세 조회 API 호출할 것임!!
-//            print(postId)
-//        }
-    }
-    
     private func registerTVC() {
         ReviewDetailPostWithImgTVC.register(target: reviewPostTV)
         ReviewDetailPostTVC.register(target: reviewPostTV)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
@@ -41,11 +41,11 @@ class ReviewDetailVC: UIViewController {
         addShadowToNaviBar()
         showActionSheet()
         setUpTapNaviBackBtn()
-        self.tabBarController?.tabBar.isHidden = true
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        self.tabBarController?.tabBar.isHidden = true
         requestGetReviewPostDetail(postID: postId ?? 5)
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
@@ -28,7 +28,7 @@ class ReviewDetailVC: UIViewController {
     @IBOutlet weak var likeCountView: UIView!
     
     // MARK: Properties
-    var detailPost: ReviewPostDetailData = ReviewPostDetailData()
+    var detailPost: ReviewPostDetailData = ReviewPostDetailData(backgroundImage: BackgroundImage(imageID: 0))
     var postId: Int?
     
     // MARK: Life Cycle

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
@@ -42,7 +42,7 @@ class ReviewMainVC: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         setUpMajorLabel()
         self.tabBarController?.tabBar.isHidden = false
-        requestGetReviewPostList(majorID: 5, writerFilter: 1, tagFilter: [1,2,3,4,5])
+        setUpRequestData()
     }
     
     // MARK: IBAction
@@ -140,6 +140,11 @@ extension ReviewMainVC {
     /// 전공 Label text를 set하는 메서드
     private func setUpMajorLabel() {
         majorLabel.text = (MajorInfo.shared.selectedMajorName != nil) ? MajorInfo.shared.selectedMajorName : UserDefaults.standard.string(forKey: UserDefaults.Keys.FirstMajorName)
+    }
+    
+    /// shared에 데이터가 있으면 shared정보로 데이터를 요청하고, 그렇지 않으면 Userdefaults의 전공ID로 요청을 보내는 메서드
+    private func setUpRequestData() {
+        requestGetReviewPostList(majorID: (MajorInfo.shared.selecteMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selecteMajorID ?? -1), writerFilter: 1, tagFilter: [1, 2, 3, 4, 5])
     }
 }
 
@@ -262,12 +267,11 @@ extension ReviewMainVC: UITableViewDataSource {
 
 // MARK: - SendUpdateModalDelegate
 extension ReviewMainVC: SendUpdateModalDelegate {
+    
+    /// 학과 선택 시 해당 학과의 게시글 리스트가 로드될 수 있도록 요청
     func sendUpdate(data: Any) {
         majorLabel.text = data as? String
-        // TODO: 은주의 할일!
-        /// 서버통신. get.
-        /// 여기서는 selected된 ID를 유저디폴트에서 뽑아오고.
-        /// UserDefaults.standard.integer(forKey: UserDefaults.Keys.SelectedMajorID))
+        setUpRequestData()
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
@@ -29,7 +29,21 @@ class ReviewWriteVC: UIViewController {
     @IBOutlet weak var choiceTagView: UIView!
     @IBOutlet weak var majorNameView: UIView!
     @IBOutlet weak var bgImgCV: UICollectionView!
-    @IBOutlet weak var majorNameLabel: UILabel!
+    @IBOutlet weak var majorNameLabel: UILabel! {
+        didSet {
+            majorNameLabel.text = UserDefaults.standard.string(forKey: UserDefaults.Keys.FirstMajorName)
+        }
+    }
+    @IBOutlet weak var majorChangeBtn: UIButton! {
+        
+        /// 회원가입 시 본전공만 존재하는 유저인 경우 버튼 비활성화 처리
+        didSet {
+            if UserDefaults.standard.string(forKey: UserDefaults.Keys.SecondMajorName) == "미진입" {
+                majorChangeBtn.isEnabled = false
+                majorChangeBtn.tintColor = UIColor.gray3
+            }
+        }
+    }
     @IBOutlet weak var oneLineReviewTextView: NadoTextView!
     @IBOutlet weak var prosAndConsTextView: NadoTextView!
     @IBOutlet weak var learnInfoTextView: NadoTextView!
@@ -70,21 +84,23 @@ class ReviewWriteVC: UIViewController {
         setUpTapCompleteBtn()
     }
     
-    // TODO: 회원가입 시 본전공만 존재하는 유저인 경우 버튼 비활성화 처리 예정
     @IBAction func tapMajorChangeBtn(_ sender: Any) {
+        let firstMajor: String = UserDefaults.standard.string(forKey: UserDefaults.Keys.FirstMajorName) ?? ""
+        let secondMajor: String = UserDefaults.standard.string(forKey: UserDefaults.Keys.SecondMajorName) ?? ""
+        
         let alert = UIAlertController(title: "후기 작성 학과", message: nil, preferredStyle: .actionSheet)
-        let majorName = UIAlertAction(title: "본전공명", style: .default) { action in
-            self.majorNameLabel.text = "국어국문학과"
+        let majorName = UIAlertAction(title: firstMajor, style: .default) { action in
+            self.majorNameLabel.text = firstMajor
         }
-        let secondMajorName = UIAlertAction(title: "제2전공명", style: .default) { action in
-            self.majorNameLabel.text = "디지털미디어학과"
+        let secondMajorName = UIAlertAction(title: secondMajor, style: .default) { action in
+            self.majorNameLabel.text = secondMajor
         }
         let cancel = UIAlertAction(title: "취소", style: .cancel)
-        
+
         alert.addAction(majorName)
         alert.addAction(secondMajorName)
         alert.addAction(cancel)
-        
+
         present(alert, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #115

## 🍎 변경 사항 및 이유
- 학과 리스트에서 학과 선택 시 후기 메인 뷰에 해당 학과의 후기글이 리스트업 되고, 
다른 탭으로 이동해도 해당학과로 진입하도록 하였습니다.

## 🍎 PR Point
- 지은이의 코드를 쇽샥해서 해당학과 리스트가 뜨도록 서버 통신하였고, `UserDefaults`값과 싱글톤 객체를 이용해 선택된 학과가 저장되어 다른 탭에서도 반영이 되도록 했습니다.
- 배경 이미지 GET에서 계속 초기화 값으로만 들어온다는 문제가 있었는데, 값이 들어오도록 해결해서 게시글에 해당하는 배경 이미지가 뜨도록 했습니다.
- 후기 작성 뷰에서 이중전공이 없는 유저일 경우 변경 버튼이 비활성화 되고, 이중전공이 있는 유저일 경우 변경 버튼 클릭 시 `ActionSheet`에서 학과를 선택할 수 있도록 하였습니다.
- 자잘한 UI 수정이 있었습니다..

## 📸 ScreenShot
