### PR TITLE
🔨 [FIX] 과방 정보상세글 댓글 0개일 때 하단 간격 수정

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoCommentHeaderTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoCommentHeaderTVC.swift
@@ -43,7 +43,7 @@ class InfoCommentHeaderTVC: BaseTVC {
 extension InfoCommentHeaderTVC {
     
     /// UI 구성 메서드
-    func configureUI(isCommentZero: Bool) {
+    private func configureUI(isCommentZero: Bool) {
         self.backgroundColor = .paleGray
         self.addSubview(commentCountLabel)
         

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoCommentHeaderTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoCommentHeaderTVC.swift
@@ -8,6 +8,7 @@
 import UIKit
 import SnapKit
 import Then
+import RxSwift
 
 class InfoCommentHeaderTVC: BaseTVC {
     
@@ -29,7 +30,6 @@ class InfoCommentHeaderTVC: BaseTVC {
     // MARK: init
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        configureUI()
         selectionStyle = .none
     }
     
@@ -43,14 +43,18 @@ class InfoCommentHeaderTVC: BaseTVC {
 extension InfoCommentHeaderTVC {
     
     /// UI 구성 메서드
-    private func configureUI() {
+    func configureUI(isCommentZero: Bool) {
         self.backgroundColor = .paleGray
         self.addSubview(commentCountLabel)
         
         commentCountLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(8)
             $0.leading.equalToSuperview().offset(16)
-            $0.bottom.equalToSuperview().offset(0)
+            if isCommentZero {
+                $0.bottom.equalToSuperview().offset(-8)
+            } else {
+                $0.bottom.equalToSuperview()
+            }
         }
     }
 }
@@ -62,5 +66,6 @@ extension InfoCommentHeaderTVC {
     func bindData(commentCount: Int) {
         commentCountLabel.text = "댓글 \(commentCount)개"
         commentCountLabel.sizeToFit()
+        commentCount > 0 ? configureUI(isCommentZero: false) : configureUI(isCommentZero: true)
     }
 }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #204

## 🍎 변경 사항 및 이유

## 🍎 PR Point
- 댓글이 0개일 때 하단 여백을 8px로 설정해주었습니다.
- 댓글이 있는 경우에는 하단에 CommentTVC가 16px의 간격을 두고 배치되기 때문에 이 경우에는 하단 여백을 0으로 분기처리해주었습니다.

## 📸 ScreenShot
- 댓글 0개일 때
<img width="375" alt="스크린샷1" src="https://user-images.githubusercontent.com/63224278/155003573-3e3e77a0-c575-4c18-a9cf-d7fc99041d6e.png">

- 댓글이 있을 때
<img width="375" alt="스크린샷2" src="https://user-images.githubusercontent.com/63224278/155003906-7bba7fd6-624d-463e-99f5-4271b8fbc49a.png">