### PR TITLE
✨ [FEAT] 과방 정보글 UI 하단 텍스팅 영역, 댓글 기능 구현

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoCommentTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoCommentTVC.swift
@@ -28,7 +28,11 @@ class InfoCommentTVC: BaseTVC {
     }
     @IBOutlet var commentDateLabel: UILabel!
     @IBOutlet var showWriterLabel: UILabel!
-    @IBOutlet var showWriterBackView: UIView!
+    @IBOutlet var showWriterBackView: UIView! {
+        didSet {
+            showWriterBackView.layer.cornerRadius = 6
+        }
+    }
     
     // MARK: Properties
     var tapMoreInfoBtn: (() -> ())?

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/SB/InfoSB.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/SB/InfoSB.storyboard
@@ -45,9 +45,9 @@
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="38" id="Kwj-LQ-L1Q"/>
                                     <constraint firstAttribute="height" relation="lessThanOrEqual" constant="90" id="akL-Wt-LGn"/>
                                 </constraints>
-                                <color key="textColor" name="gray4"/>
+                                <color key="textColor" name="gray2"/>
                                 <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences" autocorrectionType="no"/>
                             </textView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NSx-pQ-fz7">
                                 <rect key="frame" x="366" y="818" width="44" height="44"/>
@@ -75,16 +75,16 @@
                         <viewLayoutGuide key="safeArea" id="Z51-Cd-vs1"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="NSx-pQ-fz7" firstAttribute="bottom" secondItem="Z51-Cd-vs1" secondAttribute="bottom" id="23V-xs-QTK"/>
                             <constraint firstItem="nRL-BL-JiF" firstAttribute="leading" secondItem="Z51-Cd-vs1" secondAttribute="leading" id="2j9-Wn-fBN"/>
                             <constraint firstItem="m1A-mY-Z0L" firstAttribute="leading" secondItem="Z51-Cd-vs1" secondAttribute="leading" constant="16" id="4UT-Ix-mrJ"/>
+                            <constraint firstItem="NSx-pQ-fz7" firstAttribute="leading" secondItem="m1A-mY-Z0L" secondAttribute="trailing" id="5W9-u0-bqp"/>
                             <constraint firstItem="Z51-Cd-vs1" firstAttribute="bottom" secondItem="m1A-mY-Z0L" secondAttribute="bottom" constant="5" id="Cl8-Xm-esi"/>
                             <constraint firstItem="0zP-Zw-k4z" firstAttribute="leading" secondItem="Z51-Cd-vs1" secondAttribute="leading" id="Km9-U2-wK9"/>
                             <constraint firstItem="nRL-BL-JiF" firstAttribute="top" secondItem="0zP-Zw-k4z" secondAttribute="bottom" id="PhM-Fb-QXf"/>
-                            <constraint firstItem="NSx-pQ-fz7" firstAttribute="leading" secondItem="m1A-mY-Z0L" secondAttribute="trailing" id="TTJ-y2-99J"/>
                             <constraint firstItem="Z51-Cd-vs1" firstAttribute="trailing" secondItem="NSx-pQ-fz7" secondAttribute="trailing" constant="4" id="V4v-Jy-RfC"/>
                             <constraint firstItem="NSx-pQ-fz7" firstAttribute="width" secondItem="NSx-pQ-fz7" secondAttribute="height" multiplier="1:1" id="XiW-9P-NOO"/>
                             <constraint firstItem="Z51-Cd-vs1" firstAttribute="trailing" secondItem="0zP-Zw-k4z" secondAttribute="trailing" id="aw7-6c-4Qg"/>
+                            <constraint firstItem="Z51-Cd-vs1" firstAttribute="bottom" secondItem="NSx-pQ-fz7" secondAttribute="bottom" id="dSC-pL-cEC"/>
                             <constraint firstItem="Z51-Cd-vs1" firstAttribute="trailing" secondItem="nRL-BL-JiF" secondAttribute="trailing" id="lRk-28-gu3"/>
                             <constraint firstItem="0zP-Zw-k4z" firstAttribute="top" secondItem="RI6-M2-M4p" secondAttribute="top" id="ndT-Gk-ODX"/>
                             <constraint firstItem="m1A-mY-Z0L" firstAttribute="top" secondItem="nRL-BL-JiF" secondAttribute="bottom" constant="6" id="p73-nX-5q2"/>
