### PR TITLE
✨ [FEAT] 질문글 답변 스레드 수정 기능 구현

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		33CF636C279567AF00E92C04 /* QuestionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CF636B279567AF00E92C04 /* QuestionType.swift */; };
 		33DAB83A27914EAD00214CA8 /* WriteQuestionVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DAB83927914EAD00214CA8 /* WriteQuestionVC.swift */; };
 		33DAB83C279153A400214CA8 /* BaseCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DAB83B279153A400214CA8 /* BaseCVC.swift */; };
+		33EAD1F127C68D09000AD673 /* EditPostCommentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EAD1F027C68D09000AD673 /* EditPostCommentModel.swift */; };
 		33F3ED8827C54E9F00731E24 /* EditPostQuestionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F3ED8727C54E9F00731E24 /* EditPostQuestionModel.swift */; };
 		33FA751427931AA800E43523 /* ClassroomSB.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 33FA751327931AA800E43523 /* ClassroomSB.storyboard */; };
 		33FBC3192796F6C900741730 /* ReviewAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33FBC3182796F6C900741730 /* ReviewAPI.swift */; };
@@ -323,6 +324,7 @@
 		33CF636B279567AF00E92C04 /* QuestionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionType.swift; sourceTree = "<group>"; };
 		33DAB83927914EAD00214CA8 /* WriteQuestionVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteQuestionVC.swift; sourceTree = "<group>"; };
 		33DAB83B279153A400214CA8 /* BaseCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCVC.swift; sourceTree = "<group>"; };
+		33EAD1F027C68D09000AD673 /* EditPostCommentModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPostCommentModel.swift; sourceTree = "<group>"; };
 		33F02A8A278889650078F9B7 /* NadoSunbaeBtn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NadoSunbaeBtn.swift; sourceTree = "<group>"; };
 		33F3ED8727C54E9F00731E24 /* EditPostQuestionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPostQuestionModel.swift; sourceTree = "<group>"; };
 		33FA751327931AA800E43523 /* ClassroomSB.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ClassroomSB.storyboard; sourceTree = "<group>"; };
@@ -862,6 +864,7 @@
 			children = (
 				33A15F722799DDDE006FE040 /* AddCommentData.swift */,
 				33F3ED8727C54E9F00731E24 /* EditPostQuestionModel.swift */,
+				33EAD1F027C68D09000AD673 /* EditPostCommentModel.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1697,6 +1700,7 @@
 				338CDB06278C9F9B00F8227A /* ClassroomQuestionEditTVC.swift in Sources */,
 				5CC0BFDD2798836400B96905 /* DeleteNotificationDataModel.swift in Sources */,
 				7754A31F279418130093C230 /* CodeBaseCVC.swift in Sources */,
