### PR TITLE
✨ [FEAT] 과방탭 (1:1, 전체) 질문 원글 삭제 기능 구현

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		33CF636C279567AF00E92C04 /* QuestionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CF636B279567AF00E92C04 /* QuestionType.swift */; };
 		33DAB83A27914EAD00214CA8 /* WriteQuestionVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DAB83927914EAD00214CA8 /* WriteQuestionVC.swift */; };
 		33DAB83C279153A400214CA8 /* BaseCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DAB83B279153A400214CA8 /* BaseCVC.swift */; };
+		33E1E19627C7F51A0057C066 /* QnAType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E1E19527C7F51A0057C066 /* QnAType.swift */; };
 		33EAD1F127C68D09000AD673 /* EditPostCommentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EAD1F027C68D09000AD673 /* EditPostCommentModel.swift */; };
 		33F3ED8827C54E9F00731E24 /* EditPostQuestionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F3ED8727C54E9F00731E24 /* EditPostQuestionModel.swift */; };
 		33FA751427931AA800E43523 /* ClassroomSB.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 33FA751327931AA800E43523 /* ClassroomSB.storyboard */; };
@@ -324,6 +325,7 @@
 		33CF636B279567AF00E92C04 /* QuestionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionType.swift; sourceTree = "<group>"; };
 		33DAB83927914EAD00214CA8 /* WriteQuestionVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteQuestionVC.swift; sourceTree = "<group>"; };
 		33DAB83B279153A400214CA8 /* BaseCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCVC.swift; sourceTree = "<group>"; };
+		33E1E19527C7F51A0057C066 /* QnAType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QnAType.swift; sourceTree = "<group>"; };
 		33EAD1F027C68D09000AD673 /* EditPostCommentModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPostCommentModel.swift; sourceTree = "<group>"; };
 		33F02A8A278889650078F9B7 /* NadoSunbaeBtn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NadoSunbaeBtn.swift; sourceTree = "<group>"; };
 		33F3ED8727C54E9F00731E24 /* EditPostQuestionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPostQuestionModel.swift; sourceTree = "<group>"; };
@@ -571,6 +573,7 @@
 				5C32801E27973E1A00781EBE /* ListSortType.swift */,
 				3386010327988D0500C47D36 /* ActionSheetCase.swift */,
 				338601052798B1F800C47D36 /* NaviType.swift */,
+				33E1E19527C7F51A0057C066 /* QnAType.swift */,
 			);
 			path = Struct;
 			sourceTree = "<group>";
@@ -1634,6 +1637,7 @@
 				5CC0BFE12798A3C300B96905 /* SignService.swift in Sources */,
 				77A759242797656B00A8E48B /* ReviewPostData.swift in Sources */,
 				330DA4332790BCCC00FE127F /* NadoTextView.swift in Sources */,
