### PR TITLE
✨ [FEAT] 자동로그인 구현

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		5C32801F27973E1A00781EBE /* ListSortType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C32801E27973E1A00781EBE /* ListSortType.swift */; };
 		5C328021279741C200781EBE /* QuestionOrInfoListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C328020279741C200781EBE /* QuestionOrInfoListModel.swift */; };
 		5C485F242789661F00FCA5DF /* NadoTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C485F232789661F00FCA5DF /* NadoTextField.swift */; };
+		5C49669327BD469200983689 /* AutoSignInVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C49669227BD469200983689 /* AutoSignInVC.swift */; };
 		5C4ED92A278949AC001EA6BB /* SignInSB.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5C4ED929278949AC001EA6BB /* SignInSB.storyboard */; };
 		5C4ED92C278949C4001EA6BB /* SignInVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4ED92B278949C4001EA6BB /* SignInVC.swift */; };
 		5C54CEC6278D9CBB0054136D /* SignUpUserInfoVC.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5C54CEC5278D9CBB0054136D /* SignUpUserInfoVC.storyboard */; };
@@ -321,6 +322,7 @@
 		5C328020279741C200781EBE /* QuestionOrInfoListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionOrInfoListModel.swift; sourceTree = "<group>"; };
 		5C485F21278965D000FCA5DF /* NadoTextField.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NadoTextField.xib; sourceTree = "<group>"; };
 		5C485F232789661F00FCA5DF /* NadoTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NadoTextField.swift; sourceTree = "<group>"; };
+		5C49669227BD469200983689 /* AutoSignInVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoSignInVC.swift; sourceTree = "<group>"; };
 		5C4ED929278949AC001EA6BB /* SignInSB.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SignInSB.storyboard; sourceTree = "<group>"; };
 		5C4ED92B278949C4001EA6BB /* SignInVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInVC.swift; sourceTree = "<group>"; };
 		5C54CEC5278D9CBB0054136D /* SignUpUserInfoVC.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SignUpUserInfoVC.storyboard; sourceTree = "<group>"; };
@@ -1031,6 +1033,7 @@
 			isa = PBXGroup;
 			children = (
 				5C4ED92B278949C4001EA6BB /* SignInVC.swift */,
+				5C49669227BD469200983689 /* AutoSignInVC.swift */,
 			);
 			path = VC;
 			sourceTree = "<group>";
@@ -1619,6 +1622,7 @@
 				77ED045027AD75E700D077CA /* FilterVC.swift in Sources */,
 				777ABF7C278C844E002D3214 /* ReviewMainLinkTVC.swift in Sources */,
 				3313642C2784D3BD00E0C118 /* SceneDelegate.swift in Sources */,
