### PR TITLE
✨ [FEAT] 내가 작성한 후기글 수정 기능 구현

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		777ABF83278CB327002D3214 /* ReviewMainStickyHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = 777ABF82278CB327002D3214 /* ReviewMainStickyHeader.xib */; };
 		777ABF89278CB793002D3214 /* ReviewStickyHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 777ABF88278CB793002D3214 /* ReviewStickyHeaderView.swift */; };
 		77A049F627BD647900D09C69 /* ReviewDeleteResModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A049F527BD647900D09C69 /* ReviewDeleteResModel.swift */; };
+		77A049F827BEBD2B00D09C69 /* ReviewEditData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A049F727BEBD2B00D09C69 /* ReviewEditData.swift */; };
 		77A7591A279712B700A8E48B /* ReviewPostTagCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A75918279712B700A8E48B /* ReviewPostTagCVC.swift */; };
 		77A7591B279712B700A8E48B /* ReviewPostTagCVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 77A75919279712B700A8E48B /* ReviewPostTagCVC.xib */; };
 		77A7591E279762BF00A8E48B /* ReviewPostRegisterData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A7591D279762BF00A8E48B /* ReviewPostRegisterData.swift */; };
@@ -388,6 +389,7 @@
 		777ABF82278CB327002D3214 /* ReviewMainStickyHeader.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewMainStickyHeader.xib; sourceTree = "<group>"; };
 		777ABF88278CB793002D3214 /* ReviewStickyHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewStickyHeaderView.swift; sourceTree = "<group>"; };
 		77A049F527BD647900D09C69 /* ReviewDeleteResModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDeleteResModel.swift; sourceTree = "<group>"; };
+		77A049F727BEBD2B00D09C69 /* ReviewEditData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewEditData.swift; sourceTree = "<group>"; };
 		77A75918279712B700A8E48B /* ReviewPostTagCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewPostTagCVC.swift; sourceTree = "<group>"; };
 		77A75919279712B700A8E48B /* ReviewPostTagCVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewPostTagCVC.xib; sourceTree = "<group>"; };
 		77A7591D279762BF00A8E48B /* ReviewPostRegisterData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewPostRegisterData.swift; sourceTree = "<group>"; };
@@ -1258,6 +1260,7 @@
 			isa = PBXGroup;
 			children = (
 				77A7591D279762BF00A8E48B /* ReviewPostRegisterData.swift */,
+				77A049F727BEBD2B00D09C69 /* ReviewEditData.swift */,
 				77A759232797656B00A8E48B /* ReviewPostData.swift */,
 				77A7593527988E7300A8E48B /* ReviewMainPostListData.swift */,
 				77A7593B2799C81B00A8E48B /* ReviewPostDetailData.swift */,
@@ -1535,6 +1538,7 @@
 				77ED045327AEBDAF00D077CA /* SendUpdateStatusDelegate.swift in Sources */,
 				5CF1F37B278C4E3D007B8DE9 /* SelectMajorModalVC+TV.swift in Sources */,
 				5C54CECF278DF6190054136D /* SignUpCompleteVC.swift in Sources */,
+				77A049F827BEBD2B00D09C69 /* ReviewEditData.swift in Sources */,
 				5C9A93F927A64FB20097310B /* SignUpDataModel.swift in Sources */,
 				5C87EC22279A2D2C0039D935 /* CreateClassroomPostModel.swift in Sources */,
 				331364682785AE6500E0C118 /* UIColor+.swift in Sources */,

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ReviewAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ReviewAPI.swift
@@ -98,6 +98,23 @@ class ReviewAPI {
             }
         }
     }