@@ -93,10 +93,12 @@
                     </view>
                     <connections>
                         <outlet property="commentTextView" destination="m1A-mY-Z0L" id="tOV-Gw-LpG"/>
+                        <outlet property="commentTextViewBottom" destination="Cl8-Xm-esi" id="6YN-2D-ro2"/>
                         <outlet property="commentTextViewHeight" destination="5FC-uL-5NI" id="AYR-Jr-96I"/>
                         <outlet property="infoDetailNaviBar" destination="0zP-Zw-k4z" id="g1h-04-g0u"/>
                         <outlet property="infoDetailTV" destination="nRL-BL-JiF" id="gSX-dz-4Bu"/>
                         <outlet property="sendBtn" destination="NSx-pQ-fz7" id="oIN-tS-7Yl"/>
+                        <outlet property="sendBtnBottom" destination="dSC-pL-cEC" id="nss-Ev-w9a"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="goR-bQ-KL9" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -109,8 +111,8 @@
         <namedColor name="gray0">
             <color red="0.96470588235294119" green="0.96470588235294119" blue="0.97647058823529409" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
-        <namedColor name="gray4">
-            <color red="0.33725490196078434" green="0.33725490196078434" blue="0.37254901960784315" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <namedColor name="gray2">
+            <color red="0.75294117647058822" green="0.75294117647058822" blue="0.79607843137254897" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/SB/InfoSB.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/SB/InfoSB.storyboard
@@ -3,10 +3,16 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
+    <customFonts key="customFonts">
+        <array key="Pretendard-Regular.otf">
+            <string>Pretendard-Regular</string>
+        </array>
+    </customFonts>
     <scenes>
         <!--Info MainVC-->
         <scene sceneID="s0d-6b-0kx">
@@ -23,8 +29,89 @@
             </objects>
             <point key="canvasLocation" x="-23" y="107"/>
         </scene>
