### PR TITLE
🔨 [FIX] 후기 탭 변수 데이터 타입 수정

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Review/ReviewMainPostListData.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Review/ReviewMainPostListData.swift
@@ -14,11 +14,11 @@ struct ReviewMainPostListData: Codable {
     let createdAt: String
     let writer: ReviewWriter
     let tagList: [ReviewTagList]
-    let likeCount: Int
+    let like: Like
 
     enum CodingKeys: String, CodingKey {
         case postID = "postId"
-        case oneLineReview, createdAt, writer, tagList, likeCount
+        case oneLineReview, createdAt, writer, tagList, like
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Review/ReviewPostDetailData.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Review/ReviewPostDetailData.swift
@@ -11,7 +11,7 @@ import Foundation
 struct ReviewPostDetailData: Codable {
     var post: PostDetail = PostDetail()
     var writer: PostWriter = PostWriter()
-    var like: PostLike = PostLike(isLiked: false, likeCount: "")
+    var like: Like
     var backgroundImage: BackgroundImage
 }
 
@@ -29,8 +29,8 @@ struct BackgroundImage: Codable {
 // MARK: - PostLike
 struct PostLike: Codable {
     let isLiked: Bool?
-    let likeCount: String?
-    
+    let likeCount: Int?
+
     enum CodingKeys: String, CodingKey {
         case isLiked = "isLiked"
         case likeCount = "likeCount"
@@ -66,17 +66,11 @@ struct PostWriter: Codable {
     var secondMajorName: String = ""
     var secondMajorStart: String = ""
     var isOnQuestion: Bool = false
-    var isReviewd: Bool = false
+    var isReviewed: Bool = false
     
     enum CodingKeys: String, CodingKey {
         case writerID = "writerId"
         case profileImageID = "profileImageId"
-        case nickname = "nickname"
-        case firstMajorName = "firstMajorName"
-        case firstMajorStart = "firstMajorStart"
-        case secondMajorName = "secondMajorName"
-        case secondMajorStart = "secondMajorStart"
-        case isOnQuestion = "isOnQuestion"
-        case isReviewd = "isReviewd"
+        case nickname, firstMajorName, firstMajorStart, secondMajorName, secondMajorStart, isOnQuestion, isReviewed
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewMainPostTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewMainPostTVC.swift
@@ -65,7 +65,7 @@ extension ReviewMainPostTVC {
         dateLabel.text = postData.createdAt.serverTimeToString(forUse: .forDefault)
         titleLabel.text = postData.oneLineReview
         nickNameLabel.text = postData.writer.nickname
-        diamondCountLabel.text = "\(postData.likeCount)"
+        diamondCountLabel.text = "\(postData.like.likeCount)"
         majorNameLabel.text = postData.writer.firstMajorName
         secondMajorNameLabel.text = postData.writer.secondMajorName
         firstMajorStartLabel.text = postData.writer.firstMajorStart

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
@@ -30,7 +30,7 @@ class ReviewDetailVC: BaseVC {
     @IBOutlet weak var diamondImgView: UIImageView!
     
     // MARK: Properties
-    var detailPost: ReviewPostDetailData = ReviewPostDetailData(backgroundImage: BackgroundImage(imageID: 0))
+    var detailPost: ReviewPostDetailData = ReviewPostDetailData(like: Like(isLiked: false, likeCount: 0), backgroundImage: BackgroundImage(imageID: 0))
     var postId: Int?
     
     // MARK: Life Cycle
@@ -121,15 +121,15 @@ extension ReviewDetailVC {
         }
     }
     
-    func setUpLikeStatus(model: PostLike) {
-        if model.isLiked ?? true {
+    func setUpLikeStatus(model: Like) {
+        if model.isLiked {
             diamondImgView.image = UIImage(named: "colorFilledDiamond")
             likeCountView.layer.backgroundColor = UIColor.mainBlack.cgColor
         } else {
             diamondImgView.image = UIImage(named: "emptyDiamond")
             likeCountView.layer.backgroundColor = UIColor.gray0.cgColor
         }
-        likeCountLabel.text = model.likeCount
+        likeCountLabel.text = "\(model.likeCount)"
     }
 }
 
@@ -236,9 +236,9 @@ extension ReviewDetailVC {
         ClassroomAPI.shared.postClassroomLikeAPI(chatPostID: postID, postTypeID: postTypeID.rawValue) { networkResult in
             switch networkResult {
             case .success(let res):
-                if let _ = res as? PostLike {
+                if let _ = res as? Like {
                     self.requestGetReviewPostDetail(postID: postID)
-                    print("!!!!!!!! 여기 !!!!!!!!")
+                    print(res)
                     self.activityIndicator.stopAnimating()
                 }
             case .requestErr(let msg):


### PR DESCRIPTION
## 🍎 관련 이슈
closed #173 

## 🍎 변경 사항 및 이유
- 서버 API 수정에 따라 후기 탭에 사용되는 모델과 네트워크 코드(변수명, 데이터타입)를 수정했습니다.

## 🍎 PR Point
- 수정하면서 PostLike -> Like로 통일하였습니다.
지은걸 파일까지 수정완료 되면 PostLike 부분 삭제하겠습니다! 

## 📸 ScreenShot

