### PR TITLE
✅ [CHORE] 정보글 조회시 하얀 백 로딩뷰 추가 (#192)

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
@@ -339,9 +339,9 @@ extension InfoDetailVC {
                         self.infoDetailTV.reloadData()
                         self.setUpSendBtnEnabledState()
                         self.configueTextViewPlaceholder()
+                        addLoadBackView ? self.removeWhiteBackView() : nil
+                        self.activityIndicator.stopAnimating()
                     }
-                    addLoadBackView ? self.removeWhiteBackView() : nil
-                    self.activityIndicator.stopAnimating()
                 }
             case .requestErr(let msg):
                 if let message = msg as? String {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
@@ -60,13 +60,13 @@ class InfoDetailVC: BaseVC {
     private var isTextViewEmpty: Bool = true
     private var sendTextViewLineCount: Int = 1
     private let textViewMaxHeight: CGFloat = 85.adjustedH
+    private let whiteBackView = UIView()
     
     // MARK: Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
         registerXib()
         setUpNaviStyle()
-        addActivateIndicator()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -86,6 +86,26 @@ class InfoDetailVC: BaseVC {
             self.isCommentSend = true
             self.requestCreateComment(chatPostID: self.chatPostID ?? 0, comment: self.commentTextView.text)
         }
+    }
+}
+
+// MARK: - UI
+extension InfoDetailVC {
+    
+    /// 첫 진입시 데이터 로딩되는 동안 backView를 띄우기 위한 whiteBackView 구성 메서드
+    private func configureWhiteBackView() {
+        self.view.addSubview(whiteBackView)
+        addActivateIndicator()
+        
+        whiteBackView.backgroundColor = .white
+        whiteBackView.snp.makeConstraints {
+            $0.top.leading.trailing.bottom.equalToSuperview()
+        }
+    }
+    
+    /// whiteBackView remove 메서드
+    private func removeWhiteBackView() {
+        whiteBackView.removeFromSuperview()
     }
 }
 
@@ -117,7 +137,7 @@ extension InfoDetailVC {
     private func optionalBindingData() {
         if let chatPostID = chatPostID {
             DispatchQueue.main.async {
-                self.requestGetDetailInfoData(chatPostID: chatPostID)
+                self.requestGetDetailInfoData(chatPostID: chatPostID, addLoadBackView: true)
             }
         }
     }
@@ -196,13 +216,12 @@ extension InfoDetailVC: UITableViewDataSource {
             }
             
             infoQuestionCell.separatorInset = UIEdgeInsets(top: 0, left: CGFloat.greatestFiniteMagnitude, bottom: 0, right: 0)
-            
             return infoQuestionCell
         } else if indexPath.row == 1 {
             /// 정보글 댓글 수 header Cell
             let infoCommentHeaderCell = InfoCommentHeaderTVC()
             infoCommentHeaderCell.bindData(commentCount: infoDetailData?.commentCount ?? 0)
-            infoCommentHeaderCell .separatorInset = UIEdgeInsets(top: 0, left: CGFloat.greatestFiniteMagnitude, bottom: 0, right: 0)
+            infoCommentHeaderCell.separatorInset = UIEdgeInsets(top: 0, left: CGFloat.greatestFiniteMagnitude, bottom: 0, right: 0)
             return infoCommentHeaderCell
         }
         else {
@@ -306,7 +325,8 @@ extension InfoDetailVC {
 extension InfoDetailVC {
     
     /// 정보글 상세 조회 API 요청 메서드
-    func requestGetDetailInfoData(chatPostID: Int) {
+    func requestGetDetailInfoData(chatPostID: Int, addLoadBackView: Bool) {
+        addLoadBackView ? self.configureWhiteBackView() : nil
         self.activityIndicator.startAnimating()
         ClassroomAPI.shared.getInfoDetailAPI(chatPostID: chatPostID) { networkResult in
             switch networkResult {
@@ -320,6 +340,7 @@ extension InfoDetailVC {
                         self.setUpSendBtnEnabledState()
                         self.configueTextViewPlaceholder()
                     }
+                    addLoadBackView ? self.removeWhiteBackView() : nil
                     self.activityIndicator.stopAnimating()
                 }
             case .requestErr(let msg):
@@ -343,7 +364,7 @@ extension InfoDetailVC {
             case .success(let res):
                 if let _ = res as? AddCommentData {
                     DispatchQueue.main.async {
-                        self.requestGetDetailInfoData(chatPostID: chatPostID)
+                        self.requestGetDetailInfoData(chatPostID: chatPostID, addLoadBackView: false)
                         self.activityIndicator.stopAnimating()
                     }
                 }
@@ -368,7 +389,7 @@ extension InfoDetailVC {
             case .success(let res):
                 if let _ = res as? PostLikeResModel {
                     DispatchQueue.main.async {
-                        self.requestGetDetailInfoData(chatPostID: self.chatPostID ?? 0)
+                        self.requestGetDetailInfoData(chatPostID: self.chatPostID ?? 0, addLoadBackView: false)
                     }
                     self.activityIndicator.stopAnimating()
                 }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #192 

## 🍎 변경 사항 및 이유

## 🍎 PR Point
- 정보글 조회시 하얀 백 로딩뷰 추가
- 첫 진입시에만 데이터가 로딩되기 전 하얀 백 로딩뷰를 추가했습니다! (이유는 뷰가 단색이 아니고 윗면이 흰색, 아랫면(댓글부)이 회색이어서 데이터가 들어오기 전 뷰가 예뻐보이지 않아서 추가했습니돠)

## 📸 ScreenShot
![Simulator Screen Recording - iPhone 12 - 2022-02-20 at 21 28 40](https://user-images.githubusercontent.com/63224278/154842498-d2a0887a-4e48-4cb1-b34e-45bd94bae770.gif)