+				33EAD1F127C68D09000AD673 /* EditPostCommentModel.swift in Sources */,
 				331364542785A8FE00E0C118 /* StoryboardRepresentation.swift in Sources */,
 				33B9B0D327B8EAC200066C1F /* InfoDetailVC.swift in Sources */,
 				77ED045027AD75E700D077CA /* FilterVC.swift in Sources */,

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ClassroomAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ClassroomAPI.swift
@@ -134,7 +134,7 @@ class ClassroomAPI {
 
     /// [PUT] 1:1질문, 전체 질문, 정보글 질문 수정 API 메서드
     func editPostQuestionAPI(postID: Int, title: String, content: String, completion: @escaping (NetworkResult<Any>) -> (Void)) {
-        classroomProvider.request(.postTitleEdit(postID: postID, title: title, content: content)) { result in
+        classroomProvider.request(.editPostQuestion(postID: postID, title: title, content: content)) { result in
             switch result {
                 
             case .success(let response):
@@ -142,6 +142,23 @@ class ClassroomAPI {
                 let data = response.data
                 
                 completion(self.editPostQuestionJudgeData(status: statusCode, data: data))
+                
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
+    
+    /// [PUT] 1:1질문, 전체 질문, 정보글 댓글 수정 API 메서드
+    func editPostCommentAPI(commentID: Int, content: String, completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        classroomProvider.request(.editPostComment(commentID: commentID, content: content)) { result in
+            switch result {
+                
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                
+                completion(self.editPostCommentJudgeData(status: statusCode, data: data))
                 
             case .failure(let err):
                 print(err)
@@ -285,6 +302,24 @@ extension ClassroomAPI {
     private func editPostQuestionJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
         guard let decodedData = try? decoder.decode(GenericResponse<EditPostQuestionModel>.self, from: data) else {
+            return .pathErr }
+        
+        switch status {
+        case 200...204:
+            return .success(decodedData.data ?? "None-Data")
+        case 400...409:
+            return .requestErr(decodedData.message)
+        case 500:
+            return .serverErr
+        default:
+            return .networkFail
+        }
+    }
+    
+    /// 댓글 수정
+    private func editPostCommentJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
+        let decoder = JSONDecoder()
+        guard let decodedData = try? decoder.decode(GenericResponse<EditPostCommentModel>.self, from: data) else {
             return .pathErr }
         
         switch status {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Classroom/Common/EditPostCommentModel.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Classroom/Common/EditPostCommentModel.swift
@@ -1,0 +1,22 @@
+//
+//  EditPostCommentModel.swift
+//  NadoSunbae-iOS
+//
+//  Created by hwangJi on 2022/02/24.
+//
+
+import Foundation
+
+// MARK: - EditPostCommentModel
+struct EditPostCommentModel: Codable {
+    let commentID, postID: Int
+    let content, createdAt, updatedAt: String
+    let isDeleted: Bool
+    let writer: EditPostWriter
+
+    enum CodingKeys: String, CodingKey {
+        case commentID = "commentId"
+        case postID = "postId"
+        case content, createdAt, updatedAt, isDeleted, writer
+    }
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Classroom/Common/EditPostQuestionModel.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Classroom/Common/EditPostQuestionModel.swift
@@ -10,7 +10,7 @@ import Foundation
 // MARK: - EditPostQuestionModel
 struct EditPostQuestionModel: Codable {
     let post: EditedPostQuestion
-    let writer: EditPostQuestionWriter
+    let writer: EditPostWriter
     let like: Like
 }
 
@@ -25,8 +25,8 @@ struct EditedPostQuestion: Codable {
     }
 }
 
-// MARK: - EditPostQuestionWriter
-struct EditPostQuestionWriter: Codable {
+// MARK: - EditPostWriter
+struct EditPostWriter: Codable {
     let writerID, profileImageID: Int
     let nickname, firstMajorName, firstMajorStart, secondMajorName: String
     let secondMajorStart: String

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/ClassroomService.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/ClassroomService.swift
@@ -16,7 +16,8 @@ enum ClassroomService {
     case getMajorUserList(majorID: Int)
     case postClassroomContent(majorID: Int, answerID: Int?, postTypeID: Int, title: String, content: String)
     case postLike(postID: Int, postTypeID: Int)
-    case postTitleEdit(postID: Int, title: String, content: String)
+    case editPostQuestion(postID: Int, title: String, content: String)
+    case editPostComment(commentID: Int, content: String)
 }
 
 extension ClassroomService: TargetType {
@@ -41,8 +42,10 @@ extension ClassroomService: TargetType {
             return "/classroom-post"
         case .postLike:
             return "/like"
-        case .postTitleEdit(let postID, _, _):
+        case .editPostQuestion(let postID, _, _):
             return "/classroom-post/\(postID)"
+        case .editPostComment(let commentID, _):
+            return "/comment/\(commentID)"
         }
     }
     
@@ -53,7 +56,7 @@ extension ClassroomService: TargetType {
             return .get
         case .postComment, .postClassroomContent, .postLike:
             return .post
-        case .postTitleEdit:
+        case .editPostQuestion, .editPostComment:
             return .put
         }
     }
@@ -90,12 +93,14 @@ extension ClassroomService: TargetType {
                 "postTypeId": postTypeID
             ]
             return .requestParameters(parameters: body, encoding: JSONEncoding.prettyPrinted)
-            
-        case .postTitleEdit(_, let title, let content):
+        case .editPostQuestion(_, let title, let content):
             let body = [
                 "title": title,
                 "content": content
             ]
+            return .requestParameters(parameters: body, encoding: JSONEncoding.prettyPrinted)
+        case .editPostComment(_, let content):
+            let body = ["content": content]
             return .requestParameters(parameters: body, encoding: JSONEncoding.prettyPrinted)
         }
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomCommentTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomCommentTVC.swift
@@ -70,7 +70,6 @@ extension ClassroomCommentTVC {
     func bindData(_ model: ClassroomMessageList) {
         nicknameLabel.text = model.writer.nickname
         majorLabel.text = convertToMajorInfoString(model.writer.firstMajorName, model.writer.firstMajorStart, model.writer.secondMajorName, model.writer.secondMajorStart)
-        print("converted: ", convertToMajorInfoString(model.writer.firstMajorName, model.writer.firstMajorStart, model.writer.secondMajorName, model.writer.secondMajorStart))
         commentContentTextView.text = model.content
         configureQuestionContentTextView()
         uploadDateLabel.text = model.createdAt.serverTimeToString(forUse: .forDefault)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -635,11 +635,21 @@ extension DefaultQuestionChatVC {
                     self.userID = UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID)
                     self.userType = self.identifyUserType(questionerID: data.questionerID, answererID: data.answererID)
                     self.setUpSendBtnEnabledState(questionType: self.questionType ?? .personal, textView: self.sendAreaTextView)
-                    self.isCommentEdited ? self.defaultQuestionChatTV.reloadRows(at: self.editedCommentIndexPath, with: .automatic) : self.defaultQuestionChatTV.reloadData()
+                    
+                    /// 댓글 수정되었을 때
+                    if self.isCommentEdited {
+                        self.defaultQuestionChatTV.reloadRows(at: self.editedCommentIndexPath, with: .automatic)
+                        self.isCommentEdited = false
+                    } else {
+                        self.defaultQuestionChatTV.reloadData()
+                    }
+                    
+                    /// 댓글 send되었을 때
                     if self.isCommentSend {
                         self.scrollTVtoBottom(animate: true)
                         self.isCommentSend = false
                     }
+                    
                     self.configueTextViewPlaceholder(userType: self.userType ?? -1, questionType: self.questionType ?? .personal)
                     self.activityIndicator.stopAnimating()
                 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
@@ -133,8 +133,8 @@ extension WriteQuestionVC {
     /// 컴포넌트의 초기 스타일을 구성하는 메서드
     private func setUpInitStyle() {
         questionWriteNaviBar.setUpNaviStyle(state: .dismissWithNadoBtn)
- 
-        if isEditState {
+        
+        if isEditState == true {
             questionWriteTextView.setDefaultStyle(isUsePlaceholder: false, placeholderText: "")
             
             if let title = originTitle {
@@ -267,7 +267,7 @@ extension WriteQuestionVC {
     
     /// 수정상태인지 아닌지에 따라 Alert Message를 지정하는 메서드
     private func setUpAlertMsgByEditState() {
-        if isEditState {
+        if isEditState == true {
             confirmAlertMsg =
     """
     글을 수정하시겠습니까?

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
@@ -425,7 +425,6 @@ extension WriteQuestionVC {
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
-            
         }
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
@@ -134,7 +134,7 @@ extension WriteQuestionVC {
     private func setUpInitStyle() {
         questionWriteNaviBar.setUpNaviStyle(state: .dismissWithNadoBtn)
         
-        if isEditState == true {
+        if isEditState {
             questionWriteTextView.setDefaultStyle(isUsePlaceholder: false, placeholderText: "")
             
             if let title = originTitle {
@@ -267,7 +267,7 @@ extension WriteQuestionVC {
     
     /// 수정상태인지 아닌지에 따라 Alert Message를 지정하는 메서드
     private func setUpAlertMsgByEditState() {
-        if isEditState == true {
+        if isEditState {
             confirmAlertMsg =
     """
     글을 수정하시겠습니까?


### PR DESCRIPTION
## 🍎 관련 이슈
closed #211

## 🍎 변경 사항 및 이유
- 과방탭 Network 코드 변수, 모델 네이밍 수정이 있었습니다!

## 🍎 PR Point
- 답변 수정기능을 구현했습니다~! 
- 수정시에는 `isCommentEdited` 변수의 상태를 true로 설정하고, 수정된 indexPath를 `editedCommentIndexPath` 변수에 저장해주어서 `isCommentEdited`가 true이면 전체 tableView를 reload해주지 않고 해당 indexPath의 row만 reload를 해주어 수정되는 느낌을 강조해주었습니다!

## 📸 ScreenShot
<img width= 375 src = "https://user-images.githubusercontent.com/63224278/155378827-d673611a-ef81-4cc7-b2d1-54739c59b09f.gif">
