### PR TITLE
✅ [CHORE] Label 행간격 설정

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/UILabel+.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/UILabel+.swift
@@ -36,13 +36,13 @@ extension UILabel {
         self.text = text
     }
     
-    func setLineSpacing(lineSpacing: CGFloat, font: UIFont, color: UIColor, text: String) -> NSAttributedString {
-        let style = NSMutableParagraphStyle()
-        style.lineSpacing = lineSpacing
-        let attributes = [NSAttributedString.Key.paragraphStyle: style,
-                          NSAttributedString.Key.font: font,
-                          NSAttributedString.Key.foregroundColor: color]
-        
-        return NSAttributedString(string: text, attributes: attributes)
+    func setLineSpacing(lineSpacing: CGFloat) {
+        if let text = self.text {
+            let attributeString = NSMutableAttributedString(string: text)
+            let style = NSMutableParagraphStyle()
+            style.lineSpacing = lineSpacing
+            attributeString.addAttribute(NSAttributedString.Key.paragraphStyle, value: style, range: NSMakeRange(0, attributeString.length))
+            self.attributedText = attributeString
+        }
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Class/NadoAlertVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Class/NadoAlertVC.swift
@@ -32,6 +32,8 @@ class NadoAlertVC: BaseVC {
         confirmBtn.isActivated = true
         cancelBtn.isActivated = false
         cancelBtn.isEnabled = true
+        messageLabel.setLineSpacing(lineSpacing: 5)
+        messageLabel.textAlignment = .center
         self.modalPresentationStyle = .overFullScreen
         self.modalTransitionStyle = .crossDissolve
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/NadoAlertVC.xib
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/NadoAlertVC.xib
@@ -24,10 +24,10 @@
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jV9-hc-CUq">
                         <rect key="frame" x="61.5" y="355.5" width="291" height="185"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cz8-zP-5TM">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cz8-zP-5TM">
                                 <rect key="frame" x="24" y="12" width="243" height="100"/>
                                 <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="14"/>
-                                <color key="textColor" name="mainBlack"/>
+                                <color key="textColor" name="mainText"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ELo-xG-zpK" customClass="NadoSunbaeBtn" customModule="NadoSunbae_iOS" customModuleProvider="target">
@@ -88,11 +88,11 @@
         <namedColor name="gray2">
             <color red="0.75294117647058822" green="0.75294117647058822" blue="0.79607843137254897" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
-        <namedColor name="mainBlack">
-            <color red="0.0" green="0.10980392156862745" blue="0.094117647058823528" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
         <namedColor name="mainDefault">
             <color red="0.0" green="0.78431372549019607" blue="0.69019607843137254" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="mainText">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.23529411764705882" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewDetailPostTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewDetailPostTVC.swift
@@ -26,6 +26,7 @@ class ReviewDetailPostTVC: BaseTVC {
     // MARK: Life Cycle
     override func awakeFromNib() {
         super.awakeFromNib()
+        configureUI()
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
@@ -33,6 +34,18 @@ class ReviewDetailPostTVC: BaseTVC {
     }
 }
 
+// MARK: - UI
+extension ReviewDetailPostTVC {
+    func configureUI() {
+        
+        /// contentLabel 행간격 설정
+        let attrString = NSMutableAttributedString(string: contentLabel.text!)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 5
+        attrString.addAttribute(NSAttributedString.Key.paragraphStyle, value: paragraphStyle, range: NSMakeRange(0, attrString.length))
+        contentLabel.attributedText = attrString
+    }
+}
 
 // MARK: - Custom Methods
 extension ReviewDetailPostTVC {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewDetailPostTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewDetailPostTVC.swift
@@ -20,30 +20,17 @@ class ReviewDetailPostTVC: BaseTVC {
     @IBOutlet weak var contentLabel: UILabel! {
         didSet {
             contentLabel.sizeToFit()
+            contentLabel.setLineSpacing(lineSpacing: 5)
         }
     }
     
     // MARK: Life Cycle
     override func awakeFromNib() {
         super.awakeFromNib()
-        configureUI()
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
-    }
-}
-
-// MARK: - UI
-extension ReviewDetailPostTVC {
-    func configureUI() {
-        
-        /// contentLabel 행간격 설정
-        let attrString = NSMutableAttributedString(string: contentLabel.text!)
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineSpacing = 5
-        attrString.addAttribute(NSAttributedString.Key.paragraphStyle, value: paragraphStyle, range: NSMakeRange(0, attrString.length))
-        contentLabel.attributedText = attrString
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewDetailPostWithImgTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewDetailPostWithImgTVC.swift
@@ -42,6 +42,13 @@ extension ReviewDetailPostWithImgTVC {
             $0.centerX.equalTo(bgImgView.frame.size.height - 40)
             $0.width.equalTo(312.adjusted)
         }
+        
+        /// contentLabel 행간격 설정
+        let attrString = NSMutableAttributedString(string: contentLabel.text!)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 5
+        attrString.addAttribute(NSAttributedString.Key.paragraphStyle, value: paragraphStyle, range: NSMakeRange(0, attrString.length))
+        contentLabel.attributedText = attrString
     }  
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewDetailPostWithImgTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewDetailPostWithImgTVC.swift
@@ -37,18 +37,12 @@ class ReviewDetailPostWithImgTVC: BaseTVC {
 extension ReviewDetailPostWithImgTVC {
     private func configureUI() {
         postContentView.makeRounded(cornerRadius: 40.adjusted)
+        contentLabel.setLineSpacing(lineSpacing: 5)
         titleLabel.snp.makeConstraints {
             $0.centerY.equalTo(bgImgView)
             $0.centerX.equalTo(bgImgView.frame.size.height - 40)
             $0.width.equalTo(312.adjusted)
         }
-        
-        /// contentLabel 행간격 설정
-        let attrString = NSMutableAttributedString(string: contentLabel.text!)
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineSpacing = 5
-        attrString.addAttribute(NSAttributedString.Key.paragraphStyle, value: paragraphStyle, range: NSMakeRange(0, attrString.length))
-        contentLabel.attributedText = attrString
     }  
 }
 


### PR DESCRIPTION
## 🍎 관련 이슈
closed #163

## 🍎 변경 사항 및 이유
- NadoAlert, 후기상세 뷰의 행간격을 설정했습니다.

## 🍎 PR Point
- `UILabel+` 파일의 `setLineSpacing(`)을 수정했습니다.
(수정이유: 이미 거의 모든 파일에서 Label의 폰트, 크기 등이 설정되어있기 때문에 `setLineSpacing(lineSpacing: )`으로 원하는 행간격 값만 설정해줄 수 있도록 수정, 반환값이 필요없을 것 같아서 return문 삭제)
- 정빈이가 만들어 놓은 NadoAlert()에 위의 함수를 호출해 알럿 메시지가 두 줄 이상이라면 모두 동일한 행간격이 적용되도록 했습니다. + 피그마보다가 `messageLabel`색상이 다르게 설정되어있어서 피그마와 동일하게 변경도 해놓았습니다.
- 후기 상세 뷰도 동일하게 행간격 설정했습니다.

## 📸 ScreenShot
- 비교 스크린샷
<img width="300" alt="before lineSpacing" src="https://user-images.githubusercontent.com/63277563/153556128-2fb8a60d-ff03-4940-b3b1-e095b5b4bab2.png"> <img width="300" alt="스크린샷 2022-02-11 오후 1 55 02" src="https://user-images.githubusercontent.com/63277563/153556181-93254319-d8c6-4bd4-a8f9-2dd2b639acd9.png">
<img width="300" alt="스크린샷 2022-02-11 오후 2 16 37" src="https://user-images.githubusercontent.com/63277563/153556380-796b72b7-9573-4d84-89d2-c23bb3bb1461.png"> <img width="300" alt="스크린샷 2022-02-11 오후 4 53 12" src="https://user-images.githubusercontent.com/63277563/153556391-cbcdfd76-a1c2-46dd-b27e-aa4cb2d6e3d4.png">