+        <!--Info DetailVC-->
+        <scene sceneID="yjk-zE-fgV">
+            <objects>
+                <viewController storyboardIdentifier="InfoDetailVC" id="5fc-ZN-nYv" customClass="InfoDetailVC" customModule="NadoSunbae_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="RI6-M2-M4p">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="답글쓰기" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="m1A-mY-Z0L">
+                                <rect key="frame" x="16" y="819" width="350" height="38"/>
+                                <color key="backgroundColor" name="gray0"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" priority="250" constant="38" id="5FC-uL-5NI"/>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="38" id="Kwj-LQ-L1Q"/>
+                                    <constraint firstAttribute="height" relation="lessThanOrEqual" constant="90" id="akL-Wt-LGn"/>
+                                </constraints>
+                                <color key="textColor" name="gray4"/>
+                                <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NSx-pQ-fz7">
+                                <rect key="frame" x="366" y="818" width="44" height="44"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="1us-iV-4gN"/>
+                                </constraints>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" image="btnSend" title=""/>
+                                <connections>
+                                    <action selector="tapSendBtn:" destination="5fc-ZN-nYv" eventType="touchUpInside" id="1B6-qH-Shk"/>
+                                </connections>
+                            </button>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="nRL-BL-JiF">
+                                <rect key="frame" x="0.0" y="104" width="414" height="709"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            </tableView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0zP-Zw-k4z" customClass="NadoSunbaeNaviBar" customModule="NadoSunbae_iOS" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="104"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="104" id="aZ3-yv-zgK"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="Z51-Cd-vs1"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="NSx-pQ-fz7" firstAttribute="bottom" secondItem="Z51-Cd-vs1" secondAttribute="bottom" id="23V-xs-QTK"/>
+                            <constraint firstItem="nRL-BL-JiF" firstAttribute="leading" secondItem="Z51-Cd-vs1" secondAttribute="leading" id="2j9-Wn-fBN"/>
+                            <constraint firstItem="m1A-mY-Z0L" firstAttribute="leading" secondItem="Z51-Cd-vs1" secondAttribute="leading" constant="16" id="4UT-Ix-mrJ"/>
+                            <constraint firstItem="Z51-Cd-vs1" firstAttribute="bottom" secondItem="m1A-mY-Z0L" secondAttribute="bottom" constant="5" id="Cl8-Xm-esi"/>
+                            <constraint firstItem="0zP-Zw-k4z" firstAttribute="leading" secondItem="Z51-Cd-vs1" secondAttribute="leading" id="Km9-U2-wK9"/>
+                            <constraint firstItem="nRL-BL-JiF" firstAttribute="top" secondItem="0zP-Zw-k4z" secondAttribute="bottom" id="PhM-Fb-QXf"/>
+                            <constraint firstItem="NSx-pQ-fz7" firstAttribute="leading" secondItem="m1A-mY-Z0L" secondAttribute="trailing" id="TTJ-y2-99J"/>
+                            <constraint firstItem="Z51-Cd-vs1" firstAttribute="trailing" secondItem="NSx-pQ-fz7" secondAttribute="trailing" constant="4" id="V4v-Jy-RfC"/>
+                            <constraint firstItem="NSx-pQ-fz7" firstAttribute="width" secondItem="NSx-pQ-fz7" secondAttribute="height" multiplier="1:1" id="XiW-9P-NOO"/>
+                            <constraint firstItem="Z51-Cd-vs1" firstAttribute="trailing" secondItem="0zP-Zw-k4z" secondAttribute="trailing" id="aw7-6c-4Qg"/>
+                            <constraint firstItem="Z51-Cd-vs1" firstAttribute="trailing" secondItem="nRL-BL-JiF" secondAttribute="trailing" id="lRk-28-gu3"/>
+                            <constraint firstItem="0zP-Zw-k4z" firstAttribute="top" secondItem="RI6-M2-M4p" secondAttribute="top" id="ndT-Gk-ODX"/>
+                            <constraint firstItem="m1A-mY-Z0L" firstAttribute="top" secondItem="nRL-BL-JiF" secondAttribute="bottom" constant="6" id="p73-nX-5q2"/>
+                            <constraint firstItem="NSx-pQ-fz7" firstAttribute="top" secondItem="nRL-BL-JiF" secondAttribute="bottom" priority="250" constant="5" id="u3b-fA-1WM"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="commentTextView" destination="m1A-mY-Z0L" id="tOV-Gw-LpG"/>
+                        <outlet property="commentTextViewHeight" destination="5FC-uL-5NI" id="AYR-Jr-96I"/>
+                        <outlet property="infoDetailNaviBar" destination="0zP-Zw-k4z" id="g1h-04-g0u"/>
+                        <outlet property="infoDetailTV" destination="nRL-BL-JiF" id="gSX-dz-4Bu"/>
+                        <outlet property="sendBtn" destination="NSx-pQ-fz7" id="oIN-tS-7Yl"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="goR-bQ-KL9" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="757" y="106"/>
+        </scene>
     </scenes>
     <resources>
+        <image name="btnSend" width="44" height="44"/>
+        <namedColor name="gray0">
+            <color red="0.96470588235294119" green="0.96470588235294119" blue="0.97647058823529409" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="gray4">
+            <color red="0.33725490196078434" green="0.33725490196078434" blue="0.37254901960784315" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
@@ -12,71 +12,85 @@ import SafariServices
 
 class InfoDetailVC: BaseVC {
     
+    // MARK: IBOutlet
+    @IBOutlet var infoDetailNaviBar: NadoSunbaeNaviBar! {
+        didSet {
+            infoDetailNaviBar.setUpNaviStyle(state: .backWithCenterTitle)
+        }
+    }
+    
+    @IBOutlet var infoDetailTV: UITableView! {
+        didSet {
+            infoDetailTV.separatorInset = UIEdgeInsets(top: 0, left: 24, bottom: 0, right: 24)
+            infoDetailTV.removeSeparatorsOfEmptyCellsAndLastCell()
+            infoDetailTV.dataSource = self
+            infoDetailTV.allowsSelection = false
+            infoDetailTV.rowHeight  = UITableView.automaticDimension
+            infoDetailTV.keyboardDismissMode = UIScrollView.KeyboardDismissMode.onDrag
+            infoDetailTV.backgroundColor = .paleGray
+        }
+    }
+    
+    @IBOutlet var commentTextView: UITextView! {
+        didSet {
+            commentTextView.delegate = self
+            commentTextView.isScrollEnabled = false
+            commentTextView.layer.cornerRadius = 18
+            commentTextView.layer.borderWidth = 1
+            commentTextView.layer.borderColor = UIColor.gray1.cgColor
+            commentTextView.textContainerInset = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 15)
+            commentTextView.sizeToFit()
+        }
+    }
+    
+    @IBOutlet var commentTextViewHeight: NSLayoutConstraint!
+    @IBOutlet var commentTextViewBottom: NSLayoutConstraint!
+    @IBOutlet var sendBtn: UIButton!
+    @IBOutlet var sendBtnBottom: NSLayoutConstraint!
+    
     // MARK: Properties
