### PR TITLE
✅ [CHORE] 후기 메인 뷰 URL 네이티브 앱 연결 형식으로 수정

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Review/ReviewMainPostListData.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Review/ReviewMainPostListData.swift
@@ -14,7 +14,7 @@ struct ReviewMainPostListData: Codable {
     let createdAt: String
     let writer: ReviewWriter
     let tagList: [ReviewTagList]
-    let likeCount: String
+    let likeCount: Int
 
     enum CodingKeys: String, CodingKey {
         case postID = "postId"

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewMainLinkTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewMainLinkTVC.swift
@@ -9,8 +9,11 @@ import UIKit
 
 class ReviewMainLinkTVC: BaseTVC {
     
-    var homepageURL: String = ""
-    var subjectTableURL: String = ""
+    // MARK: Properties
+    var homePageLink: String = ""
+    var subjectTableLink: String = ""
+    var tapHomePageBtnAction : (() -> ())?
+    var tapSubjectBtnAction : (() -> ())?
     
     // MARK: Life Cycle
     override func awakeFromNib() {
@@ -23,15 +26,11 @@ class ReviewMainLinkTVC: BaseTVC {
     }
 
     @IBAction func tapHomePageBtn(_ sender: Any) {
-        if let url = URL(string: "\(self.homepageURL)") {
-            UIApplication.shared.open(url, options: [:])
-        }
+        tapHomePageBtnAction?()
     }
     
     @IBAction func tapSubjectBtn(_ sender: Any) {
-        if let url = URL(string: "\(self.subjectTableURL)") {
-            UIApplication.shared.open(url, options: [:])
-        }
+        tapSubjectBtnAction?()
     }
 }
 
@@ -44,8 +43,8 @@ extension ReviewMainLinkTVC {
             case .success(let res):
                 print(res)
                 if let data = res as? ReviewHomePageData {
-                    self.homepageURL = data.homepage
-                    self.subjectTableURL = data.subjectTable
+                    self.homePageLink = data.homepage
+                    self.subjectTableLink = data.subjectTable
                 }
             case .requestErr(let msg):
                 if let message = msg as? String {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewMainPostTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewMainPostTVC.swift
@@ -65,7 +65,7 @@ extension ReviewMainPostTVC {
         dateLabel.text = postData.createdAt.serverTimeToString(forUse: .forDefault)
         titleLabel.text = postData.oneLineReview
         nickNameLabel.text = postData.writer.nickname
-        diamondCountLabel.text = postData.likeCount
+        diamondCountLabel.text = "\(postData.likeCount)"
         majorNameLabel.text = postData.writer.firstMajorName
         secondMajorNameLabel.text = postData.writer.secondMajorName
         firstMajorStartLabel.text = postData.writer.firstMajorStart

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
@@ -39,7 +39,7 @@ class ReviewDetailVC: BaseVC {
         registerTVC()
         setUpTV()
         configureUI()
-        showActionSheet()
+        presentActionSheet()
         setUpTapNaviBackBtn()
     }
     
@@ -84,7 +84,7 @@ extension ReviewDetailVC {
     }
     
     /// 액션 시트
-    private func showActionSheet() {
+    private func presentActionSheet() {
         naviBarView.rightCustomBtn.press {
             let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
             let edit = UIAlertAction(title: "수정", style: .default) { action in

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
@@ -50,7 +50,7 @@ class ReviewMainVC: BaseVC {
     
     // MARK: IBAction
     @IBAction func tapNaviBarBtn(_ sender: Any) {
-        showHalfModalView()
+        presentHalfModalView()
     }
     
     @IBAction func tapFloatingBtn(_ sender: Any) {
@@ -111,7 +111,7 @@ extension ReviewMainVC {
     }
     
     /// 액션시트
-    func showActionSheet() {
+    func presentActionSheet() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         
         // TODO: 액션 추가 예정
@@ -154,7 +154,7 @@ extension ReviewMainVC {
     }
     
     /// 링크에 해당하는 웹사이트로 연결하는 함수
-    private func showSafariVC(link: String) {
+    private func presentSafariVC(link: String) {
         let webLink = NSURL(string: link)
         let safariVC: SFSafariViewController = SFSafariViewController(url: webLink! as URL)
         self.present(safariVC, animated: true, completion: nil)
@@ -165,7 +165,7 @@ extension ReviewMainVC {
 extension ReviewMainVC {
     
     /// 학과 선택 바텀시트 호출
-    @objc func showHalfModalView() {
+    @objc func presentHalfModalView() {
         let slideVC = HalfModalVC()
         slideVC.selectMajorDelegate = self
         slideVC.modalPresentationStyle = .custom
@@ -174,7 +174,7 @@ extension ReviewMainVC {
     }
     
     /// 필터 선택 바텀시트 호출
-    @objc func showHalfModalFilterView() {
+    @objc func presentHalfModalFilterView() {
         let slideVC = FilterVC()
         slideVC.selectFilterDelegate = self
         slideVC.modalPresentationStyle = .custom
@@ -229,7 +229,7 @@ extension ReviewMainVC: UITableViewDelegate {
             }
             
             headerView.tapArrangeBtnAction = {
-                self.showActionSheet()
+                self.presentActionSheet()
             }
             
             if filterStatus == true {
@@ -238,7 +238,7 @@ extension ReviewMainVC: UITableViewDelegate {
                 headerView.filterBtn.setImage(UIImage(named: "btnFilter"), for: .normal)
             }
             headerView.tapFilterBtnAction = {
-                self.showHalfModalFilterView()
+                self.presentHalfModalFilterView()
             }
             return headerView
         } else {
@@ -316,11 +316,11 @@ extension ReviewMainVC: UITableViewDataSource {
         } else if indexPath.section == 1 {
             reviewMainLinkTVC.tapHomePageBtnAction = {
                 let homePageLink = reviewMainLinkTVC.homePageLink
-                self.showSafariVC(link: homePageLink)
+                self.presentSafariVC(link: homePageLink)
             }
             reviewMainLinkTVC.tapSubjectBtnAction = {
                 let subjectTableLink = reviewMainLinkTVC.subjectTableLink
-                self.showSafariVC(link: subjectTableLink)
+                self.presentSafariVC(link: subjectTableLink)
             }
             return reviewMainLinkTVC
         } else if indexPath.section == 2 {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SafariServices
 
 class ReviewMainVC: BaseVC {
     
@@ -150,6 +151,13 @@ extension ReviewMainVC {
     /// shared에 데이터가 있으면 shared정보로 데이터를 요청하고, 그렇지 않으면 Userdefaults의 전공ID로 요청을 보내는 메서드
     private func setUpRequestData() {
         requestGetReviewPostList(majorID: (MajorInfo.shared.selecteMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selecteMajorID ?? -1), writerFilter: 1, tagFilter: [1, 2, 3, 4, 5], sort: sortType)
+    }
+    
+    /// 링크에 해당하는 웹사이트로 연결하는 함수
+    private func showSafariVC(link: String) {
+        let webLink = NSURL(string: link)
+        let safariVC: SFSafariViewController = SFSafariViewController(url: webLink! as URL)
+        self.present(safariVC, animated: true, completion: nil)
     }
 }
 
@@ -306,6 +314,14 @@ extension ReviewMainVC: UITableViewDataSource {
             reviewMainImgTVC.setData(ImgData: imgList[indexPath.row])
             return reviewMainImgTVC
         } else if indexPath.section == 1 {
+            reviewMainLinkTVC.tapHomePageBtnAction = {
+                let homePageLink = reviewMainLinkTVC.homePageLink
+                self.showSafariVC(link: homePageLink)
+            }
+            reviewMainLinkTVC.tapSubjectBtnAction = {
+                let subjectTableLink = reviewMainLinkTVC.subjectTableLink
+                self.showSafariVC(link: subjectTableLink)
+            }
             return reviewMainLinkTVC
         } else if indexPath.section == 2 {
             


### PR DESCRIPTION
## 🍎 관련 이슈
closed #169

## 🍎 변경 사항 및 이유
- 후기 메인 뷰의 학과 홈페이지, 이수과목 일람표 버튼 클릭시, 
기존의 웹뷰 이동 방식에서 인앱 브라우저 연결 방식으로 변경하였습니다.

## 🍎 PR Point
- `SafariServices`를 임포트하여 앱 안에서 해당 링크로 이동할 수 있도록 하였습니다.
(참고: 보라보라봉 티스토리💜)
- 데이터 전달은 클로저를 이용하였습니다.

## 📸 ScreenShot
- 구동영상(서버에서 DB수정중이라 학과 선택 시 '미진입'이 뜨는 것은 무시해주시면 될 것 같습니다!)

https://user-images.githubusercontent.com/63277563/153757737-b5cbfb91-3717-4bed-81d9-b811bc435bd6.mp4