+    
+    /// [PUT] 후기글 수정 API
+    func editReviewPostAPI(postID: Int, bgImgID: Int, oneLineReview: String, prosCons: String, curriculum: String, career: String, recommendLecture: String, nonRecommendLecture: String, tip: String, completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        userProvider.request(.editReviewPost(postID: postID, bgImgID: bgImgID, oneLineReview: oneLineReview, prosCons: prosCons, curriculum: curriculum, career: career, recommendLecture: recommendLecture, nonRecommendLecture: nonRecommendLecture, tip: tip)) { result in
+            switch result {
+                
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                
+                completion(self.editReviewPostJudgeData(status: statusCode, data: data))
+                
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
 }
 
 // MARK: - JudgeData
@@ -175,6 +192,23 @@ extension ReviewAPI {
     func deleteReviewPostJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
         let decodedData = try? decoder.decode(GenericResponse<ReviewDeleteResModel>.self, from: data)
+        
+        switch status {
+        case 200...204:
+            return .success(decodedData?.data ?? "None-Data")
+        case 400...409:
+            return .requestErr(decodedData?.message)
+        case 500:
+            return .serverErr
+        default:
+            return .networkFail
+        }
+    }
+    
+    /// editReviewPostJudgeData
+    func editReviewPostJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
+        let decoder = JSONDecoder()
+        let decodedData = try? decoder.decode(GenericResponse<ReviewEditData>.self, from: data)
         
         switch status {
         case 200...204:

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Review/ReviewEditData.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Review/ReviewEditData.swift
@@ -1,0 +1,42 @@
+//
+//  ReviewEditData.swift
+//  NadoSunbae-iOS
+//
+//  Created by EUNJU on 2022/02/18.
+//
+
+import Foundation
+
+// MARK: - ReviewEditData
+struct ReviewEditData: Codable {
+    let post: EditedPost
+    let writer: Editer
+    let like: Like
+    let backgroundImage: ReviewPostBackgroundImg
+}
+
+// MARK: - EditedPost
+struct EditedPost: Codable {
+    let postID: Int
+    let oneLineReview: String
+    let contentList: [ContentList]
+    let createdAt, updatedAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case postID = "postId"
+        case oneLineReview, contentList, createdAt, updatedAt
+    }
+}
+
+// MARK: - Editer
+struct Editer: Codable {
+    let editerID, profileImageID: Int
+    let nickname, firstMajorName, firstMajorStart, secondMajorName: String
+    let secondMajorStart: String
+
+    enum CodingKeys: String, CodingKey {
+        case editerID = "writerId"
+        case profileImageID = "profileImageId"
+        case nickname, firstMajorName, firstMajorStart, secondMajorName, secondMajorStart
+    }
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Review/ReviewPostRegisterData.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Review/ReviewPostRegisterData.swift
@@ -18,20 +18,9 @@ struct ReviewPostRegisterData: Codable {
 // MARK: - ReviewPostBackgroundImg
 struct ReviewPostBackgroundImg: Codable {
     let imgID: Int
-    let imgURL: ReviewPostImageURL
 
     enum CodingKeys: String, CodingKey {
         case imgID = "imageId"
-        case imgURL = "imageUrl"
-    }
-}
-
-// MARK: - ImageURL
-struct ReviewPostImageURL: Codable {
-    let imgURL: String
-
-    enum CodingKeys: String, CodingKey {
-        case imgURL = "imageUrl"
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/ReviewService.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/ReviewService.swift
@@ -14,6 +14,7 @@ enum ReviewService {
     case getReviewPostDetail(postID: Int)
     case getReviewHomepageURL(majorID: Int)
     case deleteReviewPost(postID: Int)
+    case editReviewPost(postID: Int, bgImgID: Int, oneLineReview: String, prosCons: String, curriculum: String, career: String, recommendLecture: String, nonRecommendLecture: String, tip: String)
 }
 
 extension ReviewService: TargetType {
@@ -32,6 +33,8 @@ extension ReviewService: TargetType {
             return "/review-post/\(postID)"
         case .getReviewHomepageURL(let majorID):
             return "/major/\(majorID)"
+        case .editReviewPost(let postID, _, _, _, _, _, _, _, _ ):
+            return "/review-post/\(postID)"
         }
     }
     
@@ -44,6 +47,8 @@ extension ReviewService: TargetType {
             return .get
         case .deleteReviewPost:
             return .delete
+        case .editReviewPost:
+            return .put
         }
     }
     
@@ -54,6 +59,20 @@ extension ReviewService: TargetType {
         case .createReviewPost(let majorID, let bgImgID, let oneLineReview, let prosCons, let curriculum, let career, let recommendLecture, let nonRecommendLecture, let tip):
             let body: [String : Any] = [
                 "majorId" : majorID,
+                "backgroundImageId" : bgImgID,
+                "oneLineReview" : oneLineReview,
+                "prosCons" : prosCons,
+                "curriculum" : curriculum,
+                "career" : career,
+                "recommendLecture" : recommendLecture,
+                "nonRecommendLecture" : nonRecommendLecture,
+                "tip" : tip
+            ]
+            return .requestParameters(parameters: body, encoding: JSONEncoding.prettyPrinted)
+        
+        /// 후기글 수정 경우
+        case .editReviewPost( _, let bgImgID, let oneLineReview, let prosCons, let curriculum, let career, let recommendLecture, let nonRecommendLecture, let tip):
+            let body: [String : Any] = [
                 "backgroundImageId" : bgImgID,
                 "oneLineReview" : oneLineReview,
                 "prosCons" : prosCons,
@@ -89,7 +108,7 @@ extension ReviewService: TargetType {
         
         switch self {
             
-        case .createReviewPost, .getReviewMainPostList, .getReviewPostDetail, .getReviewHomepageURL, .deleteReviewPost:
+        case .createReviewPost, .getReviewMainPostList, .getReviewPostDetail, .getReviewHomepageURL, .deleteReviewPost, .editReviewPost:
             return ["accesstoken" : accessToken]
         }
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
@@ -98,6 +98,7 @@ extension ReviewDetailVC {
                     self.present(nextVC, animated: true, completion: nil)
                     
                     /// 기존 작성 내용 전달
+                    nextVC.setIsPostingStatus(status: false)
                     nextVC.oneLineReviewTextView.textColor = .mainText
                     nextVC.oneLineReviewTextView.text = self.detailPost.post.oneLineReview
                     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
@@ -88,7 +88,47 @@ extension ReviewDetailVC {
             
             /// 내가 작성한 글인 경우 수정, 삭제
             if self.detailPost.writer.writerID == UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID) {
-                self.makeTwoAlertWithCancel(okTitle: "수정", secondOkTitle: "삭제", okAction: { _ in print("수정")}, secondOkAction: { _ in
+                self.makeTwoAlertWithCancel(okTitle: "수정", secondOkTitle: "삭제", okAction: { _ in
+                    
+                    /// 후기 작성 뷰로 이동
+                    let ReviewWriteSB = UIStoryboard.init(name: "ReviewWriteSB", bundle: nil)
+                    guard let nextVC = ReviewWriteSB.instantiateViewController(withIdentifier: ReviewWriteVC.className) as? ReviewWriteVC else { return }
+                    
+                    nextVC.modalPresentationStyle = .fullScreen
+                    self.present(nextVC, animated: true, completion: nil)
+                    
+                    /// 기존 작성 내용 전달
+                    nextVC.isPosting = false
+                    nextVC.oneLineReviewTextView.textColor = .mainText
+                    nextVC.oneLineReviewTextView.text = self.detailPost.post.oneLineReview
+                    
+                    for i in 0..<self.detailPost.post.contentList.count {
+                        let contentTitle = self.detailPost.post.contentList[i].title
+                        
+                        switch contentTitle {
+                        case "장단점":
+                            nextVC.prosAndConsTextView.textColor = .mainText
+                            nextVC.prosAndConsTextView.text = self.detailPost.post.contentList[i].content
+                        case "뭘 배우나요?":
+                            nextVC.learnInfoTextView.textColor = .mainText
+                            nextVC.learnInfoTextView.text = self.detailPost.post.contentList[i].content
+                        case "추천 수업":
+                            nextVC.recommendClassTextView.textColor = .mainText
+                            nextVC.recommendClassTextView.text = self.detailPost.post.contentList[i].content
+                        case "비추 수업":
+                            nextVC.badClassTextView.textColor = .mainText
+                            nextVC.badClassTextView.text = self.detailPost.post.contentList[i].content
+                        case "향후 진로":
+                            nextVC.futureTextView.textColor = .mainText
+                            nextVC.futureTextView.text = self.detailPost.post.contentList[i].content
+                        case "꿀팁":
+                            nextVC.tipTextView.textColor = .mainText
+                            nextVC.tipTextView.text = self.detailPost.post.contentList[i].content
+                        default:
+                            break
+                        }
+                    }
+                }, secondOkAction: { _ in
                     guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
                     alert.showNadoAlert(vc: self, message: "삭제하시겠습니까?", confirmBtnTitle: "삭제", cancelBtnTitle: "아니요")
                     alert.confirmBtn.press {
@@ -216,6 +256,7 @@ extension ReviewDetailVC {
             case .success(let res):
                 if let data = res as? ReviewPostDetailData {
                     self.detailPost = data
+                    print("여기", self.detailPost)
                     self.setUpLikeStatus(model: self.detailPost.like)
                     self.reviewPostTV.reloadData()
                     self.activityIndicator.stopAnimating()

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
@@ -89,45 +89,7 @@ extension ReviewDetailVC {
             /// 내가 작성한 글인 경우 수정, 삭제
             if self.detailPost.writer.writerID == UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID) {
                 self.makeTwoAlertWithCancel(okTitle: "수정", secondOkTitle: "삭제", okAction: { _ in
-                    
-                    /// 후기 작성 뷰로 이동
-                    let ReviewWriteSB = UIStoryboard.init(name: "ReviewWriteSB", bundle: nil)
-                    guard let nextVC = ReviewWriteSB.instantiateViewController(withIdentifier: ReviewWriteVC.className) as? ReviewWriteVC else { return }
-                    
-                    nextVC.modalPresentationStyle = .fullScreen
-                    self.present(nextVC, animated: true, completion: nil)
-                    
-                    /// 기존 작성 내용 전달
-                    nextVC.setReceivedData(status: false, postId: self.detailPost.post.postID)
-                    nextVC.oneLineReviewTextView.textColor = .mainText
-                    nextVC.oneLineReviewTextView.text = self.detailPost.post.oneLineReview
-                    
-                    for i in 0..<self.detailPost.post.contentList.count {
-                        let contentTitle = self.detailPost.post.contentList[i].title
-                        
-                        switch contentTitle {
-                        case "장단점":
-                            nextVC.prosAndConsTextView.textColor = .mainText
-                            nextVC.prosAndConsTextView.text = self.detailPost.post.contentList[i].content
-                        case "뭘 배우나요?":
-                            nextVC.learnInfoTextView.textColor = .mainText
-                            nextVC.learnInfoTextView.text = self.detailPost.post.contentList[i].content
-                        case "추천 수업":
-                            nextVC.recommendClassTextView.textColor = .mainText
-                            nextVC.recommendClassTextView.text = self.detailPost.post.contentList[i].content
-                        case "비추 수업":
-                            nextVC.badClassTextView.textColor = .mainText
-                            nextVC.badClassTextView.text = self.detailPost.post.contentList[i].content
-                        case "향후 진로":
-                            nextVC.futureTextView.textColor = .mainText
-                            nextVC.futureTextView.text = self.detailPost.post.contentList[i].content
-                        case "꿀팁":
-                            nextVC.tipTextView.textColor = .mainText
-                            nextVC.tipTextView.text = self.detailPost.post.contentList[i].content
-                        default:
-                            break
-                        }
-                    }
+                    self.sendDetailPostData()
                 }, secondOkAction: { _ in
                     guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
                     alert.showNadoAlert(vc: self, message: "삭제하시겠습니까?", confirmBtnTitle: "삭제", cancelBtnTitle: "아니요")
@@ -172,6 +134,36 @@ extension ReviewDetailVC {
     /// UserDefaults의 isReviewed 값 설정
     private func setUpIsReviewedStatus(model: ReviewDeleteResModel) {
         UserDefaults.standard.set(model.isReviewed, forKey: UserDefaults.Keys.IsReviewed)
+    }
+    
+    /// 후기 수정 위한 기존 데이터 전달 함수
+    private func sendDetailPostData() {
+        
+        /// 후기 작성 뷰로 이동
+        let ReviewWriteSB = UIStoryboard.init(name: "ReviewWriteSB", bundle: nil)
+        guard let nextVC = ReviewWriteSB.instantiateViewController(withIdentifier: ReviewWriteVC.className) as? ReviewWriteVC else { return }
+        
+        nextVC.modalPresentationStyle = .fullScreen
+        self.present(nextVC, animated: true, completion: nil)
+        
+        /// 기존 작성 내용 전달
+        nextVC.setReceivedData(status: false, postId: self.detailPost.post.postID)
+        nextVC.oneLineReviewTextView.textColor = .mainText
+        nextVC.oneLineReviewTextView.text = self.detailPost.post.oneLineReview
+        
+        let contentTitleDict: [String : UITextView] = ["장단점" : nextVC.prosAndConsTextView, "뭘 배우나요?" : nextVC.learnInfoTextView, "추천 수업" : nextVC.recommendClassTextView, "비추 수업" :  nextVC.badClassTextView, "향후 진로" : nextVC.futureTextView, "꿀팁" : nextVC.tipTextView]
+        var newContentTitleDict = [String : UITextView]()
+        var newContentDict = [String : String]()
+        
+        for i in 0..<self.detailPost.post.contentList.count {
+            newContentTitleDict.updateValue(contentTitleDict[self.detailPost.post.contentList[i].title] ?? UITextView(), forKey: self.detailPost.post.contentList[i].title)
+            newContentDict.updateValue(self.detailPost.post.contentList[i].content, forKey: self.detailPost.post.contentList[i].title)
+        }
+        
+        newContentTitleDict.forEach {
+            $0.value.textColor = .mainText
+            $0.value.text = newContentDict[$0.key]
+        }
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
@@ -98,7 +98,7 @@ extension ReviewDetailVC {
                     self.present(nextVC, animated: true, completion: nil)
                     
                     /// 기존 작성 내용 전달
-                    nextVC.setIsPostingStatus(status: false)
+                    nextVC.setReceivedData(status: false, postId: self.detailPost.post.postID)
                     nextVC.oneLineReviewTextView.textColor = .mainText
                     nextVC.oneLineReviewTextView.text = self.detailPost.post.oneLineReview
                     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
@@ -98,7 +98,6 @@ extension ReviewDetailVC {
                     self.present(nextVC, animated: true, completion: nil)
                     
                     /// 기존 작성 내용 전달
-                    nextVC.isPosting = false
                     nextVC.oneLineReviewTextView.textColor = .mainText
                     nextVC.oneLineReviewTextView.text = self.detailPost.post.oneLineReview
                     
@@ -256,7 +255,6 @@ extension ReviewDetailVC {
             case .success(let res):
                 if let data = res as? ReviewPostDetailData {
                     self.detailPost = data
-                    print("여기", self.detailPost)
                     self.setUpLikeStatus(model: self.detailPost.like)
                     self.reviewPostTV.reloadData()
                     self.activityIndicator.stopAnimating()

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
@@ -16,7 +16,11 @@ class ReviewWriteVC: BaseVC {
             /// x버튼 클릭 시 커스텀 팝업창 띄움
             reviewWriteNaviBar.dismissBtn.press {
                 guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
-                alert.showNadoAlert(vc: self, message: "페이지를 나가면 \n 작성중인 글이 삭제돼요.", confirmBtnTitle: "계속 작성", cancelBtnTitle: "나갈래요")
+                if self.isPosting {
+                    alert.showNadoAlert(vc: self, message: "페이지를 나가면 \n 작성중인 글이 삭제돼요.", confirmBtnTitle: "계속 작성", cancelBtnTitle: "나갈래요")
+                } else {
+                    alert.showNadoAlert(vc: self, message: "페이지를 나가면 \n 수정한 내용이 저장되지 않아요.", confirmBtnTitle: "계속 작성", cancelBtnTitle: "나갈래요")
+                }
                 alert.cancelBtn.press {
                     self.dismiss(animated: true, completion: nil)
                 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
@@ -218,11 +218,6 @@ extension ReviewWriteVC {
             guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
             alert.showNadoAlert(vc: self, message: "글을 올리시겠습니까?", confirmBtnTitle: "네", cancelBtnTitle: "아니요")
             
-            /// 취소 버튼 클릭 시
-            alert.cancelBtn.press {
-                self.dismiss(animated: true, completion: nil)
-            }
-            
             /// 완료 버튼 클릭 시
             alert.confirmBtn.press {
                 if self.isPosting {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
@@ -186,8 +186,6 @@ extension ReviewWriteVC {
                 for _ in 0...4 {
                     if ($0?.text.count)! >= 100 {
                         choiceTextViewStatus = true
-                    } else if $0?.text.isEmpty == false {
-                        choiceTextViewStatus = false
                     } else if $0?.text.isEmpty == true {
                         //  선택 textView가 최소1개 이상채워졌는지 분기처리
                         if learnInfoTextView.text.count >= 100 || recommendClassTextView.text.count >= 100 || badClassTextView.text.count >= 100 || futureTextView.text.count >= 100 || tipTextView.text.count >= 100 {
@@ -195,7 +193,7 @@ extension ReviewWriteVC {
                         } else {
                             choiceTextViewStatus = false
                         }
-                    } else {
+                    } else if $0?.textColor != .gray2 {
                         choiceTextViewStatus = false
                     }
                 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
@@ -88,6 +88,11 @@ class ReviewWriteVC: BaseVC {
         setUpTapCompleteBtn()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        [oneLineReviewTextView, prosAndConsTextView, learnInfoTextView, recommendClassTextView, badClassTextView, futureTextView, tipTextView].forEach { textView in setUpCompleteBtnStatus(textView: textView)}
+    }
+    
     @IBAction func tapMajorChangeBtn(_ sender: Any) {
         let firstMajor: String = UserDefaults.standard.string(forKey: UserDefaults.Keys.FirstMajorName) ?? ""
         let secondMajor: String = UserDefaults.standard.string(forKey: UserDefaults.Keys.SecondMajorName) ?? ""
@@ -111,12 +116,12 @@ class ReviewWriteVC: BaseVC {
 
 // MARK: - UI
 extension ReviewWriteVC {
-    func configureNaviUI() {
+    private func configureNaviUI() {
         reviewWriteNaviBar.setUpNaviStyle(state: .dismissWithNadoBtn)
         reviewWriteNaviBar.configureTitleLabel(title: "후기작성")
     }
     
-    func configureTagViewUI() {
+    private func configureTagViewUI() {
         essentialTagView.makeRounded(cornerRadius: 4.adjusted)
         choiceTagView.makeRounded(cornerRadius: 4.adjusted)
     }
@@ -158,6 +163,43 @@ extension ReviewWriteVC {
         ])
         
         self.bgImgCV.selectItem(at: IndexPath(item: 0, section: 0), animated: true, scrollPosition: .left)
+    }
+    
+    /// 조건에 따라 완료버튼 상태 설정하는 함수
+    private func setUpCompleteBtnStatus(textView: UITextView) {
+        
+        /// 필수 항목 모두 작성되었을 때
+        if oneLineReviewTextView.text != "학과를 한줄로 표현한다면?" && oneLineReviewTextView.text.count > 0 && prosAndConsTextView.text.count >= 100  {
+            essentialTextViewStatus = true
+        } else {
+            essentialTextViewStatus = false
+        }
+        
+        
+        /// 선택 항목 분기 처리
+        [learnInfoTextView, recommendClassTextView, badClassTextView, futureTextView, tipTextView].forEach {
+            if textView == $0 {
+                for _ in 0...4 {
+                    if ($0?.text.count)! >= 100 {
+                        choiceTextViewStatus = true
+                    } else if $0?.text.isEmpty == false {
+                        choiceTextViewStatus = false
+                    } else if $0?.text.isEmpty == true {
+                        //  선택 textView가 최소1개 이상채워졌는지 분기처리
+                        if learnInfoTextView.text.count >= 100 || recommendClassTextView.text.count >= 100 || badClassTextView.text.count >= 100 || futureTextView.text.count >= 100 || tipTextView.text.count >= 100 {
+                            choiceTextViewStatus = true
+                        } else {
+                            choiceTextViewStatus = false
+                        }
+                    } else {
+                        choiceTextViewStatus = false
+                    }
+                }
+            }
+        }
+        
+        /// 완료 버튼 활성화 조건 (필수작성항목 모두 채워지고, 선택항목 조건 달성)
+        reviewWriteNaviBar.rightActivateBtn.isActivated = essentialTextViewStatus && choiceTextViewStatus
     }
     
     private func setUpTapCompleteBtn() {
@@ -335,39 +377,9 @@ extension ReviewWriteVC: UITextViewDelegate {
     
     func textViewDidChange(_ textView: UITextView) {
         
-        /// 필수 항목 모두 작성되었을 때
-        if oneLineReviewTextView.text != "학과를 한줄로 표현한다면?" && oneLineReviewTextView.text.count > 0 && prosAndConsTextView.text.count >= 100  {
-            essentialTextViewStatus = true
-        } else {
-            essentialTextViewStatus = false
-        }
-        
-        
-        /// 선택 항목 분기 처리
-        [learnInfoTextView, recommendClassTextView, badClassTextView, futureTextView, tipTextView].forEach {
-            if textView == $0 {
-                for _ in 0...4 {
-                    if ($0?.text.count)! >= 100 {
-                        choiceTextViewStatus = true
-                    } else if $0?.text.isEmpty == false {
-                        choiceTextViewStatus = false
-                    } else if $0?.text.isEmpty == true {
-                        //  선택 textView가 최소1개 이상채워졌는지 분기처리
-                        if learnInfoTextView.text.count >= 100 || recommendClassTextView.text.count >= 100 || badClassTextView.text.count >= 100 || futureTextView.text.count >= 100 || tipTextView.text.count >= 100 {
-                            choiceTextViewStatus = true
-                        } else {
-                            choiceTextViewStatus = false
-                        }
-                    } else {
-                        choiceTextViewStatus = false
-                    }
-                }
-            }
-        }
-        
-        /// 완료 버튼 활성화 조건 (필수작성항목 모두 채워지고, 선택항목 조건 달성)
-        reviewWriteNaviBar.rightActivateBtn.isActivated = essentialTextViewStatus && choiceTextViewStatus
-        
+        /// 텍스트뷰의 내용이 바뀔때 마다 조건 판단하기 위한 함수 호출
+        setUpCompleteBtnStatus(textView: textView)
+
         /// 텍스트뷰 내 indicator 백그라운드 컬러 설정
         func scrollViewDidScroll(_ scrollView: UIScrollView) {
             DispatchQueue.main.async() {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
@@ -202,6 +202,11 @@ extension ReviewWriteVC {
         reviewWriteNaviBar.rightActivateBtn.isActivated = essentialTextViewStatus && choiceTextViewStatus
     }
     
+    /// ReviewDetailVC에서 상태값 받아오기 위한 함수
+    func setIsPostingStatus(status: Bool) {
+        isPosting = status
+    }
+    
     private func setUpTapCompleteBtn() {
         reviewWriteNaviBar.rightActivateBtn.press(vibrate: true, for: .touchUpInside) {
             guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
@@ -70,6 +70,9 @@ class ReviewWriteVC: BaseVC {
     private var bgImgList: [ReviewWriteBgImgData] = []
     let screenHeight = UIScreen.main.bounds.size.height
     
+    // 새글 작성, 기존글 수정 구분 위한 변수
+    var isPosting: Bool = true
+    
     // MARK: Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
@@ -94,7 +94,9 @@ class ReviewWriteVC: BaseVC {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        [oneLineReviewTextView, prosAndConsTextView, learnInfoTextView, recommendClassTextView, badClassTextView, futureTextView, tipTextView].forEach { textView in setUpCompleteBtnStatus(textView: textView)}
+        [oneLineReviewTextView, prosAndConsTextView, learnInfoTextView, recommendClassTextView, badClassTextView, futureTextView, tipTextView].forEach {
+            textView in setUpCompleteBtnStatus(textView: textView)
+        }
     }
     
     @IBAction func tapMajorChangeBtn(_ sender: Any) {


### PR DESCRIPTION
## 🍎 관련 이슈
closed #183

## 🍎 변경 사항 및 이유
- 후기글 수정 기능을 구현했습니다.

## 🍎 PR Point
- 후기 상세뷰에서 후기 작성 뷰로 화면 전환 시 데이터를 전달하여 이전에 작성한 내용이 해당 `textView`에 보이도록 했습니다.
- 후기 작성 상황과 달리 수정 시에는 뷰가 그려질 때 이미 `textView`에 `text`가 있기 때문에 기존 `textViewDidChange()` 에 있던 조건문 코드를 밖으로 빼서 함수화 시키고, `viewWillAppear()`와 `textViewDidChange()`에서 호출하였습니다. 
- 또한 `placeholder` 값을 텍스트로 인식하지 않도록 하기 위해 완료 버튼 활성화 코드를 변경하였습니다.
- x버튼 클릭 시 나타나는 알럿 메시지를 분기처리해주었습니다. 

    **클라에서 더미 관리 SSAP POSSIBLE**

## 📸 ScreenShot
- 수정 플로우

https://user-images.githubusercontent.com/63277563/154719532-95839c09-d4ee-4b83-a2f8-18aef0826b92.mp4

- 후기글 수정 상황에서 x버튼 클릭 시

https://user-images.githubusercontent.com/63277563/154721008-6178ecad-ee86-4850-946c-224c836e9466.mp4


