### PR TITLE
🔨 [FIX] 과방탭 재사용셀 BaseQuestionTVC 좋아요 아이콘 일괄 변경

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/QuestionMain/BaseQuestionTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/QuestionMain/BaseQuestionTVC.swift
@@ -47,7 +47,7 @@ class BaseQuestionTVC: BaseTVC {
     }
     
     private let likeImgView = UIImageView().then {
-        $0.image = UIImage(named: "btnDiamond")
+        $0.image = UIImage(named: "heart")
         $0.contentMode = .scaleAspectFill
     }
     
@@ -111,13 +111,14 @@ extension BaseQuestionTVC {
         }
         
         likeImgView.snp.makeConstraints {
-            $0.trailing.equalTo(likeCountLabel.snp.leading)
-            $0.height.width.equalTo(32)
+            $0.trailing.equalTo(likeCountLabel.snp.leading).offset(-8)
+            $0.width.equalTo(16)
+            $0.height.equalTo(12)
             $0.centerY.equalTo(nicknameLabel)
         }
         
         commentCountLabel.snp.makeConstraints {
-            $0.trailing.equalTo(likeImgView.snp.leading).offset(-8)
+            $0.trailing.equalTo(likeImgView.snp.leading).offset(-16)
             $0.centerY.equalTo(nicknameLabel)
         }
         


### PR DESCRIPTION
## 🍎 관련 이슈
closed #187 

## 🍎 변경 사항 및 이유
- BaseQuetionTVC 좋아요 아이콘을 diamond에서 heart로 변경했습니다! (*디자인 수정)

## 🍎 PR Point
- BaseQuestionTVC 파일 한개 좋아요 아이콘 변경하고 레이아웃 조금 다시 손봐줬더니 무려 4개의 UI가 동시에 업데이트됐답니다 짝짝짝 🤗🤗🤗

## 📸 ScreenShot
<img width="375" alt="Simulator Screen Shot - iPhone 12 - 2022-02-18 at 01 02 55" src="https://user-images.githubusercontent.com/63224278/154525302-0a65149d-2ff2-4ed5-9cec-49a1f4cafe8c.png"><img width="375" alt="Simulator Screen Shot - iPhone 12 - 2022-02-18 at 01 03 15" src="https://user-images.githubusercontent.com/63224278/154525339-065cfdfb-f89b-486c-9e32-f37a1d51d223.png">

<img width="375" alt="Simulator Screen Shot - iPhone 12 - 2022-02-18 at 01 03 06" src="https://user-images.githubusercontent.com/63224278/154525328-60d288c1-b226-44d7-bd60-c2770867b672.png"><img width="375" alt="Simulator Screen Shot - iPhone 12 - 2022-02-18 at 01 03 52" src="https://user-images.githubusercontent.com/63224278/154525348-4a38a882-77fa-4e17-960c-3bc6462c1556.png"> 