### PR TITLE
✨ [FEAT] 후기 미작성 유저 게시글 열람 제한 기능 구현

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
@@ -252,10 +252,26 @@ extension ReviewMainVC: UITableViewDelegate {
         if indexPath.section == 2 {
             
             if !postList.isEmpty {
-                let ReviewDetailSB = UIStoryboard.init(name: "ReviewDetailSB", bundle: nil)
-                guard let nextVC = ReviewDetailSB.instantiateViewController(withIdentifier: ReviewDetailVC.className) as? ReviewDetailVC else { return }
-                nextVC.postId = postList[indexPath.row].postID
-                self.navigationController?.pushViewController(nextVC, animated: true)
+                
+                /// 후기글 작성하지 않은 유저라면 후기글 열람 제한
+                if UserDefaults.standard.bool(forKey: UserDefaults.Keys.IsReviewed) == false {
+                    guard let restrictionAlert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+                    
+                    /// 후기 작성 버튼 클릭시 후기 작성 페이지로 이동
+                    restrictionAlert.confirmBtn.press {
+                        let ReviewWriteSB = UIStoryboard.init(name: "ReviewWriteSB", bundle: nil)
+                        guard let nextVC = ReviewWriteSB.instantiateViewController(withIdentifier: ReviewWriteVC.className) as? ReviewWriteVC else { return }
+                        
+                        nextVC.modalPresentationStyle = .fullScreen
+                        self.present(nextVC, animated: true, completion: nil)
+                    }
+                    restrictionAlert.showNadoAlert(vc: self, message: "내 학과 후기를 작성해야\n이용할 수 있는 기능이에요.", confirmBtnTitle: "후기 작성", cancelBtnTitle: "다음에 작성")
+                } else {
+                    let ReviewDetailSB = UIStoryboard.init(name: "ReviewDetailSB", bundle: nil)
+                    guard let nextVC = ReviewDetailSB.instantiateViewController(withIdentifier: ReviewDetailVC.className) as? ReviewDetailVC else { return }
+                    nextVC.postId = postList[indexPath.row].postID
+                    self.navigationController?.pushViewController(nextVC, animated: true)
+                }
             }
         }
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
@@ -254,7 +254,7 @@ extension ReviewMainVC: UITableViewDelegate {
             if !postList.isEmpty {
                 
                 /// 후기글 작성하지 않은 유저라면 후기글 열람 제한
-                if UserDefaults.standard.bool(forKey: UserDefaults.Keys.IsReviewed) == false {
+                if UserDefaults.standard.bool(forKey: UserDefaults.Keys.IsReviewed) {
                     guard let restrictionAlert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
                     
                     /// 후기 작성 버튼 클릭시 후기 작성 페이지로 이동

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
@@ -254,7 +254,7 @@ extension ReviewMainVC: UITableViewDelegate {
             if !postList.isEmpty {
                 
                 /// 후기글 작성하지 않은 유저라면 후기글 열람 제한
-                if UserDefaults.standard.bool(forKey: UserDefaults.Keys.IsReviewed) {
+                if !(UserDefaults.standard.bool(forKey: UserDefaults.Keys.IsReviewed)) {
                     guard let restrictionAlert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
                     
                     /// 후기 작성 버튼 클릭시 후기 작성 페이지로 이동

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
@@ -176,6 +176,7 @@ extension ReviewWriteVC {
                 } else if self.majorNameLabel.text == UserDefaults.standard.string(forKey: UserDefaults.Keys.SecondMajorName) {
                     self.requestCreateReviewPost(majorID: UserDefaults.standard.integer(forKey: UserDefaults.Keys.SecondMajorID), bgImgID: self.postBgImgId, oneLineReview: self.oneLineReviewTextView.text, prosCons: self.prosAndConsTextView.text, curriculum: self.learnInfoTextView.text, career: self.futureTextView.text, recommendLecture: self.recommendClassTextView.text, nonRecommendLecture: self.badClassTextView.text, tip: self.tipTextView.text)
                 }
+                UserDefaults.standard.set(true, forKey: UserDefaults.Keys.IsReviewed)
             }
             
             /// TextView의 text가 placeholder일 때 텍스트가 서버에 넘어가지 않도록 분기 처리


### PR DESCRIPTION
## 🍎 관련 이슈
closed #161

## 🍎 변경 사항 및 이유
- 후기글을 쓰지 않은 유저에 대해 게시글 열람을 제한하는 기능을 구현했습니다.

## 🍎 PR Point
- `UserDefaults`의 `isReviewed`값을 이용해서 기능을 구현했습니다.
- 후기글 post시 기존 `UserDefaults`의 `isReviewed`값에 관계없이 `true`로 상태가 업데이트 되어야하기 때문에 post서버 통신 완료 시에 `true`값을 세팅해주었습니다. 
- 게시글 클릭시 `UserDefaults`에 저장된 값으로 분기처리하여 알럿을 띄웠습니다.
- 알럿 메시지 행간격은 다음 PR에 게시글 행간격 조정하며 함께 변경하도록 하겠습니다!

## 📸 ScreenShot
- 게시글 열람 제한

https://user-images.githubusercontent.com/63277563/153417648-f5b64f45-d684-44dc-9df0-529a23014f1d.mp4

- 후기 미작성자가 후기글 작성완료 시 권한 변경

https://user-images.githubusercontent.com/63277563/153417662-c60b9e42-824e-472f-84be-64e513c2612b.mp4


