### PR TITLE
✨ [FEAT] 후기 메인 뷰 필터 기능 구현

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/PublicData/Singleton/MajorInfo.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/PublicData/Singleton/MajorInfo.swift
@@ -13,7 +13,7 @@ class MajorInfo {
     static let shared = MajorInfo()
     
     var majorList: [MajorInfoModel]?
-    var selecteMajorID: Int?
+    var selectedMajorID: Int?
     var selectedMajorName: String?
     private init() { }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/HalfModalVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/HalfModalVC.swift
@@ -17,6 +17,7 @@ class HalfModalVC: UIViewController {
     // MARK: Properties
     var majorList: [MajorInfoModel] = []
     var selectMajorDelegate: SendUpdateModalDelegate?
+    var selectFilterDelegate: SendUpdateStatusDelegate?
     
     // MARK: Life Cycle Part
     override func viewDidLoad() {
@@ -60,6 +61,11 @@ class HalfModalVC: UIViewController {
                 MajorInfo.shared.selecteMajorID = selectedMajorID
                 selectMajorDelegate.sendUpdate(data: selectedMajorName)
             }
+            if self.selectFilterDelegate != nil {
+                ReviewFilterInfo.shared.selectedBtnList = [false, false, false, false, false, false, false]
+                self.selectFilterDelegate?.sendStatus(data: false)
+            }
+    
             self.dismiss(animated: true, completion: {
                 NotificationCenter.default.post(name: Notification.Name.dismissHalfModal, object: nil)
             })

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/HalfModalVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/HalfModalVC.swift
@@ -15,7 +15,7 @@ class HalfModalVC: UIViewController {
     @IBOutlet weak var majorChooseBtn: NadoSunbaeBtn!
     
     // MARK: Properties
-    var majorList: [MajorInfoModel] = []
+    private var majorList: [MajorInfoModel] = []
     var selectMajorDelegate: SendUpdateModalDelegate?
     var selectFilterDelegate: SendUpdateStatusDelegate?
     
@@ -51,7 +51,7 @@ class HalfModalVC: UIViewController {
     }
     
     /// 선택완료 버튼 클릭 시 데이터 전달
-    func tapMajorChooseBtnAction() {
+    private func tapMajorChooseBtnAction() {
         majorChooseBtn.press {
             let selectedMajorName = self.majorList[self.majorTV.indexPathForSelectedRow?.row ?? 0].majorName
             let selectedMajorID = self.majorList[self.majorTV.indexPathForSelectedRow?.row ?? 0].majorID
@@ -61,6 +61,7 @@ class HalfModalVC: UIViewController {
                 MajorInfo.shared.selectedMajorID = selectedMajorID
                 selectMajorDelegate.sendUpdate(data: selectedMajorName)
             }
+            
             if self.selectFilterDelegate != nil {
                 ReviewFilterInfo.shared.selectedBtnList = [false, false, false, false, false, false, false]
                 self.selectFilterDelegate?.sendStatus(data: false)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/HalfModalVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/HalfModalVC.swift
@@ -58,7 +58,7 @@ class HalfModalVC: UIViewController {
 
             if let selectMajorDelegate = self.selectMajorDelegate {
                 MajorInfo.shared.selectedMajorName = selectedMajorName
-                MajorInfo.shared.selecteMajorID = selectedMajorID
+                MajorInfo.shared.selectedMajorID = selectedMajorID
                 selectMajorDelegate.sendUpdate(data: selectedMajorName)
             }
             if self.selectFilterDelegate != nil {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
@@ -145,7 +145,7 @@ extension InfoMainVC {
     
     /// shared에 데이터가 있으면 shared정보로 데이터를 요청하고, 그렇지 않으면 Userdefaults의 전공ID로 요청을 보내는 메서드
     private func setUpRequestData(sortType: ListSortType) {
-        requestGetGroupOrInfoListData(majorID: (MajorInfo.shared.selecteMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selecteMajorID ?? -1), postTypeID: .info, sort: sortType)
+        requestGetGroupOrInfoListData(majorID: (MajorInfo.shared.selectedMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selectedMajorID ?? -1), postTypeID: .info, sort: sortType)
     }
     
     /// activityIndicator 설정 메서드

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/EntireQuestionListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/EntireQuestionListVC.swift
@@ -122,7 +122,7 @@ extension EntireQuestionListVC {
     
     /// shared에 데이터가 있으면 shared정보로 데이터를 요청하고, 그렇지 않으면 Userdefaults의 전공ID로 요청을 보내는 메서드
     private func setUpRequestData(sortType: ListSortType) {
-        requestGetGroupOrInfoListData(majorID: (MajorInfo.shared.selecteMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selecteMajorID ?? -1), postTypeID: .group, sort: sortType)
+        requestGetGroupOrInfoListData(majorID: (MajorInfo.shared.selectedMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selectedMajorID ?? -1), postTypeID: .group, sort: sortType)
     }
 }
 
@@ -171,7 +171,7 @@ extension EntireQuestionListVC: UITableViewDelegate {
                                         okAction: { _ in
                 self.selectActionSheetIndex = 0
                 self.setUpRequestData(sortType: .recent)
-                self.requestGetGroupOrInfoListData(majorID: MajorInfo.shared.selecteMajorID ?? 0, postTypeID: .group, sort: .recent)
+                self.requestGetGroupOrInfoListData(majorID: MajorInfo.shared.selectedMajorID ?? 0, postTypeID: .group, sort: .recent)
                 self.entireQuestionListTV.reloadSections([0], with: .fade)
             },
                                         secondOkAction: { _ in

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionMainVC.swift
@@ -152,7 +152,7 @@ extension QuestionMainVC {
     private func setUpTapPersonalQuestionBtn() {
         personalQuestionBtn.press(vibrate: true) {
             let questionPersonVC = QuestionPersonListVC()
-            questionPersonVC.majorID = MajorInfo.shared.selecteMajorID ?? UserDefaults.standard.value(forKey: UserDefaults.Keys.FirstMajorID) as! Int
+            questionPersonVC.majorID = MajorInfo.shared.selectedMajorID ?? UserDefaults.standard.value(forKey: UserDefaults.Keys.FirstMajorID) as! Int
             self.navigationController?.pushViewController(questionPersonVC, animated: true)
         }
     }
@@ -160,12 +160,12 @@ extension QuestionMainVC {
     /// 선택된 전공정보에 따라 서버통신 요청하는 메서드
     @objc
     func updateDataBySelectedMajor() {
-        requestGetGroupOrInfoListData(majorID: MajorInfo.shared.selecteMajorID ?? 0, postTypeID: .group, sort: .recent)
+        requestGetGroupOrInfoListData(majorID: MajorInfo.shared.selectedMajorID ?? 0, postTypeID: .group, sort: .recent)
     }
     
     /// shared에 데이터가 있으면 shared정보로 데이터를 요청하고, 그렇지 않으면 Userdefaults의 전공ID로 요청을 보내는 메서드
     private func setUpRequestData() {
-        requestGetGroupOrInfoListData(majorID: (MajorInfo.shared.selecteMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selecteMajorID ?? -1), postTypeID: .group, sort: .recent)
+        requestGetGroupOrInfoListData(majorID: (MajorInfo.shared.selectedMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selectedMajorID ?? -1), postTypeID: .group, sort: .recent)
     }
     
     /// ActivateIndicator 추가 메서드

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
@@ -19,7 +19,7 @@ class WriteQuestionVC: BaseVC {
     private let disposeBag = DisposeBag()
     private var questionTextViewLineCount: Int = 1
     private var isTextViewEmpty: Bool = true
-    private var majorID: Int = MajorInfo.shared.selecteMajorID ?? UserDefaults.standard.value(forKey: UserDefaults.Keys.FirstMajorID) as! Int
+    private var majorID: Int = MajorInfo.shared.selectedMajorID ?? UserDefaults.standard.value(forKey: UserDefaults.Keys.FirstMajorID) as! Int
     @IBOutlet weak var questionWriteNaviBar: NadoSunbaeNaviBar! {
         didSet {
             questionWriteNaviBar.addShadow(location: .nadoBotttom, color: .shadowDefault, opacity: 0.3, radius: 16)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewMainLinkTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewMainLinkTVC.swift
@@ -18,7 +18,7 @@ class ReviewMainLinkTVC: BaseTVC {
     // MARK: Life Cycle
     override func awakeFromNib() {
         super.awakeFromNib()
-        requestGetHomePageList(majorID: MajorInfo.shared.selecteMajorID ?? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID))
+        requestGetHomePageList(majorID: MajorInfo.shared.selectedMajorID ?? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID))
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
@@ -26,9 +26,9 @@ class ReviewMainVC: BaseVC {
     var postList: [ReviewMainPostListData] = []
     var majorInfo: String = ""
     var sortType: ListSortType = .recent
-    var filterStatus = false
-    var selectedWriterFilter: Int = 1
-    var selectedTagFilter: [Int] = []
+    private var filterStatus = false
+    private var selectedWriterFilter: Int = 1
+    private var selectedTagFilter: [Int] = []
     private var selectActionSheetIndex: Int = 0
     
     // MARK: Life Cycle Part
@@ -113,7 +113,7 @@ extension ReviewMainVC {
     }
     
     /// 액션시트
-    func presentActionSheet() {
+    private func presentActionSheet() {
         makeTwoAlertWithCancel(okTitle: "최신순", secondOkTitle: "좋아요순", okAction: { _ in
             self.sortType = .recent
             self.setUpRequestData()
@@ -374,7 +374,6 @@ extension ReviewMainVC: SendUpdateStatusDelegate {
         } else {
             /// 필터 off 상태일 때
             requestGetReviewPostList(majorID: (MajorInfo.shared.selectedMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selectedMajorID ?? -1), writerFilter: 1, tagFilter: [1, 2, 3, 4, 5], sort: sortType)
-            
         }
         reviewTV.reloadData()
     }
@@ -384,7 +383,7 @@ extension ReviewMainVC: SendUpdateStatusDelegate {
 
 /// 학과 정보 리스트 조회
 extension ReviewMainVC {
-    func requestGetMajorList(univID: Int, filterType: String) {
+    private func requestGetMajorList(univID: Int, filterType: String) {
         PublicAPI.shared.getMajorListAPI(univID: univID, filterType: filterType) { networkResult in
             switch networkResult {
                 
@@ -415,13 +414,12 @@ extension ReviewMainVC {
 
 /// 후기글 리스트 조회
 extension ReviewMainVC {
-    func requestGetReviewPostList(majorID: Int, writerFilter: Int, tagFilter: [Int], sort: ListSortType) {
+    private func requestGetReviewPostList(majorID: Int, writerFilter: Int, tagFilter: [Int], sort: ListSortType) {
         self.activityIndicator.startAnimating()
         ReviewAPI.shared.getReviewPostListAPI(majorID: majorID, writerFilter: writerFilter, tagFilter: tagFilter, sort: sort) { networkResult in
             switch networkResult {
                 
             case .success(let res):
-                print(res)
                 self.activityIndicator.stopAnimating()
                 if let data = res as? [ReviewMainPostListData] {
                     DispatchQueue.main.async {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
@@ -27,6 +27,8 @@ class ReviewMainVC: BaseVC {
     var majorInfo: String = ""
     var sortType: ListSortType = .recent
     var filterStatus = false
+    var selectedWriterFilter: Int = 1
+    var selectedTagFilter: [Int] = []
     private var selectActionSheetIndex: Int = 0
     
     // MARK: Life Cycle Part
@@ -150,7 +152,7 @@ extension ReviewMainVC {
     
     /// shared에 데이터가 있으면 shared정보로 데이터를 요청하고, 그렇지 않으면 Userdefaults의 전공ID로 요청을 보내는 메서드
     private func setUpRequestData() {
-        requestGetReviewPostList(majorID: (MajorInfo.shared.selecteMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selecteMajorID ?? -1), writerFilter: 1, tagFilter: [1, 2, 3, 4, 5], sort: sortType)
+        requestGetReviewPostList(majorID: (MajorInfo.shared.selecteMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selecteMajorID ?? -1), writerFilter: self.selectedWriterFilter, tagFilter: self.selectedTagFilter == [] ? [1, 2, 3, 4, 5] : self.selectedTagFilter, sort: sortType)
     }
     
     /// 링크에 해당하는 웹사이트로 연결하는 함수
@@ -354,7 +356,38 @@ extension ReviewMainVC: SendUpdateModalDelegate {
 // MARK: - SendUpdateStatusDelegate
 extension ReviewMainVC: SendUpdateStatusDelegate {
     func sendStatus(data: Bool) {
+        let selectedList = ReviewFilterInfo.shared.selectedBtnList
+        
+        /// 필터 on/off 판단
         filterStatus = data
+        
+        /// 태그 필터 초기화
+        selectedTagFilter = []
+        
+        /// 작성자 필터 판단
+        if selectedList[0] == true  && selectedList[1] == false {
+            selectedWriterFilter = 2
+        } else if selectedList[1] == false && selectedList[1] == true {
+            selectedWriterFilter = 3
+        } else {
+            selectedWriterFilter = 1
+        }
+        
+        /// 태그 필터 판단
+        for i in 2...selectedList.count-1 {
+            if selectedList[i] == true {
+                selectedTagFilter.append(Int(i-1))
+            }
+        }
+        
+        if filterStatus == true {
+            /// 필터 on 상태일 때
+            requestGetReviewPostList(majorID: (MajorInfo.shared.selecteMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selecteMajorID ?? -1), writerFilter: selectedWriterFilter, tagFilter: selectedTagFilter == [] ? [1, 2, 3, 4, 5] : selectedTagFilter, sort: sortType)
+        } else {
+            /// 필터 off 상태일 때
+            requestGetReviewPostList(majorID: (MajorInfo.shared.selecteMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selecteMajorID ?? -1), writerFilter: 1, tagFilter: [1, 2, 3, 4, 5], sort: sortType)
+            
+        }
         reviewTV.reloadData()
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
@@ -114,28 +114,15 @@ extension ReviewMainVC {
     
     /// 액션시트
     func presentActionSheet() {
-        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        
-        // TODO: 액션 추가 예정
-        let new = UIAlertAction(title: "최신순", style: .default) { action in
+        makeTwoAlertWithCancel(okTitle: "최신순", secondOkTitle: "좋아요순", okAction: { _ in
             self.sortType = .recent
-            self.requestGetReviewPostList(majorID: (MajorInfo.shared.selecteMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selecteMajorID ?? -1), writerFilter: 1, tagFilter: [1, 2, 3, 4, 5], sort: .recent)
+            self.setUpRequestData()
             self.reviewTV.reloadSections([2], with: .fade)
-        }
-        
-        // TODO: 액션 추가 예정
-        let like = UIAlertAction(title: "좋아요순", style: .default) { action in
+        }, secondOkAction: { _ in
             self.sortType = .like
-            self.requestGetReviewPostList(majorID: (MajorInfo.shared.selecteMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selecteMajorID ?? -1), writerFilter: 1, tagFilter: [1, 2, 3, 4, 5], sort: .like)
+            self.setUpRequestData()
             self.reviewTV.reloadSections([2], with: .fade)
-        }
-        let cancel = UIAlertAction(title: "취소", style: .cancel)
-        
-        alert.addAction(new)
-        alert.addAction(like)
-        alert.addAction(cancel)
-        
-        present(alert, animated: true, completion: nil)
+        })
     }
     
     /// 화면 상단에 닿으면 스크롤 disable
@@ -170,6 +157,7 @@ extension ReviewMainVC {
     @objc func presentHalfModalView() {
         let slideVC = HalfModalVC()
         slideVC.selectMajorDelegate = self
+        slideVC.selectFilterDelegate = self
         slideVC.modalPresentationStyle = .custom
         slideVC.transitioningDelegate = self
         self.present(slideVC, animated: true, completion: nil)
@@ -434,12 +422,12 @@ extension ReviewMainVC {
                 
             case .success(let res):
                 print(res)
+                self.activityIndicator.stopAnimating()
                 if let data = res as? [ReviewMainPostListData] {
                     DispatchQueue.main.async {
                         self.postList = data
                         self.reviewTV.reloadData()
                     }
-                    self.activityIndicator.stopAnimating()
                 }
             case .requestErr(let msg):
                 if let message = msg as? String {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
@@ -139,7 +139,7 @@ extension ReviewMainVC {
     
     /// shared에 데이터가 있으면 shared정보로 데이터를 요청하고, 그렇지 않으면 Userdefaults의 전공ID로 요청을 보내는 메서드
     private func setUpRequestData() {
-        requestGetReviewPostList(majorID: (MajorInfo.shared.selecteMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selecteMajorID ?? -1), writerFilter: self.selectedWriterFilter, tagFilter: self.selectedTagFilter == [] ? [1, 2, 3, 4, 5] : self.selectedTagFilter, sort: sortType)
+        requestGetReviewPostList(majorID: (MajorInfo.shared.selectedMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selectedMajorID ?? -1), writerFilter: self.selectedWriterFilter, tagFilter: self.selectedTagFilter == [] ? [1, 2, 3, 4, 5] : self.selectedTagFilter, sort: sortType)
     }
     
     /// 링크에 해당하는 웹사이트로 연결하는 함수
@@ -336,7 +336,7 @@ extension ReviewMainVC: SendUpdateModalDelegate {
     /// 학과 선택 시 해당 학과의 게시글 리스트가 로드될 수 있도록 요청
     func sendUpdate(data: Any) {
         majorLabel.text = data as? String
-        requestGetReviewPostList(majorID: (MajorInfo.shared.selecteMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selecteMajorID ?? -1), writerFilter: 1, tagFilter: [1, 2, 3, 4, 5], sort: .recent)
+        requestGetReviewPostList(majorID: (MajorInfo.shared.selectedMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selectedMajorID ?? -1), writerFilter: 1, tagFilter: [1, 2, 3, 4, 5], sort: .recent)
         self.sortType = .recent
     }
 }
@@ -370,10 +370,10 @@ extension ReviewMainVC: SendUpdateStatusDelegate {
         
         if filterStatus == true {
             /// 필터 on 상태일 때
-            requestGetReviewPostList(majorID: (MajorInfo.shared.selecteMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selecteMajorID ?? -1), writerFilter: selectedWriterFilter, tagFilter: selectedTagFilter == [] ? [1, 2, 3, 4, 5] : selectedTagFilter, sort: sortType)
+            requestGetReviewPostList(majorID: (MajorInfo.shared.selectedMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selectedMajorID ?? -1), writerFilter: selectedWriterFilter, tagFilter: selectedTagFilter == [] ? [1, 2, 3, 4, 5] : selectedTagFilter, sort: sortType)
         } else {
             /// 필터 off 상태일 때
-            requestGetReviewPostList(majorID: (MajorInfo.shared.selecteMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selecteMajorID ?? -1), writerFilter: 1, tagFilter: [1, 2, 3, 4, 5], sort: sortType)
+            requestGetReviewPostList(majorID: (MajorInfo.shared.selectedMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selectedMajorID ?? -1), writerFilter: 1, tagFilter: [1, 2, 3, 4, 5], sort: sortType)
             
         }
         reviewTV.reloadData()

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
@@ -362,13 +362,13 @@ extension ReviewMainVC: SendUpdateStatusDelegate {
         }
         
         /// 태그 필터 판단
-        for i in 2...selectedList.count-1 {
+        for i in 2...selectedList.count - 1 {
             if selectedList[i] == true {
-                selectedTagFilter.append(Int(i-1))
+                selectedTagFilter.append(Int(i - 1))
             }
         }
         
-        if filterStatus == true {
+        if filterStatus {
             /// 필터 on 상태일 때
             requestGetReviewPostList(majorID: (MajorInfo.shared.selectedMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selectedMajorID ?? -1), writerFilter: selectedWriterFilter, tagFilter: selectedTagFilter == [] ? [1, 2, 3, 4, 5] : selectedTagFilter, sort: sortType)
         } else {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Xib/FilterVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Xib/FilterVC.swift
@@ -32,7 +32,7 @@ class FilterVC: UIViewController {
     @IBOutlet weak var tipBtn: UIButton!
     
     // MARK: Properties
-    var filterStatus = false
+    private var filterStatus = false
     var filterItemArray: [UIButton] = []
     var selectFilterDelegate: SendUpdateStatusDelegate?
     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Xib/FilterVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Xib/FilterVC.swift
@@ -32,6 +32,7 @@ class FilterVC: UIViewController {
     @IBOutlet weak var tipBtn: UIButton!
     
     // MARK: Properties
+    var filterStatus = false
     var filterItemArray: [UIButton] = []
     var selectFilterDelegate: SendUpdateStatusDelegate?
     
@@ -135,13 +136,12 @@ extension FilterVC {
 extension FilterVC {
     private func tapCompleteBtnAction() {
         completeBtn.press {
-            var filterStatus = false
             if self.majorBtn.isSelected || self.secondMajorBtn.isSelected || self.learnInfoBtn.isSelected || self.recommendClassBtn.isSelected || self.badClassBtn.isSelected || self.futureJobBtn.isSelected || self.tipBtn.isSelected {
-                filterStatus = true
+                self.filterStatus = true
             }
             if let selectFilterDelegate = self.selectFilterDelegate {
                 self.saveBtnStatus()
-                selectFilterDelegate.sendStatus(data: filterStatus)
+                selectFilterDelegate.sendStatus(data: self.filterStatus)
             }
             self.dismiss(animated: true, completion: {
                 NotificationCenter.default.post(name: Notification.Name.dismissHalfModal, object: nil)


### PR DESCRIPTION
## 🍎 관련 이슈
closed #212

## 🍎 변경 사항 및 이유
- 후기 메인 뷰 필터 기능을 구현했습니다.

## 🍎 PR Point
- `FilterVC`가 닫힐때 호출되는 setStatus(data: Bool) 함수에서 
싱글톤에 저장해놓은 배열을 이용해 각 상황에 맞게 태그 배열이 서버에 요청되도록 처리해주었습니다.
- 다른 학과 페이지로 이동 시 필터가 초기화 기능을 구현해주기 위해 학과선택 바텀시트인 `HalfModalVC`에서 
필터관련 delegate 처리를 해주었습니다.

## 📸 ScreenShot
- 구동영상은 용량문제로 슬랙에서 확인해주시면 감사하겠습니다!
