### PR TITLE
✨ [FEAT] 과방 질문 댓글 삭제 기능 구현

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ClassroomAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ClassroomAPI.swift
@@ -175,7 +175,24 @@ class ClassroomAPI {
                 let statusCode = response.statusCode
                 let data = response.data
                 
-                completion(self.deletePostQuestionJudgeData(status: statusCode, data: data))
+                completion(self.deletePostJudgeData(status: statusCode, data: data))
+                
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
+    
+    /// [DELETE] 1:1질문, 전체 질문, 정보글 댓글 삭제 API 메서드
+    func deletePostCommentAPI(commentID: Int, completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        classroomProvider.request(.deletePostComment(commentID: commentID)) { result in
+            switch result {
+                
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                
+                completion(self.deletePostJudgeData(status: statusCode, data: data))
                 
             case .failure(let err):
                 print(err)
@@ -351,8 +368,8 @@ extension ClassroomAPI {
         }
     }
     
-    /// 질문 삭제
-    private func deletePostQuestionJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
+    /// 질문, 댓글 삭제
+    private func deletePostJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
         guard let decodedData = try? decoder.decode(GenericResponse<String>.self, from: data) else {
             return .pathErr }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/ClassroomService.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/ClassroomService.swift
@@ -19,6 +19,7 @@ enum ClassroomService {
     case editPostQuestion(postID: Int, title: String, content: String)
     case editPostComment(commentID: Int, content: String)
     case deletePostQuestion(postID: Int)
+    case deletePostComment(commentID: Int)
 }
 
 extension ClassroomService: TargetType {
@@ -45,7 +46,7 @@ extension ClassroomService: TargetType {
             return "/like"
         case .editPostQuestion(let postID, _, _), .deletePostQuestion(let postID):
             return "/classroom-post/\(postID)"
-        case .editPostComment(let commentID, _):
+        case .editPostComment(let commentID, _), .deletePostComment(let commentID):
             return "/comment/\(commentID)"
         }
     }
@@ -59,7 +60,7 @@ extension ClassroomService: TargetType {
             return .post
         case .editPostQuestion, .editPostComment:
             return .put
-        case .deletePostQuestion:
+        case .deletePostQuestion, .deletePostComment:
             return .delete
         }
     }
@@ -105,7 +106,7 @@ extension ClassroomService: TargetType {
         case .editPostComment(_, let content):
             let body = ["content": content]
             return .requestParameters(parameters: body, encoding: JSONEncoding.prettyPrinted)
-        case .deletePostQuestion(_):
+        case .deletePostQuestion, .deletePostComment:
             return .requestPlain
         }
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -328,7 +328,7 @@ extension DefaultQuestionChatVC {
     }
     
     /// 나도선배 delete alert를 만드는 메서드
-    private func makeNadoDeleteAlert(qnaType: QnAType) {
+    private func makeNadoDeleteAlert(qnaType: QnAType, commentID: Int, indexPath: [IndexPath]) {
         guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
         let alertMsgdict: [QnAType: String] = [
             .question: """
@@ -343,7 +343,7 @@ extension DefaultQuestionChatVC {
         
         // TODO: 추후에 답변 삭제 함수 추가 후 nil부분 답변 삭제 함수로 변경 예정
         alert.confirmBtn.press(vibrate: true, for: .touchUpInside) {
-            qnaType == .question ? self.requestDeletePostQuestion(postID: self.postID ?? 0) : nil
+            qnaType == .question ? self.requestDeletePostQuestion(postID: self.postID ?? 0) : self.requestDeletePostComment(commentID: commentID, indexPath: indexPath)
         }
     }
 }
@@ -478,7 +478,7 @@ extension DefaultQuestionChatVC: UITableViewDataSource {
                             defaultQuestionChatTV.reloadData()
                         }, secondOkAction: { _ in
                             /// 삭제
-                            self.makeNadoDeleteAlert(qnaType: indexPath.row == 0 ? .question : .comment)
+                            self.makeNadoDeleteAlert(qnaType: indexPath.row == 0 ? .question : .comment, commentID: questionChatData[indexPath.row].messageID, indexPath: [IndexPath(row: indexPath.row, section: indexPath.section)])
                         })
                     } else {
                         /// 타인이 흰색 말풍선의 더보기 버튼을 눌렀을 경우
@@ -664,7 +664,9 @@ extension DefaultQuestionChatVC {
                     
                     /// 댓글 수정되었을 때
                     if self.isCommentEdited {
-                        self.defaultQuestionChatTV.reloadRows(at: self.editedCommentIndexPath, with: .automatic)
+                        self.defaultQuestionChatTV.performBatchUpdates {
+                            self.defaultQuestionChatTV.reloadRows(at: self.editedCommentIndexPath, with: .automatic)
+                        }
                         self.isCommentEdited = false
                     } else {
                         self.defaultQuestionChatTV.reloadData()
@@ -769,6 +771,34 @@ extension DefaultQuestionChatVC {
             switch networkResult {
             case .success(_):
                 self.navigationController?.popViewController(animated: true)
+                self.activityIndicator.stopAnimating()
+            case .requestErr(let msg):
+                if let message = msg as? String {
+                    print(message)
+                }
+                self.activityIndicator.stopAnimating()
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+            default:
+                self.activityIndicator.stopAnimating()
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+            }
+        }
+    }
+    
+    /// 1:1질문, 전체 질문 질문 댓글 삭제 API 요청 메서드
+    private func requestDeletePostComment(commentID: Int, indexPath: [IndexPath]) {
+        self.activityIndicator.startAnimating()
+        ClassroomAPI.shared.deletePostCommentAPI(commentID: commentID) { networkResult in
+            switch networkResult {
+            case .success(_):
+                self.questionChatData.remove(at: indexPath.first!.row)
+                self.defaultQuestionChatTV.performBatchUpdates {
+                    self.defaultQuestionChatTV.deleteRows(at: indexPath, with: .fade)
+                } completion: { (done) in
+                    let indexPathsToUpdate = (0...self.defaultQuestionChatTV.numberOfRows(inSection: 0)).map { IndexPath(row: $0, section: 0) }
+                    self.defaultQuestionChatTV.reloadRows(at: indexPathsToUpdate, with: .none)
+                }
+                self.activityIndicator.stopAnimating()
             case .requestErr(let msg):
                 if let message = msg as? String {
                     print(message)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -703,6 +703,7 @@ extension DefaultQuestionChatVC {
                 if let _ = res as? AddCommentData {
                     DispatchQueue.main.async {
                         self.requestGetDetailQuestionData(postID: postID)
+                        self.isTextViewEmpty = true
                         self.activityIndicator.stopAnimating()
                     }
                 }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #218

## 🍎 PR Point
- 과방 질문글 댓글 삭제기능 구현완료했습니다!
- 기본 tableView 함수 내에서 삭제가 이뤄지는게 아니다보니 tv.deleteRows 함수를 호출해준 후 indexPath가 업데이트되지 않는 상황(삭제 후 0 2 3 4 --> deleteRows호출을 통해 UI만 업데이트되어 indexPath에 공백이 생기는)이 생겨서  indexPath update 코드를 작성해주었습니다!

## 📸 ScreenShot
<img width=375 src="https://user-images.githubusercontent.com/63224278/155746317-d7e95f57-bf54-430d-800a-e36d1bd587b8.gif">
