### PR TITLE
✨ [FEAT] 내가 작성한 후기글 삭제 기능 구현

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
@@ -179,6 +179,7 @@
 		777ABF81278C9584002D3214 /* ReviewMainPostTVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 777ABF7F278C9584002D3214 /* ReviewMainPostTVC.xib */; };
 		777ABF83278CB327002D3214 /* ReviewMainStickyHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = 777ABF82278CB327002D3214 /* ReviewMainStickyHeader.xib */; };
 		777ABF89278CB793002D3214 /* ReviewStickyHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 777ABF88278CB793002D3214 /* ReviewStickyHeaderView.swift */; };
+		77A049F627BD647900D09C69 /* ReviewDeleteResModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A049F527BD647900D09C69 /* ReviewDeleteResModel.swift */; };
 		77A7591A279712B700A8E48B /* ReviewPostTagCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A75918279712B700A8E48B /* ReviewPostTagCVC.swift */; };
 		77A7591B279712B700A8E48B /* ReviewPostTagCVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 77A75919279712B700A8E48B /* ReviewPostTagCVC.xib */; };
 		77A7591E279762BF00A8E48B /* ReviewPostRegisterData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A7591D279762BF00A8E48B /* ReviewPostRegisterData.swift */; };
@@ -384,6 +385,7 @@
 		777ABF7F278C9584002D3214 /* ReviewMainPostTVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewMainPostTVC.xib; sourceTree = "<group>"; };
 		777ABF82278CB327002D3214 /* ReviewMainStickyHeader.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewMainStickyHeader.xib; sourceTree = "<group>"; };
 		777ABF88278CB793002D3214 /* ReviewStickyHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewStickyHeaderView.swift; sourceTree = "<group>"; };
+		77A049F527BD647900D09C69 /* ReviewDeleteResModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDeleteResModel.swift; sourceTree = "<group>"; };
 		77A75918279712B700A8E48B /* ReviewPostTagCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewPostTagCVC.swift; sourceTree = "<group>"; };
 		77A75919279712B700A8E48B /* ReviewPostTagCVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewPostTagCVC.xib; sourceTree = "<group>"; };
 		77A7591D279762BF00A8E48B /* ReviewPostRegisterData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewPostRegisterData.swift; sourceTree = "<group>"; };
@@ -1257,6 +1259,7 @@
 				77A7593527988E7300A8E48B /* ReviewMainPostListData.swift */,
 				77A7593B2799C81B00A8E48B /* ReviewPostDetailData.swift */,
 				77A75943279B111300A8E48B /* ReviewHomePageData.swift */,
+				77A049F527BD647900D09C69 /* ReviewDeleteResModel.swift */,
 			);
 			path = Review;
 			sourceTree = "<group>";
@@ -1557,6 +1560,7 @@
 				330DA4332790BCCC00FE127F /* NadoTextView.swift in Sources */,
 				3313646A2785AED600E0C118 /* UIFont+.swift in Sources */,
 				33C1B8A527974B72004BABEC /* ClassroomService.swift in Sources */,
+				77A049F627BD647900D09C69 /* ReviewDeleteResModel.swift in Sources */,
 				331364AE2785DC1900E0C118 /* ViewControllerFactory.swift in Sources */,
 				33CF636827955D9500E92C04 /* ClassroomNC.swift in Sources */,
 				33BE2D4727897DD1000FB6C8 /* NadoSunbaeNaviBar.swift in Sources */,

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ReviewAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ReviewAPI.swift
@@ -81,6 +81,23 @@ class ReviewAPI {
             }
         }
     }
