### PR TITLE
✨ [FEAT] 과방 정보글 댓글 삭제 기능 구현

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
@@ -347,7 +347,7 @@ extension InfoDetailVC {
 extension InfoDetailVC {
     
     /// 정보글 상세 조회 API 요청 메서드
-    func requestGetDetailInfoData(postID: Int, addLoadBackView: Bool) {
+    private func requestGetDetailInfoData(postID: Int, addLoadBackView: Bool) {
         addLoadBackView ? self.configureWhiteBackView() : nil
         self.activityIndicator.startAnimating()
         ClassroomAPI.shared.getInfoDetailAPI(postID: postID) { networkResult in
@@ -381,7 +381,7 @@ extension InfoDetailVC {
     }
     
     /// 정보글에 댓글 등록 API 요청 메서드
-    func requestCreateComment(postID: Int, comment: String) {
+    private func requestCreateComment(postID: Int, comment: String) {
         self.activityIndicator.startAnimating()
         ClassroomAPI.shared.createCommentAPI(postID: postID, comment: comment) { networkResult in
             switch networkResult {
@@ -407,7 +407,7 @@ extension InfoDetailVC {
     }
     
     /// 좋아요 API 요청 메서드
-    func requestPostLikeData(postID: Int, postTypeID: QuestionType) {
+    private func requestPostLikeData(postID: Int, postTypeID: QuestionType) {
         self.activityIndicator.startAnimating()
         ClassroomAPI.shared.postClassroomLikeAPI(postID: postID, postTypeID: postTypeID.rawValue) { networkResult in
             switch networkResult {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
@@ -389,6 +389,7 @@ extension InfoDetailVC {
                 if let _ = res as? AddCommentData {
                     DispatchQueue.main.async {
                         self.requestGetDetailInfoData(postID: postID, addLoadBackView: false)
+                        self.isTextViewEmpty = true
                         self.activityIndicator.stopAnimating()
                     }
                 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
@@ -134,10 +134,11 @@ extension InfoDetailVC {
                 }, secondOkAction: { _ in
                     self.makeNadoDeleteAlert(qnaType: .question, commentID: 0, indexPath: [[]])
                 })
+            } else {
+                self.makeAlertWithCancel(okTitle: "신고", okAction: { _ in
+                    // TODO: 추후에 신고 기능 추가 예정
+                })
             }
-            self.makeAlertWithCancel(okTitle: "신고", okAction: { _ in
-                // TODO: 추후에 신고 기능 추가 예정
-            })
         }
     }
     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
@@ -59,6 +59,7 @@ class InfoDetailVC: BaseVC {
     private var isCommentSend: Bool = false
     private var isTextViewEmpty: Bool = true
     private var sendTextViewLineCount: Int = 1
+    private var isWriter: Bool?
     private let textViewMaxHeight: CGFloat = 85.adjustedH
     private let whiteBackView = UIView()
     
@@ -126,9 +127,15 @@ extension InfoDetailVC {
             self.navigationController?.popViewController(animated: true)
         }
         infoDetailNaviBar.rightCustomBtn.press {
-            // TODO: 추후에 권한 분기처리 예정
+            if self.isWriter == true {
+                self.makeTwoAlertWithCancel(okTitle: "수정", secondOkTitle: "삭제", okAction: { _ in
+                    self.presentWriteQuestionVC()
+                }, secondOkAction: { _ in
+                    
+                })
+            }
             self.makeAlertWithCancel(okTitle: "신고", okAction: { _ in
-                // TODO: 추후에 기능 추가 예정
+                // TODO: 추후에 신고 기능 추가 예정
             })
         }
     }
@@ -186,6 +193,21 @@ extension InfoDetailVC {
         commentTextView.text = "답글쓰기"
         commentTextView.textColor = .gray2
         commentTextView.backgroundColor = .gray0
+    }
+    
+    /// 정보글 원글을 수정하기 위해 WriteQuestionVC로 화면전환하는 메서드
+    private func presentWriteQuestionVC() {
+        let writeQuestionSB: UIStoryboard = UIStoryboard(name: Identifiers.WriteQusetionSB, bundle: nil)
+        guard let editPostVC = writeQuestionSB.instantiateViewController(identifier: WriteQuestionVC.className) as? WriteQuestionVC else { return }
+        
+        editPostVC.questionType = .info
+        editPostVC.isEditState = true
+        editPostVC.postID = self.postID
+        editPostVC.originTitle = self.infoDetailData?.post.title
+        editPostVC.originContent = self.infoDetailData?.post.content
+        editPostVC.modalPresentationStyle = .fullScreen
+        
+        self.present(editPostVC, animated: true, completion: nil)
     }
 }
 
@@ -335,6 +357,8 @@ extension InfoDetailVC {
                     self.infoDetailData = data
                     self.infoDetailCommentData = data.commentList
                     self.userID = UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID)
+                    self.isWriter = (self.userID == self.infoDetailData?.writer.writerID) ? true : false
+                    
                     DispatchQueue.main.async {
                         self.infoDetailTV.reloadData()
                         self.setUpSendBtnEnabledState()

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
@@ -317,7 +317,9 @@ extension InfoDetailVC: UITextViewDelegate {
     
     /// textViewDidEndEditing
     func textViewDidEndEditing(_ textView: UITextView) {
-        isTextViewEmpty = textView.text.isEmpty ? true : false
+        if textView.text.isEmpty {
+            isTextViewEmpty = true
+        }
         setUpSendBtnEnabledState()
         configueTextViewPlaceholder()
     }
@@ -409,8 +411,8 @@ extension InfoDetailVC {
             case .success(let res):
                 if let _ = res as? AddCommentData {
                     DispatchQueue.main.async {
-                        self.requestGetDetailInfoData(postID: postID, addLoadBackView: false)
                         self.isTextViewEmpty = true
+                        self.requestGetDetailInfoData(postID: postID, addLoadBackView: false)
                         self.activityIndicator.stopAnimating()
                     }
                 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -340,8 +340,6 @@ extension DefaultQuestionChatVC {
         ]
         
         alert.showNadoAlert(vc: self, message: (qnaType == .question ? alertMsgdict[.question] : alertMsgdict[.comment]) ?? "", confirmBtnTitle: "네", cancelBtnTitle: "아니요")
-        
-        // TODO: 추후에 답변 삭제 함수 추가 후 nil부분 답변 삭제 함수로 변경 예정
         alert.confirmBtn.press(vibrate: true, for: .touchUpInside) {
             qnaType == .question ? self.requestDeletePostQuestion(postID: self.postID ?? 0) : self.requestDeletePostComment(commentID: commentID, indexPath: indexPath)
         }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #222

## 🍎 PR Point
- 사용자 분기처리를 통해 `userID`와 특정 댓글의 `wirterID`가 같을 경우에 `삭제` 권한을, 다를 경우엔 `신고` 권한을 부여했습니다.
- 과방 정보글 댓글 삭제 기능을 구현했습니다.
- 특정 cell만 삭제하는 모션이 자연스럽지 않고, 댓글 개수도 같이 업데이트되어야하기 때문에 정보글 상세조회 API를 재호출해주었습니다.

**📌 풀리퀘 머지가 되지 않아 전 브랜치에서 따서 작업한 브랜치이기 때문에 커밋 기록이 남아있습니다! `이슈번호 #222` 커밋만 봐주세용!!

## 📸 ScreenShot
[댓글 삭제]
<img width=375 src="https://user-images.githubusercontent.com/63224278/155771839-9f579e4e-9570-40fa-a8f2-bbfb9d7c97f9.gif">