-    private let infoDetailNaviBar = NadoSunbaeNaviBar().then {
-        $0.setUpNaviStyle(state: .backWithCenterTitle)
-    }
-    
-    private let infoDetailTV = UITableView().then {
-        $0.separatorInset = UIEdgeInsets(top: 0, left: 24, bottom: 0, right: 24)
-        $0.removeSeparatorsOfEmptyCellsAndLastCell()
-    }
-    
     var chatPostID: Int?
     var userID: Int?
-    var userType: Int?
     var questionerID: Int?
-    var infoDetailData: InfoDetailDataModel?
-    var infoDetailCommentData: [InfoDetailCommentList] = []
-    var infoDetailLikeData: Like?
-
+    private var infoDetailData: InfoDetailDataModel?
+    private var infoDetailCommentData: [InfoDetailCommentList] = []
+    private var infoDetailLikeData: Like?
+    private let screenHeight = UIScreen.main.bounds.size.height
+    private var isCommentSend: Bool = false
+    private var isTextViewEmpty: Bool = true
+    private var sendTextViewLineCount: Int = 1
+    private let textViewMaxHeight: CGFloat = 85
+    
     // MARK: Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureUI()
         registerXib()
-        setUpTV()
         setUpNaviStyle()
         addActivateIndicator()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         self.tabBarController?.tabBar.isHidden = true
+        addKeyboardObserver()
         optionalBindingData()
     }
