### PR TITLE
✨ [FEAT] 과방 정보글 원글 수정, 삭제 기능 구현

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ClassroomAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ClassroomAPI.swift
@@ -175,7 +175,24 @@ class ClassroomAPI {
                 let statusCode = response.statusCode
                 let data = response.data
                 
-                completion(self.deletePostQuestionJudgeData(status: statusCode, data: data))
+                completion(self.deletePostJudgeData(status: statusCode, data: data))
+                
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
+    
+    /// [DELETE] 1:1질문, 전체 질문, 정보글 댓글 삭제 API 메서드
+    func deletePostCommentAPI(commentID: Int, completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        classroomProvider.request(.deletePostComment(commentID: commentID)) { result in
+            switch result {
+                
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                
+                completion(self.deletePostJudgeData(status: statusCode, data: data))
                 
             case .failure(let err):
                 print(err)
@@ -351,8 +368,8 @@ extension ClassroomAPI {
         }
     }
     
-    /// 질문 삭제
-    private func deletePostQuestionJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
+    /// 질문, 댓글 삭제
+    private func deletePostJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
         guard let decodedData = try? decoder.decode(GenericResponse<String>.self, from: data) else {
             return .pathErr }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/ClassroomService.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/ClassroomService.swift
@@ -19,6 +19,7 @@ enum ClassroomService {
     case editPostQuestion(postID: Int, title: String, content: String)
     case editPostComment(commentID: Int, content: String)
     case deletePostQuestion(postID: Int)
+    case deletePostComment(commentID: Int)
 }
 
 extension ClassroomService: TargetType {
@@ -45,7 +46,7 @@ extension ClassroomService: TargetType {
             return "/like"
         case .editPostQuestion(let postID, _, _), .deletePostQuestion(let postID):
             return "/classroom-post/\(postID)"
-        case .editPostComment(let commentID, _):
+        case .editPostComment(let commentID, _), .deletePostComment(let commentID):
             return "/comment/\(commentID)"
         }
     }
@@ -59,7 +60,7 @@ extension ClassroomService: TargetType {
             return .post
         case .editPostQuestion, .editPostComment:
             return .put
-        case .deletePostQuestion:
+        case .deletePostQuestion, .deletePostComment:
             return .delete
         }
     }
@@ -105,7 +106,7 @@ extension ClassroomService: TargetType {
         case .editPostComment(_, let content):
             let body = ["content": content]
             return .requestParameters(parameters: body, encoding: JSONEncoding.prettyPrinted)
-        case .deletePostQuestion(_):
+        case .deletePostQuestion, .deletePostComment:
             return .requestPlain
         }
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
@@ -347,7 +347,7 @@ extension InfoDetailVC {
 extension InfoDetailVC {
     
     /// 정보글 상세 조회 API 요청 메서드
-    func requestGetDetailInfoData(postID: Int, addLoadBackView: Bool) {
+    private func requestGetDetailInfoData(postID: Int, addLoadBackView: Bool) {
         addLoadBackView ? self.configureWhiteBackView() : nil
         self.activityIndicator.startAnimating()
         ClassroomAPI.shared.getInfoDetailAPI(postID: postID) { networkResult in
@@ -381,7 +381,7 @@ extension InfoDetailVC {
     }
     
     /// 정보글에 댓글 등록 API 요청 메서드
-    func requestCreateComment(postID: Int, comment: String) {
+    private func requestCreateComment(postID: Int, comment: String) {
         self.activityIndicator.startAnimating()
         ClassroomAPI.shared.createCommentAPI(postID: postID, comment: comment) { networkResult in
             switch networkResult {
@@ -407,7 +407,7 @@ extension InfoDetailVC {
     }
     
     /// 좋아요 API 요청 메서드
-    func requestPostLikeData(postID: Int, postTypeID: QuestionType) {
+    private func requestPostLikeData(postID: Int, postTypeID: QuestionType) {
         self.activityIndicator.startAnimating()
         ClassroomAPI.shared.postClassroomLikeAPI(postID: postID, postTypeID: postTypeID.rawValue) { networkResult in
             switch networkResult {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
@@ -389,6 +389,7 @@ extension InfoDetailVC {
                 if let _ = res as? AddCommentData {
                     DispatchQueue.main.async {
                         self.requestGetDetailInfoData(postID: postID, addLoadBackView: false)
+                        self.isTextViewEmpty = true
                         self.activityIndicator.stopAnimating()
                     }
                 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
@@ -59,6 +59,7 @@ class InfoDetailVC: BaseVC {
     private var isCommentSend: Bool = false
     private var isTextViewEmpty: Bool = true
     private var sendTextViewLineCount: Int = 1
+    private var isWriter: Bool?
     private let textViewMaxHeight: CGFloat = 85.adjustedH
     private let whiteBackView = UIView()
     
@@ -126,9 +127,15 @@ extension InfoDetailVC {
             self.navigationController?.popViewController(animated: true)
         }
         infoDetailNaviBar.rightCustomBtn.press {
-            // TODO: 추후에 권한 분기처리 예정
+            if self.isWriter == true {
+                self.makeTwoAlertWithCancel(okTitle: "수정", secondOkTitle: "삭제", okAction: { _ in
+                    self.presentWriteQuestionVC()
+                }, secondOkAction: { _ in
+                    
+                })
+            }
             self.makeAlertWithCancel(okTitle: "신고", okAction: { _ in
-                // TODO: 추후에 기능 추가 예정
+                // TODO: 추후에 신고 기능 추가 예정
             })
         }
     }
@@ -186,6 +193,21 @@ extension InfoDetailVC {
         commentTextView.text = "답글쓰기"
         commentTextView.textColor = .gray2
         commentTextView.backgroundColor = .gray0
+    }
+    
+    /// 정보글 원글을 수정하기 위해 WriteQuestionVC로 화면전환하는 메서드
+    private func presentWriteQuestionVC() {
+        let writeQuestionSB: UIStoryboard = UIStoryboard(name: Identifiers.WriteQusetionSB, bundle: nil)
+        guard let editPostVC = writeQuestionSB.instantiateViewController(identifier: WriteQuestionVC.className) as? WriteQuestionVC else { return }
+        
+        editPostVC.questionType = .info
+        editPostVC.isEditState = true
+        editPostVC.postID = self.postID
+        editPostVC.originTitle = self.infoDetailData?.post.title
+        editPostVC.originContent = self.infoDetailData?.post.content
+        editPostVC.modalPresentationStyle = .fullScreen
+        
+        self.present(editPostVC, animated: true, completion: nil)
     }
 }
 
@@ -335,6 +357,8 @@ extension InfoDetailVC {
                     self.infoDetailData = data
                     self.infoDetailCommentData = data.commentList
                     self.userID = UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID)
+                    self.isWriter = (self.userID == self.infoDetailData?.writer.writerID) ? true : false
+                    
                     DispatchQueue.main.async {
                         self.infoDetailTV.reloadData()
                         self.setUpSendBtnEnabledState()

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
@@ -317,7 +317,9 @@ extension InfoDetailVC: UITextViewDelegate {
     
     /// textViewDidEndEditing
     func textViewDidEndEditing(_ textView: UITextView) {
-        isTextViewEmpty = textView.text.isEmpty ? true : false
+        if textView.text.isEmpty {
+            isTextViewEmpty = true
+        }
         setUpSendBtnEnabledState()
         configueTextViewPlaceholder()
     }
@@ -409,8 +411,8 @@ extension InfoDetailVC {
             case .success(let res):
                 if let _ = res as? AddCommentData {
                     DispatchQueue.main.async {
-                        self.requestGetDetailInfoData(postID: postID, addLoadBackView: false)
                         self.isTextViewEmpty = true
+                        self.requestGetDetailInfoData(postID: postID, addLoadBackView: false)
                         self.activityIndicator.stopAnimating()
                     }
                 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -328,7 +328,7 @@ extension DefaultQuestionChatVC {
     }
     
     /// 나도선배 delete alert를 만드는 메서드
-    private func makeNadoDeleteAlert(qnaType: QnAType) {
+    private func makeNadoDeleteAlert(qnaType: QnAType, commentID: Int, indexPath: [IndexPath]) {
         guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
         let alertMsgdict: [QnAType: String] = [
             .question: """
@@ -343,7 +343,7 @@ extension DefaultQuestionChatVC {
         
         // TODO: 추후에 답변 삭제 함수 추가 후 nil부분 답변 삭제 함수로 변경 예정
         alert.confirmBtn.press(vibrate: true, for: .touchUpInside) {
-            qnaType == .question ? self.requestDeletePostQuestion(postID: self.postID ?? 0) : nil
+            qnaType == .question ? self.requestDeletePostQuestion(postID: self.postID ?? 0) : self.requestDeletePostComment(commentID: commentID, indexPath: indexPath)
         }
     }
 }
@@ -478,7 +478,7 @@ extension DefaultQuestionChatVC: UITableViewDataSource {
                             defaultQuestionChatTV.reloadData()
                         }, secondOkAction: { _ in
                             /// 삭제
-                            self.makeNadoDeleteAlert(qnaType: indexPath.row == 0 ? .question : .comment)
+                            self.makeNadoDeleteAlert(qnaType: indexPath.row == 0 ? .question : .comment, commentID: questionChatData[indexPath.row].messageID, indexPath: [IndexPath(row: indexPath.row, section: indexPath.section)])
                         })
                     } else {
                         /// 타인이 흰색 말풍선의 더보기 버튼을 눌렀을 경우
@@ -664,7 +664,9 @@ extension DefaultQuestionChatVC {
                     
                     /// 댓글 수정되었을 때
                     if self.isCommentEdited {
-                        self.defaultQuestionChatTV.reloadRows(at: self.editedCommentIndexPath, with: .automatic)
+                        self.defaultQuestionChatTV.performBatchUpdates {
+                            self.defaultQuestionChatTV.reloadRows(at: self.editedCommentIndexPath, with: .automatic)
+                        }
                         self.isCommentEdited = false
                     } else {
                         self.defaultQuestionChatTV.reloadData()
@@ -769,6 +771,34 @@ extension DefaultQuestionChatVC {
             switch networkResult {
             case .success(_):
                 self.navigationController?.popViewController(animated: true)
+                self.activityIndicator.stopAnimating()
+            case .requestErr(let msg):
+                if let message = msg as? String {
+                    print(message)
+                }
+                self.activityIndicator.stopAnimating()
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+            default:
+                self.activityIndicator.stopAnimating()
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+            }
+        }
+    }
+    
+    /// 1:1질문, 전체 질문 질문 댓글 삭제 API 요청 메서드
+    private func requestDeletePostComment(commentID: Int, indexPath: [IndexPath]) {
+        self.activityIndicator.startAnimating()
+        ClassroomAPI.shared.deletePostCommentAPI(commentID: commentID) { networkResult in
+            switch networkResult {
+            case .success(_):
+                self.questionChatData.remove(at: indexPath.first!.row)
+                self.defaultQuestionChatTV.performBatchUpdates {
+                    self.defaultQuestionChatTV.deleteRows(at: indexPath, with: .fade)
+                } completion: { (done) in
+                    let indexPathsToUpdate = (0...self.defaultQuestionChatTV.numberOfRows(inSection: 0)).map { IndexPath(row: $0, section: 0) }
+                    self.defaultQuestionChatTV.reloadRows(at: indexPathsToUpdate, with: .none)
+                }
+                self.activityIndicator.stopAnimating()
             case .requestErr(let msg):
                 if let message = msg as? String {
                     print(message)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -703,6 +703,7 @@ extension DefaultQuestionChatVC {
                 if let _ = res as? AddCommentData {
                     DispatchQueue.main.async {
                         self.requestGetDetailQuestionData(postID: postID)
+                        self.isTextViewEmpty = true
                         self.activityIndicator.stopAnimating()
                     }
                 }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #220

## 🍎 변경 사항 및 이유
- 네트워크 관련 함수 private화 해주었습니다.

## 🍎 PR Point
- 정보 상세글 진입시 글쓴이 / 타인 분기처리를 통해 글쓴이일 때 상단 네비바 우측 더보기 버튼을 통해 정보글 원글을 수정, 삭제할 수 있는 권한을 부여했습니다.
- 정보 원글 수정,삭제 API는 질문과 동일해서 따로 service, api는 만들어주지 않았습니다 ~!

## 📸 ScreenShot
[정보 원글 수정]
<img width=375 src="https://user-images.githubusercontent.com/63224278/155763535-f45778d1-5d05-4913-af24-f9bf3d917557.gif">

[정보 원글 삭제]
<img width=375 src="https://user-images.githubusercontent.com/63224278/155763575-45100129-af0d-4e4f-8698-a0b9870514ed.gif">