+    
+    /// [DELETE] 후기글 삭제 API
+    func deleteReviewPostAPI(postID: Int, completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        userProvider.request(.deleteReviewPost(postID: postID)) { result in
+            switch result {
+                
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                
+                completion(self.deleteReviewPostJudgeData(status: statusCode, data: data))
+                
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
 }
 
 // MARK: - JudgeData
@@ -141,6 +158,23 @@ extension ReviewAPI {
     func getReviewHomepageJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
         let decodedData = try? decoder.decode(GenericResponse<ReviewHomePageData>.self, from: data)
+        
+        switch status {
+        case 200...204:
+            return .success(decodedData?.data ?? "None-Data")
+        case 400...409:
+            return .requestErr(decodedData?.message)
+        case 500:
+            return .serverErr
+        default:
+            return .networkFail
+        }
+    }
+    
+    /// deleteReviewPostJudgeData
+    func deleteReviewPostJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
+        let decoder = JSONDecoder()
+        let decodedData = try? decoder.decode(GenericResponse<ReviewDeleteResModel>.self, from: data)
         
         switch status {
         case 200...204:

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Review/ReviewDeleteResModel.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Review/ReviewDeleteResModel.swift
@@ -1,0 +1,20 @@
+//
+//  ReviewDeleteResModel.swift
+//  NadoSunbae-iOS
+//
+//  Created by EUNJU on 2022/02/17.
+//
+
+import Foundation
+
+// MARK: - ReviewDeleteResModel
+struct ReviewDeleteResModel: Codable {
+    let postID: Int
+    let isDeleted: Bool
+    let isReviewed: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case postID = "postId"
+        case isDeleted, isReviewed
+    }
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Review/ReviewPostDetailData.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Review/ReviewPostDetailData.swift
@@ -26,17 +26,6 @@ struct BackgroundImage: Codable {
     }
 }
 
-// MARK: - PostLike
-struct PostLike: Codable {
-    let isLiked: Bool?
-    let likeCount: Int?
-
-    enum CodingKeys: String, CodingKey {
-        case isLiked = "isLiked"
-        case likeCount = "likeCount"
-    }
-}
-
 // MARK: - PostDetail
 struct PostDetail: Codable {
     var postID: Int = -1

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/ReviewService.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/ReviewService.swift
@@ -13,6 +13,7 @@ enum ReviewService {
     case getReviewMainPostList(majorID: Int, writerFilter: Int, tagFilter:[Int], sort: String)
     case getReviewPostDetail(postID: Int)
     case getReviewHomepageURL(majorID: Int)
+    case deleteReviewPost(postID: Int)
 }
 
 extension ReviewService: TargetType {
@@ -27,7 +28,7 @@ extension ReviewService: TargetType {
             return "/review-post"
         case .getReviewMainPostList:
             return "/review-post/list"
-        case .getReviewPostDetail(let postID):
+        case .getReviewPostDetail(let postID), .deleteReviewPost(let postID):
             return "/review-post/\(postID)"
         case .getReviewHomepageURL(let majorID):
             return "/major/\(majorID)"
@@ -41,6 +42,8 @@ extension ReviewService: TargetType {
             return .post
         case .getReviewPostDetail, .getReviewHomepageURL:
             return .get
+        case .deleteReviewPost:
+            return .delete
         }
     }
     
@@ -75,7 +78,7 @@ extension ReviewService: TargetType {
             // 배열값([Int])을 보낼 때는 JSONEncoding.prettyPrinted 사용해야함
             return .requestCompositeParameters(bodyParameters: body, bodyEncoding: JSONEncoding.prettyPrinted, urlParameters: query)
             
-        case .getReviewPostDetail, .getReviewHomepageURL:
+        case .getReviewPostDetail, .getReviewHomepageURL, .deleteReviewPost:
             return .requestPlain
         }
     }
@@ -86,7 +89,7 @@ extension ReviewService: TargetType {
         
         switch self {
             
-        case .createReviewPost, .getReviewMainPostList, .getReviewPostDetail, .getReviewHomepageURL:
+        case .createReviewPost, .getReviewMainPostList, .getReviewPostDetail, .getReviewHomepageURL, .deleteReviewPost:
             return ["accesstoken" : accessToken]
         }
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
@@ -85,24 +85,15 @@ extension ReviewDetailVC {
     /// 액션 시트
     private func presentActionSheet() {
         naviBarView.rightCustomBtn.press {
-            let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-            let edit = UIAlertAction(title: "수정", style: .default) { action in
-                
-                // TODO: 액션 추가 예정
-                print("수정")
-            }
-            let delete = UIAlertAction(title: "삭제", style: .default) { action in
-                
-                // TODO: 화면전환 방식 navigation 방식으로 변경 후 팝업 추가 예정
-                print("삭제")
-            }
-            let cancel = UIAlertAction(title: "취소", style: .cancel)
             
-            alert.addAction(edit)
-            alert.addAction(delete)
-            alert.addAction(cancel)
-            
-            self.present(alert, animated: true, completion: nil)
+            /// 내가 작성한 글인 경우 수정, 삭제
+            if self.detailPost.writer.writerID == UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID) {
+                self.makeTwoAlertWithCancel(okTitle: "수정", secondOkTitle: "삭제", okAction: { _ in print("수정")}, secondOkAction: { _ in print("삭제")})
+            } else {
+                
+                /// 타인 작성 글인 경우 신고
+                self.makeAlertWithCancel(okTitle: "신고", okAction: { _ in print("신고")})
+            }
         }
     }
     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
@@ -227,7 +227,7 @@ extension ReviewDetailVC {
                 }
             default:
                 self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "네트워크 오류입니다.")
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }
@@ -247,11 +247,11 @@ extension ReviewDetailVC {
                 if let message = msg as? String {
                     print(message)
                     self.activityIndicator.stopAnimating()
-                    self.makeAlert(title: "내부 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
                 }
             default:
                 self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "내부 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }
@@ -275,7 +275,7 @@ extension ReviewDetailVC {
                 }
             default:
                 self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "네트워크 오류입니다.")
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
@@ -235,7 +235,7 @@ extension ReviewDetailVC {
         ClassroomAPI.shared.postClassroomLikeAPI(chatPostID: postID, postTypeID: postTypeID.rawValue) { networkResult in
             switch networkResult {
             case .success(let res):
-                if let _ = res as? Like {
+                if let _ = res as? PostLikeResModel {
                     self.requestGetReviewPostDetail(postID: postID)
                     print(res)
                     self.activityIndicator.stopAnimating()

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
@@ -333,7 +333,7 @@ extension ReviewWriteVC: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
         
         /// 필수 항목 모두 작성되었을 때
-        if oneLineReviewTextView.text.count > 0 && prosAndConsTextView.text.count >= 100  {
+        if oneLineReviewTextView.text != "학과를 한줄로 표현한다면?" && oneLineReviewTextView.text.count > 0 && prosAndConsTextView.text.count >= 100  {
             essentialTextViewStatus = true
         } else {
             essentialTextViewStatus = false


### PR DESCRIPTION
## 🍎 관련 이슈
closed #178 

## 🍎 변경 사항 및 이유
- 후기글 삭제 기능을 구현 했습니다.

## 🍎 PR Point
- 작성자 기준 수정,삭제/신고 분기처리 (`writerID`와 `userID` 비교)
- 삭제 버튼 클릭 시 나타나는 알럿 창 추가 및 DELETE 서버 통신
- 작성한 게시글 모두 삭제했다면 후기글 열람 다시 제한 
- `WriteVC` 완료 버튼 분기처리 코드 수정 

   **이제 더미? 클라에서 관리해.**

## 📸 ScreenShot
- 작성자 기준 수정,삭제/신고 분기처리

<img width="250" src="https://user-images.githubusercontent.com/63277563/154418477-c928b9a7-c038-4d85-8a79-497731d702ca.PNG"> <img width="250" src="https://user-images.githubusercontent.com/63277563/154418486-9d09cd81-9781-4eff-801e-39d985cb9d4f.PNG">

- 후기글 삭제

https://user-images.githubusercontent.com/63277563/154417726-f1a4e567-4099-459b-8338-303f675f1cb7.mp4

- 내가 쓴 게시글 모두 지웠다면 열람 권한 뺏기

https://user-images.githubusercontent.com/63277563/154417922-70d3434a-74e3-4ed8-a0bc-8150ea61eac3.mp4