-}
-
-// MARK: - UI
-extension InfoDetailVC {
-    private func configureUI() {
-        self.view.addSubviews([infoDetailNaviBar, infoDetailTV])
-        
-        infoDetailNaviBar.snp.makeConstraints {
-            $0.top.leading.trailing.equalToSuperview()
-            $0.height.equalTo(104)
-        }
-        
-        infoDetailTV.snp.makeConstraints {
-            $0.top.equalTo(infoDetailNaviBar.snp.bottom)
-            $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(236)
-            $0.bottom.equalToSuperview()
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        removeKeyboardObserver()
+    }
+    
+    // MARK: IBOutlet
+    @IBAction func tapSendBtn(_ sender: UIButton) {
+        DispatchQueue.main.async {
+            self.isCommentSend = true
+            self.requestCreateComment(chatPostID: self.chatPostID ?? 0, comment: self.commentTextView.text)
         }
     }
 }
 
 // MARK: - Custom Methods
 extension InfoDetailVC {
-    
-    /// infoDetailTV 구성 메서드
-    private func setUpTV() {
-        infoDetailTV.dataSource = self
-        infoDetailTV.allowsSelection = false
-        infoDetailTV.separatorStyle = .none
-        infoDetailTV.rowHeight  = UITableView.automaticDimension
-        infoDetailTV.keyboardDismissMode = UIScrollView.KeyboardDismissMode.onDrag
-        infoDetailTV.backgroundColor = .paleGray
-    }
     
     /// xib 등록 메서드
     private func registerXib() {
@@ -90,6 +104,12 @@ extension InfoDetailVC {
         infoDetailNaviBar.rightCustomBtn.setImgByName(name: "btnMoreVertChatGray", selectedName: "btnMoreVertChatGray")
         infoDetailNaviBar.backBtn.press {
             self.navigationController?.popViewController(animated: true)
+        }
+        infoDetailNaviBar.rightCustomBtn.press {
+            // TODO: 추후에 권한 분기처리 예정
+            self.makeAlertWithCancel(okTitle: "신고", okAction: { _ in
+                // TODO: 추후에 기능 추가 예정
+            })
         }
     }
     
@@ -107,6 +127,46 @@ extension InfoDetailVC {
         activityIndicator.center = CGPoint(x: self.view.center.x, y: view.center.y)
         view.addSubview(self.activityIndicator)
     }
+    
+    /// 전송 버튼의 상태를 setUp하는 메서드
+    private func setUpSendBtnEnabledState() {
+        sendBtn.isEnabled = isTextViewEmpty ? false : true
+    }
+    
+    /// 전송 영역 TextView Height 조정하는 메서드
+    private func sendAreaDynamicHeight(textView: UITextView) {
+        if textView.contentSize.height >= self.textViewMaxHeight {
+            commentTextViewHeight.constant = self.textViewMaxHeight
+            textView.isScrollEnabled = true
+        } else {
+            commentTextViewHeight.constant = textView.contentSize.height
+            textView.isScrollEnabled = false
+        }
+    }
+    
+    /// 전송 영역 height값이 커짐에 따라 TableView contentOffset 조정하는 메서드
+    private func adjustTVContentOffset(textView: UITextView) {
+        var isLineAdded = true
+        
+        if sendTextViewLineCount != textView.numberOfLines() && textView.numberOfLines() > 1 {
+            isLineAdded = sendTextViewLineCount > textView.numberOfLines() ? false : true
+            
+            if isLineAdded {
+                if textView.contentSize.height <= self.textViewMaxHeight {
+                    self.infoDetailTV.contentOffset.y += 38
+                }
+            }
+        }
+        sendTextViewLineCount = textView.numberOfLines()
+    }
+    
+    /// TextView의 placeholder 지정하는 메서드
+    private func configueTextViewPlaceholder() {
+        commentTextView.endEditing(true)
+        commentTextView.text = "답글쓰기"
+        commentTextView.textColor = .gray2
+        commentTextView.backgroundColor = .gray0
+    }
 }
 
 // MARK: - UITableViewDataSource
@@ -121,11 +181,11 @@ extension InfoDetailVC: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let infoQuestionCell = tableView.dequeueReusableCell(withIdentifier: InfoQuestionTVC.className, for: indexPath) as? InfoQuestionTVC,
               let infoCommentCell = tableView.dequeueReusableCell(withIdentifier: InfoCommentTVC.className, for: indexPath) as? InfoCommentTVC else { return UITableViewCell() }
-
+        
         /// 정보글 원글 Cell
         if indexPath.row == 0 {
             infoQuestionCell.bindData(infoDetailData ?? InfoDetailDataModel(post: InfoDetailPost(postID: 0, title: "", content: "", createdAt: ""), writer: InfoDetailWriter(writerID: 0, profileImageID: 0, nickname: "", firstMajorName: "", firstMajorStart: "", secondMajorName: "", secondMajorStart: "", isPostWriter: false), like: Like(isLiked: false, likeCount: 0), commentCount: 0, commentList: []))
-    
+            
             infoQuestionCell.tapLikeBtnAction = { [unowned self] in
                 requestPostLikeData(chatID: chatPostID ?? 0, postTypeID: .info)
             }
@@ -134,11 +194,15 @@ extension InfoDetailVC: UITableViewDataSource {
                 let safariView: SFSafariViewController = SFSafariViewController(url: url)
                 self.present(safariView, animated: true, completion: nil)
             }
+            
+            infoQuestionCell.separatorInset = UIEdgeInsets(top: 0, left: CGFloat.greatestFiniteMagnitude, bottom: 0, right: 0)
+            
             return infoQuestionCell
         } else if indexPath.row == 1 {
             /// 정보글 댓글 수 header Cell
             let infoCommentHeaderCell = InfoCommentHeaderTVC()
-            infoCommentHeaderCell.bindData(commentCount: infoDetailData?.commentCount ?? -1)
+            infoCommentHeaderCell.bindData(commentCount: infoDetailData?.commentCount ?? 0)
+            infoCommentHeaderCell .separatorInset = UIEdgeInsets(top: 0, left: CGFloat.greatestFiniteMagnitude, bottom: 0, right: 0)
             return infoCommentHeaderCell
         }
         else {
@@ -151,7 +215,7 @@ extension InfoDetailVC: UITableViewDataSource {
                 })
             }
             
-            infoQuestionCell.interactURL = { url in
+            infoCommentCell.interactURL = { url in
                 let safariView: SFSafariViewController = SFSafariViewController(url: url)
                 self.present(safariView, animated: true, completion: nil)
             }
@@ -166,6 +230,75 @@ extension InfoDetailVC: UITableViewDelegate {
     /// estimatedHeightForRowAt
     func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
         return 140
+    }
+}
+
+// MARK: - UITextViewDelegate
+extension InfoDetailVC: UITextViewDelegate {
+    
+    /// textViewDidChange
+    func textViewDidChange(_ textView: UITextView) {
+        isTextViewEmpty = textView.text.isEmpty ? true : false
+        sendAreaDynamicHeight(textView: textView)
+        adjustTVContentOffset(textView: textView)
+        setUpSendBtnEnabledState()
+    }
+    
+    /// textViewDidBeginEditing
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.textColor == .gray2 {
+            textView.text = nil
+            textView.textColor = UIColor.black
+            textView.backgroundColor = .white
+        }
+    }
+    
+    /// textViewDidEndEditing
+    func textViewDidEndEditing(_ textView: UITextView) {
+        isTextViewEmpty = textView.text.isEmpty ? true : false
+        setUpSendBtnEnabledState()
+        configueTextViewPlaceholder()
+    }
+}
+
+
+// MARK: - Keyboard
+extension InfoDetailVC {
+    
+    /// Keyboard Observer add 메서드
+    private func addKeyboardObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(self.keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    @objc
+    private func keyboardWillShow(_ notification: Notification) {
+        if screenHeight == 667 {
+            if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+                commentTextViewBottom.constant = keyboardSize.height + 6
+                sendBtnBottom.constant = keyboardSize.height + 1
+            }
+        } else {
+            if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+                commentTextViewBottom.constant = keyboardSize.height - 25
+                sendBtnBottom.constant = keyboardSize.height - 30
+            }
+        }
+    }
+    
+    @objc
+    private func keyboardWillHide(_ notification:Notification) {
+        if ((notification.userInfo?[UIResponder.keyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue) != nil {
+            commentTextViewBottom.constant = 5
+            sendBtnBottom.constant = 0
+            infoDetailTV.fitContentInset(inset: .zero)
+        }
+    }
+    
+    /// Keyboard Observer remove 메서드
+    private func removeKeyboardObserver() {
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
     }
 }
 
@@ -184,6 +317,8 @@ extension InfoDetailVC {
                     self.userID = UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID)
                     DispatchQueue.main.async {
                         self.infoDetailTV.reloadData()
+                        self.setUpSendBtnEnabledState()
+                        self.configueTextViewPlaceholder()
                     }
                     self.activityIndicator.stopAnimating()
                 }