+				5C49669327BD469200983689 /* AutoSignInVC.swift in Sources */,
 				5CD4213D2790865A00D09DEE /* MypageNVC.swift in Sources */,
 				33B9B0DE27B8EB6700066C1F /* InfoCommentHeaderTVC.swift in Sources */,
 				3313645C2785A9F100E0C118 /* UITextField+.swift in Sources */,

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/UserDefaults+.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/UserDefaults+.swift
@@ -44,5 +44,11 @@ extension UserDefaults {
         
         /// String
         static var SelectedMajorName = "SelectedMajorName"
+        
+        /// String
+        static var Email = "Email"
+        
+        /// String
+        static var PW = "PW"
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Sign/SignInDataModel.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Sign/SignInDataModel.swift
@@ -10,10 +10,12 @@ import Foundation
 struct SignInDataModel: Codable {
     var user: User
     var accesstoken: String
+    var refreshtoken: String
 
     enum CodingKeys: String, CodingKey {
         case user = "user"
         case accesstoken = "accesstoken"
+        case refreshtoken = "refreshtoken"
     }
     
     struct User: Codable {
@@ -25,6 +27,7 @@ struct SignInDataModel: Codable {
         var secondMajorID: Int
         var secondMajorName: String
         var isReviewed: Bool
+        var isEmailVerified: Bool
 
         enum CodingKeys: String, CodingKey {
             case userID = "userId"
@@ -35,6 +38,7 @@ struct SignInDataModel: Codable {
             case secondMajorID = "secondMajorId"
             case secondMajorName = "secondMajorName"
             case isReviewed = "isReviewed"
+            case isEmailVerified = "isEmailVerified"
         }
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/SB/SignInSB.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/SB/SignInSB.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="RDp-6C-syV">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
@@ -200,7 +200,34 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="131.8840579710145" y="101.78571428571428"/>
+            <point key="canvasLocation" x="1609" y="100"/>
+        </scene>
+        <!--Auto Sign InVC-->
+        <scene sceneID="FA8-4b-3bQ">
+            <objects>
+                <viewController storyboardIdentifier="AutoSignInVC" id="RDp-6C-syV" customClass="AutoSignInVC" customModule="NadoSunbae_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="PkO-Ju-Iqk">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="~ 대충 런치스크린과 동일한 이미지 ~" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xz7-fP-PqO">
+                                <rect key="frame" x="63" y="395.66666666666669" width="249" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="5VA-lh-SpP"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="xz7-fP-PqO" firstAttribute="centerX" secondItem="PkO-Ju-Iqk" secondAttribute="centerX" id="GcA-i3-h0G"/>
+                            <constraint firstItem="xz7-fP-PqO" firstAttribute="centerY" secondItem="PkO-Ju-Iqk" secondAttribute="centerY" id="zVQ-6H-kOh"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Lh1-AL-8Yh" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="909.60000000000002" y="100.49261083743843"/>
         </scene>
     </scenes>
     <resources>
@@ -219,6 +246,9 @@
         <namedColor name="paleGray">
             <color red="0.98431372549019602" green="0.98431372549019602" blue="0.99215686274509807" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
         <systemColor name="systemRedColor">
             <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/VC/AutoSignInVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/VC/AutoSignInVC.swift
@@ -1,0 +1,62 @@
+//
+//  AutoSignInVC.swift
+//  NadoSunbae-iOS
+//
+//  Created by 1v1 on 2022/02/16.
+//
+
+import UIKit
+
+class AutoSignInVC: BaseVC {
+    
+    // MARK: Properties
+    let email: String = UserDefaults.standard.string(forKey: UserDefaults.Keys.Email) ?? ""
+    let PW: String = UserDefaults.standard.string(forKey: UserDefaults.Keys.PW) ?? ""
+    
+    // MARK: LifeCycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}
+
+// MARK: Custom Methods
+extension AutoSignInVC {
+    
+    /// Userdefaults에 값 지정하는 메서드
+    private func setUpUserdefaultValues(data: SignInDataModel) {
+        UserDefaults.standard.set(data.accesstoken, forKey: UserDefaults.Keys.AccessToken)
+        UserDefaults.standard.set(data.accesstoken, forKey: UserDefaults.Keys.RefreshToken)
+        UserDefaults.standard.set(data.user.firstMajorID, forKey: UserDefaults.Keys.FirstMajorID)
+        UserDefaults.standard.set(data.user.firstMajorName, forKey: UserDefaults.Keys.FirstMajorName)
+        UserDefaults.standard.set(data.user.secondMajorID, forKey: UserDefaults.Keys.SecondMajorID)
+        UserDefaults.standard.set(data.user.secondMajorName, forKey: UserDefaults.Keys.SecondMajorName)
+        UserDefaults.standard.set(data.user.isReviewed, forKey: UserDefaults.Keys.IsReviewed)
+        UserDefaults.standard.set(data.user.userID, forKey: UserDefaults.Keys.UserID)
+    }
+}
+
+// MARK: Network
+extension AutoSignInVC {
+    
+    /// 로그인 요청하는 메서드
+    private func requestSignIn() {
+        self.activityIndicator.startAnimating()
+        SignAPI.shared.signIn(email: email, PW: PW, deviceToken: UserDefaults.standard.value(forKey: UserDefaults.Keys.FCMTokenForDevice) as! String) { networkResult in
+            switch networkResult {
+            case .success(let res):
+                self.activityIndicator.stopAnimating()
+                if let data = res as? SignInDataModel {
+                    self.setUpUserdefaultValues(data: data)
+                    let nadoSunbaeTBC = NadoSunbaeTBC()
+                    nadoSunbaeTBC.modalPresentationStyle = .fullScreen
+                    self.present(nadoSunbaeTBC, animated: true, completion: nil)
+                }
+            default:
+                self.activityIndicator.stopAnimating()
+                print("Failed Auto SignIn")
+                guard let signInVC = self.storyboard?.instantiateViewController(withIdentifier: SignInVC.className) as? SignInVC else { return }
+                self.present(signInVC, animated: true, completion: nil)
+            }
+        }
+    }
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/VC/AutoSignInVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/VC/AutoSignInVC.swift
@@ -16,6 +16,7 @@ class AutoSignInVC: BaseVC {
     // MARK: LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        requestSignIn()
     }
 }
 
@@ -41,7 +42,7 @@ extension AutoSignInVC {
     /// 로그인 요청하는 메서드
     private func requestSignIn() {
         self.activityIndicator.startAnimating()
-        SignAPI.shared.signIn(email: email, PW: PW, deviceToken: UserDefaults.standard.value(forKey: UserDefaults.Keys.FCMTokenForDevice) as! String) { networkResult in
+        SignAPI.shared.signIn(email: email, PW: PW, deviceToken: UserDefaults.standard.string(forKey: UserDefaults.Keys.FCMTokenForDevice) ?? "") { networkResult in
             switch networkResult {
             case .success(let res):
                 self.activityIndicator.stopAnimating()
@@ -55,6 +56,7 @@ extension AutoSignInVC {
                 self.activityIndicator.stopAnimating()
                 print("Failed Auto SignIn")
                 guard let signInVC = self.storyboard?.instantiateViewController(withIdentifier: SignInVC.className) as? SignInVC else { return }
+                signInVC.modalPresentationStyle = .fullScreen
                 self.present(signInVC, animated: true, completion: nil)
             }
         }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/VC/AutoSignInVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/VC/AutoSignInVC.swift
@@ -26,7 +26,7 @@ extension AutoSignInVC {
     /// Userdefaults에 값 지정하는 메서드
     private func setUpUserdefaultValues(data: SignInDataModel) {
         UserDefaults.standard.set(data.accesstoken, forKey: UserDefaults.Keys.AccessToken)
-        UserDefaults.standard.set(data.accesstoken, forKey: UserDefaults.Keys.RefreshToken)
+        UserDefaults.standard.set(data.refreshtoken, forKey: UserDefaults.Keys.RefreshToken)
         UserDefaults.standard.set(data.user.firstMajorID, forKey: UserDefaults.Keys.FirstMajorID)
         UserDefaults.standard.set(data.user.firstMajorName, forKey: UserDefaults.Keys.FirstMajorName)
         UserDefaults.standard.set(data.user.secondMajorID, forKey: UserDefaults.Keys.SecondMajorID)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/VC/SignInVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/VC/SignInVC.swift
@@ -100,7 +100,7 @@ extension SignInVC {
     /// Userdefaults에 값 지정하는 메서드
     private func setUpUserdefaultValues(data: SignInDataModel) {
         UserDefaults.standard.set(data.accesstoken, forKey: UserDefaults.Keys.AccessToken)
-        UserDefaults.standard.set(data.accesstoken, forKey: UserDefaults.Keys.RefreshToken)
+        UserDefaults.standard.set(data.refreshtoken, forKey: UserDefaults.Keys.RefreshToken)
         UserDefaults.standard.set(data.user.firstMajorID, forKey: UserDefaults.Keys.FirstMajorID)
         UserDefaults.standard.set(data.user.firstMajorName, forKey: UserDefaults.Keys.FirstMajorName)
         UserDefaults.standard.set(data.user.secondMajorID, forKey: UserDefaults.Keys.SecondMajorID)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/VC/SignInVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/VC/SignInVC.swift
@@ -107,6 +107,8 @@ extension SignInVC {
         UserDefaults.standard.set(data.user.secondMajorName, forKey: UserDefaults.Keys.SecondMajorName)
         UserDefaults.standard.set(data.user.isReviewed, forKey: UserDefaults.Keys.IsReviewed)
         UserDefaults.standard.set(data.user.userID, forKey: UserDefaults.Keys.UserID)
+        UserDefaults.standard.set(emailTextField.text, forKey: UserDefaults.Keys.Email)
+        UserDefaults.standard.set(PWTextField.text, forKey: UserDefaults.Keys.PW)
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Support/SceneDelegate.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Support/SceneDelegate.swift
@@ -22,7 +22,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             
             // rootVC를 tabBar로 지정
 //            window.rootViewController = NadoSunbaeTBC()
-            window.rootViewController = UIStoryboard.init(name: "SignInSB", bundle: nil).instantiateViewController(withIdentifier: SignInVC.className) as? SignInVC
+            window.rootViewController = UIStoryboard.init(name: "SignInSB", bundle: nil).instantiateViewController(withIdentifier: AutoSignInVC.className) as? AutoSignInVC
             self.window = window
             window.makeKeyAndVisible()
         }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #172

## 🍎 변경 사항 및 이유
* 자동로그인 구현

## 🍎 PR Point
~ 로직 설명 ~
* `SignInVC`에서 로그인 성공했을 경우 `UserDefaults`에 아이디/비번 저장
* `AutoSignInVC`에서 로그인 성공/실패 판단하여 후기탭으로 갈지 `SignInVC`로 갈지 분기 처리
* `AutoSignInVC`에서 로그인 실패한 경우(설치후 첫실행이라 데이터 없을 경우, 불의의 사고로 계정이 없거나 변경되었을 경우 등등...) 하나로 퉁쳐서 `switch-case`문 `default`로 처리!
* `AutoSignInVC` 뷰는 런치스크린 뷰랑 동일하게 구성! 이건 디자인쌤들이 나중에 런치스크린 완성해 주시면 이미지만 넣으면 됩니당~

* `SignUpVC`에서 회원가입 성공했을 경우 `UserDefaults`에 아이디/비번 저장 -> `SignInVC`로 이동하지 않고 바로 로그인 요청 .... ~회원가입마무리하고구현할게염~

## 📸 ScreenShot
직접확인해보세요. ㅋ 순식간에 지나가서 업슴