+				33E1E19627C7F51A0057C066 /* QnAType.swift in Sources */,
 				3313646A2785AED600E0C118 /* UIFont+.swift in Sources */,
 				33C1B8A527974B72004BABEC /* ClassroomService.swift in Sources */,
 				77A049F627BD647900D09C69 /* ReviewDeleteResModel.swift in Sources */,

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/PublicData/Singleton/MajorInfo.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/PublicData/Singleton/MajorInfo.swift
@@ -13,7 +13,7 @@ class MajorInfo {
     static let shared = MajorInfo()
     
     var majorList: [MajorInfoModel]?
-    var selecteMajorID: Int?
+    var selectedMajorID: Int?
     var selectedMajorName: String?
     private init() { }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/QnAType.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/QnAType.swift
@@ -1,0 +1,13 @@
+//
+//  QnAType.swift
+//  NadoSunbae-iOS
+//
+//  Created by hwangJi on 2022/02/25.
+//
+
+import Foundation
+
+enum QnAType {
+    case question
+    case comment
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/HalfModalVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/HalfModalVC.swift
@@ -15,8 +15,9 @@ class HalfModalVC: UIViewController {
     @IBOutlet weak var majorChooseBtn: NadoSunbaeBtn!
     
     // MARK: Properties
-    var majorList: [MajorInfoModel] = []
+    private var majorList: [MajorInfoModel] = []
     var selectMajorDelegate: SendUpdateModalDelegate?
+    var selectFilterDelegate: SendUpdateStatusDelegate?
     
     // MARK: Life Cycle Part
     override func viewDidLoad() {
@@ -50,16 +51,22 @@ class HalfModalVC: UIViewController {
     }
     
     /// 선택완료 버튼 클릭 시 데이터 전달
-    func tapMajorChooseBtnAction() {
+    private func tapMajorChooseBtnAction() {
         majorChooseBtn.press {
             let selectedMajorName = self.majorList[self.majorTV.indexPathForSelectedRow?.row ?? 0].majorName
             let selectedMajorID = self.majorList[self.majorTV.indexPathForSelectedRow?.row ?? 0].majorID
 
             if let selectMajorDelegate = self.selectMajorDelegate {
                 MajorInfo.shared.selectedMajorName = selectedMajorName
-                MajorInfo.shared.selecteMajorID = selectedMajorID
+                MajorInfo.shared.selectedMajorID = selectedMajorID
                 selectMajorDelegate.sendUpdate(data: selectedMajorName)
             }
+            
+            if self.selectFilterDelegate != nil {
+                ReviewFilterInfo.shared.selectedBtnList = [false, false, false, false, false, false, false]
+                self.selectFilterDelegate?.sendStatus(data: false)
+            }
+    
             self.dismiss(animated: true, completion: {
                 NotificationCenter.default.post(name: Notification.Name.dismissHalfModal, object: nil)
             })

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ClassroomAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ClassroomAPI.swift
@@ -117,7 +117,7 @@ class ClassroomAPI {
     
     /// [POST] 1:1질문, 전체 질문, 정보글에 좋아요 다는 API 메서드
     func postClassroomLikeAPI(postID: Int, postTypeID: Int, completion: @escaping (NetworkResult<Any>) -> (Void)) {
-        classroomProvider.request(.postLike(postID: postID, postTypeID: postTypeID)) { result in
+        classroomProvider.request(.likePost(postID: postID, postTypeID: postTypeID)) { result in
             switch result {
                 
             case .success(let response):

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ClassroomAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ClassroomAPI.swift
@@ -165,6 +165,23 @@ class ClassroomAPI {
             }
         }
     }
+    
+    /// [DELETE] 1:1질문, 전체 질문, 정보글 질문 삭제 API 메서드
+    func deletePostQuestionAPI(postID: Int, completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        classroomProvider.request(.deletePostQuestion(postID: postID)) { result in
+            switch result {
+                
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                
+                completion(self.deletePostQuestionJudgeData(status: statusCode, data: data))
+                
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
 }
 
 
@@ -320,6 +337,24 @@ extension ClassroomAPI {
     private func editPostCommentJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
         guard let decodedData = try? decoder.decode(GenericResponse<EditPostCommentModel>.self, from: data) else {
+            return .pathErr }
+        
+        switch status {
+        case 200...204:
+            return .success(decodedData.data ?? "None-Data")
+        case 400...409:
+            return .requestErr(decodedData.message)
+        case 500:
+            return .serverErr
+        default:
+            return .networkFail
+        }
+    }
+    
+    /// 질문 삭제
+    private func deletePostQuestionJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
+        let decoder = JSONDecoder()
+        guard let decodedData = try? decoder.decode(GenericResponse<String>.self, from: data) else {
             return .pathErr }
         
         switch status {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/ClassroomService.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/ClassroomService.swift
@@ -15,7 +15,7 @@ enum ClassroomService {
     case postComment(postID: Int, comment: String)
     case getMajorUserList(majorID: Int)
     case postClassroomContent(majorID: Int, answerID: Int?, postTypeID: Int, title: String, content: String)
-    case postLike(postID: Int, postTypeID: Int)
+    case likePost(postID: Int, postTypeID: Int)
     case editPostQuestion(postID: Int, title: String, content: String)
     case editPostComment(commentID: Int, content: String)
 }
@@ -40,7 +40,7 @@ extension ClassroomService: TargetType {
             return "/user/mypage/list/major/\(majorID)"
         case .postClassroomContent:
             return "/classroom-post"
-        case .postLike:
+        case .likePost:
             return "/like"
         case .editPostQuestion(let postID, _, _):
             return "/classroom-post/\(postID)"
@@ -54,7 +54,7 @@ extension ClassroomService: TargetType {
             
         case .getQuestionDetail, .getInfoDetail, .getGroupQuestionOrInfoList, .getMajorUserList:
             return .get
-        case .postComment, .postClassroomContent, .postLike:
+        case .postComment, .postClassroomContent, .likePost:
             return .post
         case .editPostQuestion, .editPostComment:
             return .put
@@ -87,7 +87,7 @@ extension ClassroomService: TargetType {
                 "content": content
             ]
             return .requestParameters(parameters: body, encoding: JSONEncoding.prettyPrinted)
-        case .postLike(let postID, let postTypeID):
+        case .likePost(let postID, let postTypeID):
             let body: [String: Any] = [
                 "postId": postID,
                 "postTypeId": postTypeID

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/ClassroomService.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/ClassroomService.swift
@@ -18,6 +18,7 @@ enum ClassroomService {
     case likePost(postID: Int, postTypeID: Int)
     case editPostQuestion(postID: Int, title: String, content: String)
     case editPostComment(commentID: Int, content: String)
+    case deletePostQuestion(postID: Int)
 }
 
 extension ClassroomService: TargetType {
@@ -42,7 +43,7 @@ extension ClassroomService: TargetType {
             return "/classroom-post"
         case .likePost:
             return "/like"
-        case .editPostQuestion(let postID, _, _):
+        case .editPostQuestion(let postID, _, _), .deletePostQuestion(let postID):
             return "/classroom-post/\(postID)"
         case .editPostComment(let commentID, _):
             return "/comment/\(commentID)"
@@ -58,6 +59,8 @@ extension ClassroomService: TargetType {
             return .post
         case .editPostQuestion, .editPostComment:
             return .put
+        case .deletePostQuestion:
+            return .delete
         }
     }
     
@@ -102,6 +105,8 @@ extension ClassroomService: TargetType {
         case .editPostComment(_, let content):
             let body = ["content": content]
             return .requestParameters(parameters: body, encoding: JSONEncoding.prettyPrinted)
+        case .deletePostQuestion(_):
+            return .requestPlain
         }
     }
     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/PublicService.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/PublicService.swift
@@ -25,6 +25,7 @@ extension PublicService: TargetType {
             return "/major/list/\(univID)"
         }
     }
+    
     var method: Moya.Method {
         switch self {
             
@@ -37,21 +38,12 @@ extension PublicService: TargetType {
         switch self {
             
         case .getMajorList(_, let filter):
-            let body = ["filter" : filter]
+            let body = ["filter": filter]
             return .requestParameters(parameters: body, encoding: URLEncoding.queryString)
         }
     }
     
-    var headers: [String : String]? {
-        //let accessToken: String = UserDefaults.standard.string(forKey: UserDefaults.Keys.AccessToken) ?? ""
-        
-        switch self {
-            
-        case .getMajorList:
-            return ["Content-Type" : "application/json"]
-        }
+    var headers: [String: String]? {
+        return ["Content-Type": "application/json"]
     }
 }
-    
-    
-

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
@@ -145,7 +145,7 @@ extension InfoMainVC {
     
     /// shared에 데이터가 있으면 shared정보로 데이터를 요청하고, 그렇지 않으면 Userdefaults의 전공ID로 요청을 보내는 메서드
     private func setUpRequestData(sortType: ListSortType) {
-        requestGetGroupOrInfoListData(majorID: (MajorInfo.shared.selecteMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selecteMajorID ?? -1), postTypeID: .info, sort: sortType)
+        requestGetGroupOrInfoListData(majorID: (MajorInfo.shared.selectedMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selectedMajorID ?? -1), postTypeID: .info, sort: sortType)
     }
     
     /// activityIndicator 설정 메서드

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -458,6 +458,7 @@ extension DefaultQuestionChatVC: UITableViewDataSource {
                         /// 작성자 본인이 흰색 말풍선의 더보기 버튼을 눌렀을 경우
                         self.makeTwoAlertWithCancel(okTitle: actionSheetString[0], secondOkTitle: actionSheetString[1], okAction: { _ in
                             if indexPath.row == 0 {
+                                /// 수정
                                 /// 질문 원글일 경우
                                 let writeQuestionSB: UIStoryboard = UIStoryboard(name: Identifiers.WriteQusetionSB, bundle: nil)
                                 guard let editPostVC = writeQuestionSB.instantiateViewController(identifier: WriteQuestionVC.className) as? WriteQuestionVC else { return }
@@ -476,13 +477,8 @@ extension DefaultQuestionChatVC: UITableViewDataSource {
                             }
                             defaultQuestionChatTV.reloadData()
                         }, secondOkAction: { _ in
-                            if indexPath.row == 0 {
-                                /// 질문 원글일 경우
-                                self.makeNadoDeleteAlert(qnaType: .question)
-                            } else {
-                                /// 질문 답변일 경우
-                                self.makeNadoDeleteAlert(qnaType: .comment)
-                            }
+                            /// 삭제
+                            indexPath.row == 0 ? self.makeNadoDeleteAlert(qnaType: .question) : self.makeNadoDeleteAlert(qnaType: .comment)
                         })
                     } else {
                         /// 타인이 흰색 말풍선의 더보기 버튼을 눌렀을 경우

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -52,7 +52,7 @@ class DefaultQuestionChatVC: BaseVC {
         }
     }
     
-    @IBOutlet var questionNaviBar: NadoSunbaeNaviBar! 
+    @IBOutlet var questionNaviBar: NadoSunbaeNaviBar!
     
     // MARK: Properties
     var editIndex: [Int]?
@@ -330,11 +330,11 @@ extension DefaultQuestionChatVC {
     /// 나도선배 delete alert를 만드는 메서드
     private func makeNadoDeleteAlert(qnaType: QnAType) {
         guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
-        let alertMsgdict: [QnAType : String] = [
-            .question :  """
+        let alertMsgdict: [QnAType: String] = [
+            .question: """
                 글을 삭제하시겠습니까?
                 """,
-            .comment : """
+            .comment: """
                 댓글을 삭제하시겠습니까?
                 """
         ]
@@ -571,7 +571,7 @@ extension DefaultQuestionChatVC: UITableViewDataSource {
                     editIndex = []
                     moreBtnTapIndex = [1,indexPath.row]
                 }
-              
+                
                 commentCell.bindData(questionChatData[indexPath.row])
                 return commentCell
             }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -762,7 +762,7 @@ extension DefaultQuestionChatVC {
         }
     }
     
-    /// 답변 수정 API 요청 메서드
+    /// 1:1질문, 전체 질문 질문 원글 삭제 API 요청 메서드
     private func requestDeletePostQuestion(postID: Int) {
         self.activityIndicator.startAnimating()
         ClassroomAPI.shared.deletePostQuestionAPI(postID: postID) { networkResult in

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -478,7 +478,7 @@ extension DefaultQuestionChatVC: UITableViewDataSource {
                             defaultQuestionChatTV.reloadData()
                         }, secondOkAction: { _ in
                             /// 삭제
-                            indexPath.row == 0 ? self.makeNadoDeleteAlert(qnaType: .question) : self.makeNadoDeleteAlert(qnaType: .comment)
+                            self.makeNadoDeleteAlert(qnaType: indexPath.row == 0 ? .question : .comment)
                         })
                     } else {
                         /// 타인이 흰색 말풍선의 더보기 버튼을 눌렀을 경우

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -64,6 +64,7 @@ class DefaultQuestionChatVC: BaseVC {
     var userID: Int?
     var userType: Int?
     var postID: Int?
+    private var qnaType: QnAType?
     private var questionChatData: [ClassroomMessageList] = []
     private var questionLikeData: Like?
     private var isCommentEdited: Bool = false
@@ -180,10 +181,8 @@ extension DefaultQuestionChatVC {
         case .group:
             sendAreaTextView.isEditable = true
             sendAreaTextView.text = "답글쓰기"
-        case .info:
-            print("info")
         default:
-            print("Review")
+            print("info or Review")
         }
         
         sendAreaTextView.endEditing(true)
@@ -327,6 +326,26 @@ extension DefaultQuestionChatVC {
             }
         }
     }
+    
+    /// 나도선배 delete alert를 만드는 메서드
+    private func makeNadoDeleteAlert(qnaType: QnAType) {
+        guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+        let alertMsgdict: [QnAType : String] = [
+            .question :  """
+                글을 삭제하시겠습니까?
+                """,
+            .comment : """
+                댓글을 삭제하시겠습니까?
+                """
+        ]
+        
+        alert.showNadoAlert(vc: self, message: (qnaType == .question ? alertMsgdict[.question] : alertMsgdict[.comment]) ?? "", confirmBtnTitle: "네", cancelBtnTitle: "아니요")
+        
+        // TODO: 추후에 답변 삭제 함수 추가 후 nil부분 답변 삭제 함수로 변경 예정
+        alert.confirmBtn.press(vibrate: true, for: .touchUpInside) {
+            qnaType == .question ? self.requestDeletePostQuestion(postID: self.postID ?? 0) : nil
+        }
+    }
 }
 
 // MARK: - UITextViewDelegate
@@ -436,8 +455,10 @@ extension DefaultQuestionChatVC: UITableViewDataSource {
                     }
                     
                     if actionSheetString.count > 1 {
+                        /// 작성자 본인이 흰색 말풍선의 더보기 버튼을 눌렀을 경우
                         self.makeTwoAlertWithCancel(okTitle: actionSheetString[0], secondOkTitle: actionSheetString[1], okAction: { _ in
                             if indexPath.row == 0 {
+                                /// 질문 원글일 경우
                                 let writeQuestionSB: UIStoryboard = UIStoryboard(name: Identifiers.WriteQusetionSB, bundle: nil)
                                 guard let editPostVC = writeQuestionSB.instantiateViewController(identifier: WriteQuestionVC.className) as? WriteQuestionVC else { return }
                                 
@@ -450,16 +471,23 @@ extension DefaultQuestionChatVC: UITableViewDataSource {
                                 
                                 self.present(editPostVC, animated: true, completion: nil)
                             } else {
+                                /// 질문 답변일 경우
                                 editIndex = [0,indexPath.row]
                             }
                             defaultQuestionChatTV.reloadData()
                         }, secondOkAction: { _ in
-                            // TODO: 추후에 기능 추가 예정
-                            print("삭제")
+                            if indexPath.row == 0 {
+                                /// 질문 원글일 경우
+                                self.makeNadoDeleteAlert(qnaType: .question)
+                            } else {
+                                /// 질문 답변일 경우
+                                self.makeNadoDeleteAlert(qnaType: .comment)
+                            }
                         })
                     } else {
+                        /// 타인이 흰색 말풍선의 더보기 버튼을 눌렀을 경우
                         self.makeAlertWithCancel(okTitle: actionSheetString[0], okAction: { _ in
-                            // TODO: 추후에 기능 추가 예정
+                            // TODO: 추후에 질문 신고 기능 추가 예정
                         })
                     }
                     editIndex = []
@@ -525,17 +553,19 @@ extension DefaultQuestionChatVC: UITableViewDataSource {
                     }
                     
                     if actionSheetString.count > 1 {
+                        /// 작성자 본인이 민트색 말풍선의 더보기 버튼을 눌렀을 경우
                         self.makeTwoAlertWithCancel(okTitle: actionSheetString[0], secondOkTitle: actionSheetString[1], okAction: { _ in
                             if actionSheetString[0] == "수정" {
                                 editIndex = [1,indexPath.row]
                             }
                             defaultQuestionChatTV.reloadData()
                         }, secondOkAction: { _ in
-                            // TODO: 추후에 기능 추가 예정
+                            // TODO: 추후에 답변 삭제 기능 추가 예정
                         })
                     } else {
+                        /// 타인이 민트색 말풍선의 더보기 버튼을 눌렀을 경우
                         self.makeAlertWithCancel(okTitle: actionSheetString[0], okAction: { _ in
-                            // TODO: 추후에 기능 추가 예정
+                            // TODO: 추후에 답변 신고 기능 추가 예정
                         })
                     }
                     editIndex = []
@@ -723,6 +753,26 @@ extension DefaultQuestionChatVC {
                 self.isCommentEdited = true
                 self.requestGetDetailQuestionData(postID: self.postID ?? 0)
                 self.activityIndicator.stopAnimating()
+            case .requestErr(let msg):
+                if let message = msg as? String {
+                    print(message)
+                }
+                self.activityIndicator.stopAnimating()
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+            default:
+                self.activityIndicator.stopAnimating()
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+            }
+        }
+    }
+    
+    /// 답변 수정 API 요청 메서드
+    private func requestDeletePostQuestion(postID: Int) {
+        self.activityIndicator.startAnimating()
+        ClassroomAPI.shared.deletePostQuestionAPI(postID: postID) { networkResult in
+            switch networkResult {
+            case .success(_):
+                self.navigationController?.popViewController(animated: true)
             case .requestErr(let msg):
                 if let message = msg as? String {
                     print(message)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/EntireQuestionListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/EntireQuestionListVC.swift
@@ -122,7 +122,7 @@ extension EntireQuestionListVC {
     
     /// shared에 데이터가 있으면 shared정보로 데이터를 요청하고, 그렇지 않으면 Userdefaults의 전공ID로 요청을 보내는 메서드
     private func setUpRequestData(sortType: ListSortType) {
-        requestGetGroupOrInfoListData(majorID: (MajorInfo.shared.selecteMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selecteMajorID ?? -1), postTypeID: .group, sort: sortType)
+        requestGetGroupOrInfoListData(majorID: (MajorInfo.shared.selectedMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selectedMajorID ?? -1), postTypeID: .group, sort: sortType)
     }
 }
 
@@ -171,7 +171,7 @@ extension EntireQuestionListVC: UITableViewDelegate {
                                         okAction: { _ in
                 self.selectActionSheetIndex = 0
                 self.setUpRequestData(sortType: .recent)
-                self.requestGetGroupOrInfoListData(majorID: MajorInfo.shared.selecteMajorID ?? 0, postTypeID: .group, sort: .recent)
+                self.requestGetGroupOrInfoListData(majorID: MajorInfo.shared.selectedMajorID ?? 0, postTypeID: .group, sort: .recent)
                 self.entireQuestionListTV.reloadSections([0], with: .fade)
             },
                                         secondOkAction: { _ in

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionMainVC.swift
@@ -152,7 +152,7 @@ extension QuestionMainVC {
     private func setUpTapPersonalQuestionBtn() {
         personalQuestionBtn.press(vibrate: true) {
             let questionPersonVC = QuestionPersonListVC()
-            questionPersonVC.majorID = MajorInfo.shared.selecteMajorID ?? UserDefaults.standard.value(forKey: UserDefaults.Keys.FirstMajorID) as! Int
+            questionPersonVC.majorID = MajorInfo.shared.selectedMajorID ?? UserDefaults.standard.value(forKey: UserDefaults.Keys.FirstMajorID) as! Int
             self.navigationController?.pushViewController(questionPersonVC, animated: true)
         }
     }
@@ -160,12 +160,12 @@ extension QuestionMainVC {
     /// 선택된 전공정보에 따라 서버통신 요청하는 메서드
     @objc
     func updateDataBySelectedMajor() {
-        requestGetGroupOrInfoListData(majorID: MajorInfo.shared.selecteMajorID ?? 0, postTypeID: .group, sort: .recent)
+        requestGetGroupOrInfoListData(majorID: MajorInfo.shared.selectedMajorID ?? 0, postTypeID: .group, sort: .recent)
     }
     
     /// shared에 데이터가 있으면 shared정보로 데이터를 요청하고, 그렇지 않으면 Userdefaults의 전공ID로 요청을 보내는 메서드
     private func setUpRequestData() {
-        requestGetGroupOrInfoListData(majorID: (MajorInfo.shared.selecteMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selecteMajorID ?? -1), postTypeID: .group, sort: .recent)
+        requestGetGroupOrInfoListData(majorID: (MajorInfo.shared.selectedMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selectedMajorID ?? -1), postTypeID: .group, sort: .recent)
     }
     
     /// ActivateIndicator 추가 메서드

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
@@ -19,7 +19,7 @@ class WriteQuestionVC: BaseVC {
     private let disposeBag = DisposeBag()
     private var questionTextViewLineCount: Int = 1
     private var isTextViewEmpty: Bool = true
-    private var majorID: Int = MajorInfo.shared.selecteMajorID ?? UserDefaults.standard.value(forKey: UserDefaults.Keys.FirstMajorID) as! Int
+    private var majorID: Int = MajorInfo.shared.selectedMajorID ?? UserDefaults.standard.value(forKey: UserDefaults.Keys.FirstMajorID) as! Int
     @IBOutlet weak var questionWriteNaviBar: NadoSunbaeNaviBar! {
         didSet {
             questionWriteNaviBar.addShadow(location: .nadoBotttom, color: .shadowDefault, opacity: 0.3, radius: 16)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewMainLinkTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewMainLinkTVC.swift
@@ -18,7 +18,7 @@ class ReviewMainLinkTVC: BaseTVC {
     // MARK: Life Cycle
     override func awakeFromNib() {
         super.awakeFromNib()
-        requestGetHomePageList(majorID: MajorInfo.shared.selecteMajorID ?? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID))
+        requestGetHomePageList(majorID: MajorInfo.shared.selectedMajorID ?? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID))
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Xib/FilterVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Xib/FilterVC.swift
@@ -32,6 +32,7 @@ class FilterVC: UIViewController {
     @IBOutlet weak var tipBtn: UIButton!
     
     // MARK: Properties
+    private var filterStatus = false
     var filterItemArray: [UIButton] = []
     var selectFilterDelegate: SendUpdateStatusDelegate?
     
@@ -135,13 +136,12 @@ extension FilterVC {
 extension FilterVC {
     private func tapCompleteBtnAction() {
         completeBtn.press {
-            var filterStatus = false
             if self.majorBtn.isSelected || self.secondMajorBtn.isSelected || self.learnInfoBtn.isSelected || self.recommendClassBtn.isSelected || self.badClassBtn.isSelected || self.futureJobBtn.isSelected || self.tipBtn.isSelected {
-                filterStatus = true
+                self.filterStatus = true
             }
             if let selectFilterDelegate = self.selectFilterDelegate {
                 self.saveBtnStatus()
-                selectFilterDelegate.sendStatus(data: filterStatus)
+                selectFilterDelegate.sendStatus(data: self.filterStatus)
             }
             self.dismiss(animated: true, completion: {
                 NotificationCenter.default.post(name: Notification.Name.dismissHalfModal, object: nil)


### PR DESCRIPTION
## 🍎 관련 이슈
closed #215 

## 🍎 변경 사항 및 이유
- 좋아요 Service moyaTarget case명 수정 
- 질문글 내에서 질문(원글), 답변(댓글) 상태 분기처리를 위해 QnAType(enum) 추가

## 🍎 PR Point
- 질문글에는 ,, 아주 신기한 전설이 있었으니 ,, 질문 스레드의 흰색 박스는 사실 질문원글, 질문자 댓글로 분리되어 보이지만 같은 셀을 사용한답니다~~ 
- 댓글일 경우 titleLabel에 text가 없어서 sizeToFit을 통해 댓글 부분은 민트색 타이틀 글씨가 안보이게 되는 구런 눈속임을 갖구 있는데요,, 그래서 요 분기처리를 cellForRowAt의 questionCell 내에서 indexPath가 0일경우 아닐경우로 분기처리를 해주고 있습니다!
- 근데 그  if-else문 안에서 또 alert함수를 코드로 if-else 마다 써줘야 하는 문제가 발생해서 중복되는 alert 생성 부분을 함수로 빼게 되었고 alert 코드 내에서 딕셔너리를 이용해서 QnAType에 따른 alertMsg를 짝으로 지어주었습니다. (사실은 같은 셀의 더보기 버튼의 삭제버튼을 누른거지만 질문 원글 삭제일 경우와 질문 댓글일 경우 alertMsg도 다르게 떠야할 것 같아서 이 부분을 분기처리 해주었습니다!)
- 그래서 현재 질문 원글 삭제 부분만 기능을 구현했구요! 질문 댓글 삭제 부분은 다른 API를 이용해야하기에 그 부분을 nil로 설정해둔 상태입니다! (TODO참고 🤗)

- 앗! 그리고 제 코드가 넘 길어가지고 `/// 주석`으로 분기처리마다 설명을 간략하게 달아놓아서 주석 추가 코드가 많으니 깃에서 보기 힘드시더라도 양해 부탁해여 정숙걸즈 ~~ 🤗🤗🌀🌀

## 📸 ScreenShot
<img width=375 src="https://user-images.githubusercontent.com/63224278/155583222-3200f7de-1896-4884-8a0a-d21578b19152.gif">

