### PR TITLE
✅ [Chore] 과방탭 좋아요 관련 UI 수정사항 반영

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomQuestionTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomQuestionTVC.swift
@@ -93,7 +93,7 @@ extension ClassroomQuestionTVC {
     
     func bindLikeData(_ model: Like) {
         likeCountLabel.text = "\(model.likeCount)"
-        likeBtn.setBackgroundImage(UIImage(named: model.isLiked ? "btnDiamondMint" : "btnDiamond") , for: .normal)
+        likeBtn.setBackgroundImage(UIImage(named: model.isLiked ? "heart_filled" : "btn_heart") , for: .normal)
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomQuestionTVC.xib
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomQuestionTVC.xib
@@ -80,7 +80,7 @@
                                     <constraint firstAttribute="width" secondItem="hkZ-Xq-Tbg" secondAttribute="height" multiplier="1:1" id="k7P-Ye-b9p"/>
                                 </constraints>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                <state key="normal" backgroundImage="btnDiamond">
+                                <state key="normal" backgroundImage="btn_heart">
                                     <color key="titleColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </state>
                                 <state key="selected" backgroundImage="btnDiamondMint"/>
@@ -154,9 +154,9 @@
         </tableViewCell>
     </objects>
     <resources>
-        <image name="btnDiamond" width="32" height="32"/>
         <image name="btnDiamondMint" width="32" height="32"/>
         <image name="btnMoreVertChatGray" width="24" height="24"/>
+        <image name="btn_heart" width="32" height="32"/>
         <namedColor name="gray2">
             <color red="0.75294117647058822" green="0.75294117647058822" blue="0.79607843137254897" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/QuestionMain/BaseQuestionTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/QuestionMain/BaseQuestionTVC.swift
@@ -111,14 +111,13 @@ extension BaseQuestionTVC {
         }
         
         likeImgView.snp.makeConstraints {
-            $0.trailing.equalTo(likeCountLabel.snp.leading).offset(-8)
-            $0.width.equalTo(16)
-            $0.height.equalTo(12)
+            $0.trailing.equalTo(likeCountLabel.snp.leading)
+            $0.width.height.equalTo(32)
             $0.centerY.equalTo(nicknameLabel)
         }
         
         commentCountLabel.snp.makeConstraints {
-            $0.trailing.equalTo(likeImgView.snp.leading).offset(-16)
+            $0.trailing.equalTo(likeImgView.snp.leading).offset(-8)
             $0.centerY.equalTo(nicknameLabel)
         }
         
@@ -139,6 +138,7 @@ extension BaseQuestionTVC {
         questionTimeLabel.text = data.createdAt.serverTimeToString(forUse: .forDefault)
         commentCountLabel.text = "\(data.commentCount)"
         likeCountLabel.text = "\(data.like.likeCount)"
+        likeImgView.image = data.like.isLiked ? UIImage(named: "heart_filled") : UIImage(named: "btn_heart")
     }
 }
 


### PR DESCRIPTION
## 🍎 관련 이슈
closed #189

## 🍎 변경 사항 및 이유
- BaseQuestionTVC에 heartFill 관련 코드를 추가했습니다

## 🍎 PR Point
- 과방 피드에서 내가 좋아요한 글에 대해서 좋아요 표시되는 기능을 추가했습니다!
- 질문 채팅 UI에서 좋아요 아이콘을 다이아몬드에서 하트로 변경했습니다.
- 과방탭 좋아요관련 수정사항 모두 반영 완료우!

## 📸 ScreenShot
<img width="375" alt="Simulator Screen Shot - iPhone 12 - 2022-02-18 at 02 38 47" src="https://user-images.githubusercontent.com/63224278/154539117-55b56104-efdb-440e-bfe1-50f2a4de7386.png"><img width="375" alt="Simulator Screen Shot - iPhone 12 - 2022-02-18 at 02 38 55" src="https://user-images.githubusercontent.com/63224278/154539195-ed77408b-a8c3-4fab-aa7b-8a14c8216da0.png">