@@ -191,16 +326,16 @@ extension InfoDetailVC {
                 if let message = msg as? String {
                     print(message)
                     self.activityIndicator.stopAnimating()
-                    self.makeAlert(title: "내부 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
                 }
             default:
                 self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "내부 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }
     
-    /// 1:1질문, 전체 질문, 정보글에 댓글 등록 API 요청 메서드
+    /// 정보글에 댓글 등록 API 요청 메서드
     func requestCreateComment(chatPostID: Int, comment: String) {
         self.activityIndicator.startAnimating()
         ClassroomAPI.shared.createCommentAPI(chatID: chatPostID, comment: comment) { networkResult in
@@ -216,11 +351,11 @@ extension InfoDetailVC {
                 if let message = msg as? String {
                     print(message)
                     self.activityIndicator.stopAnimating()
-                    self.makeAlert(title: "내부 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
                 }
             default:
                 self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "내부 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }
@@ -241,11 +376,11 @@ extension InfoDetailVC {
                 if let message = msg as? String {
                     print(message)
                     self.activityIndicator.stopAnimating()
-                    self.makeAlert(title: "내부 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
                 }
             default:
                 self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "내부 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
@@ -59,7 +59,7 @@ class InfoDetailVC: BaseVC {
     private var isCommentSend: Bool = false
     private var isTextViewEmpty: Bool = true
     private var sendTextViewLineCount: Int = 1
-    private let textViewMaxHeight: CGFloat = 85
+    private let textViewMaxHeight: CGFloat = 85.adjustedH
     
     // MARK: Life Cycle
     override func viewDidLoad() {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
@@ -235,7 +235,7 @@ extension InfoMainVC: UITableViewDelegate {
     
     /// didSelectRowAt
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let infoDetailVC = InfoDetailVC()
+        guard let infoDetailVC = self.storyboard?.instantiateViewController(withIdentifier: InfoDetailVC.className) as? InfoDetailVC else { return }
         
         if infoList.count != 0 {
             infoDetailVC.chatPostID = infoList[indexPath.row].postID

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -108,7 +108,6 @@ class DefaultQuestionChatVC: BaseVC {
             DispatchQueue.main.async {
                 self.isCommentSend = true
                 self.requestCreateComment(chatPostID: self.chatPostID ?? 0, comment: self.sendAreaTextView.text)
-                self.clearTextView()
             }
         }
     }
@@ -185,21 +184,9 @@ extension DefaultQuestionChatVC {
             print("Review")
         }
         
+        sendAreaTextView.endEditing(true)
         sendAreaTextView.textColor = .gray2
         sendAreaTextView.backgroundColor = .gray0
-    }
-    
-    /// TextView의 content를 초기상태로 되돌리는 메서드
-    private func clearTextView() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: {
-            self.sendAreaTextView.text = ""
-            self.sendAreaTextViewHeight.constant = 38
-            if self.sendAreaTextView.textColor == .gray2 {
-                self.sendAreaTextView.text = nil
-                self.sendAreaTextView.textColor = UIColor.black
-                self.sendAreaTextView.backgroundColor = .white
-            }
-        })
     }
     
     private func scrollTVtoBottom(animate: Bool) {
@@ -638,9 +625,8 @@ extension DefaultQuestionChatVC {
                     if self.isCommentSend {
                         self.scrollTVtoBottom(animate: true)
                         self.isCommentSend = false
-                    } else {
-                        self.configueTextViewPlaceholder(userType: self.userType ?? -1, questionType: self.questionType ?? .personal)
                     }
+                    self.configueTextViewPlaceholder(userType: self.userType ?? -1, questionType: self.questionType ?? .personal)
                     self.activityIndicator.stopAnimating()
                 }
             case .requestErr(let msg):


### PR DESCRIPTION
## 🍎 관련 이슈
closed #182 

## 🍎 변경 사항 및 이유
- InfoDetailVC를 코드베이스로 짰었는데, 하단 텍스팅영역을 개발하기에 스토리보드베이스가 더 편리할 것 같아서 스토리보드베이스로 변경하였습니다!
- 그리고 질문 채팅 UI에서도 생겼던 텍스팅영역의 자잘한 버그들을 같이 수정했습니다! (원래는 댓글남기고 바로 placeholder가 뜨는게 아니라 빈 textView를 띄웠었는데 에타에 직접 댓글달아서 확인한 결과 placeholder가 뜨길래 그렇게 UI를 수정했음!)

## 🍎 PR Point
- 정보글에 댓글을 남길 수 있도록 하단 텍스팅 영역을 추가하였고, 전송 버튼을 통해 댓글을 남길 수 있는 기능을 구현했습니다.

## 📸 ScreenShot
- 전체 구현영상 gif
<img width="375" alt="Simulator Screen Recording - iPhone 12 - 2022-02-18 at 00 28 30" src="https://user-images.githubusercontent.com/63224278/154517442-7fae73a6-2650-4374-92f3-04c5c4e35a7d.gif">

- 원글 작성자가 댓글 남긴 경우
<img width="375" alt="Simulator Screen Shot - iPhone 12 - 2022-02-18 at 00 28 41" src="https://user-images.githubusercontent.com/63224278/154517477-3ac9c490-3ec8-4876-a8fe-c65da4e53072.png">

- 키보드 올라왔을 때
<img width="375" alt="Simulator Screen Shot - iPhone 12 - 2022-02-18 at 00 28 50" src="https://user-images.githubusercontent.com/63224278/154517618-e5b86878-09bb-4d60-974b-07d6af27a6dd.png">

