### PR TITLE
✨ [FEAT] 마이페이지 설정 뷰/플로우 구현

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
@@ -228,6 +228,8 @@
 		C7ACE63227CB73F80011B23F /* SettingTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ACE63127CB73F80011B23F /* SettingTVC.swift */; };
 		C7ACE63427CBD3130011B23F /* SettingAppInfoVC.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C7ACE63327CBD3130011B23F /* SettingAppInfoVC.storyboard */; };
 		C7ACE63627CBD3280011B23F /* SettingAppInfoVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ACE63527CBD3280011B23F /* SettingAppInfoVC.swift */; };
+		C7ACE63827CBD8450011B23F /* SettingVersionTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ACE63727CBD8450011B23F /* SettingVersionTVC.swift */; };
+		C7ACE63A27CBDF550011B23F /* SettingTVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = C7ACE63927CBDF550011B23F /* SettingTVC.xib */; };
 		C7C4144927C9392000296C30 /* MypageSettingAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4144827C9392000296C30 /* MypageSettingAPI.swift */; };
 		C7C4144B27C9392F00296C30 /* MypageSettingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4144A27C9392F00296C30 /* MypageSettingService.swift */; };
 		C7C4144E27C939EE00296C30 /* EditProfileRequestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4144D27C939ED00296C30 /* EditProfileRequestModel.swift */; };
@@ -460,6 +462,9 @@
 		C7ACE63127CB73F80011B23F /* SettingTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTVC.swift; sourceTree = "<group>"; };
 		C7ACE63327CBD3130011B23F /* SettingAppInfoVC.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SettingAppInfoVC.storyboard; sourceTree = "<group>"; };
 		C7ACE63527CBD3280011B23F /* SettingAppInfoVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingAppInfoVC.swift; sourceTree = "<group>"; };
+		C7ACE63727CBD8450011B23F /* SettingVersionTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingVersionTVC.swift; sourceTree = "<group>"; };
+		C7ACE63927CBDF550011B23F /* SettingTVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingTVC.xib; sourceTree = "<group>"; };
+		C7ACE63B27CBDF9B0011B23F /* SettingVersionTVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingVersionTVC.xib; sourceTree = "<group>"; };
 		C7C4144827C9392000296C30 /* MypageSettingAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageSettingAPI.swift; sourceTree = "<group>"; };
 		C7C4144A27C9392F00296C30 /* MypageSettingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageSettingService.swift; sourceTree = "<group>"; };
 		C7C4144D27C939ED00296C30 /* EditProfileRequestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileRequestModel.swift; sourceTree = "<group>"; };
@@ -1488,6 +1493,9 @@
 			isa = PBXGroup;
 			children = (
 				C7ACE63127CB73F80011B23F /* SettingTVC.swift */,
+				C7ACE63927CBDF550011B23F /* SettingTVC.xib */,
+				C7ACE63B27CBDF9B0011B23F /* SettingVersionTVC.xib */,
+				C7ACE63727CBD8450011B23F /* SettingVersionTVC.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -1615,6 +1623,7 @@
 				5C54CECD278DF6120054136D /* SignUpCompleteVC.storyboard in Resources */,
 				C7ACE62D27CB71EA0011B23F /* SettingVC.storyboard in Resources */,
 				5CA7337B278A91BE00806B17 /* NadoAlertVC.xib in Resources */,
+				C7ACE63A27CBDF550011B23F /* SettingTVC.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1816,6 +1825,7 @@
 				777ABF7C278C844E002D3214 /* ReviewMainLinkTVC.swift in Sources */,
 				3313642C2784D3BD00E0C118 /* SceneDelegate.swift in Sources */,
 				5C49669327BD469200983689 /* AutoSignInVC.swift in Sources */,
+				C7ACE63827CBD8450011B23F /* SettingVersionTVC.swift in Sources */,
 				5CD4213D2790865A00D09DEE /* MypageNVC.swift in Sources */,
 				33B9B0DE27B8EB6700066C1F /* InfoCommentHeaderTVC.swift in Sources */,
 				3313645C2785A9F100E0C118 /* UITextField+.swift in Sources */,

--- a/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
@@ -223,6 +223,9 @@
 		77ED045527B19DBD00D077CA /* ReviewFilterInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77ED045427B19DBD00D077CA /* ReviewFilterInfo.swift */; };
 		C740A85927C7C55D00C4518A /* EditProfileVC.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C740A85827C7C55D00C4518A /* EditProfileVC.storyboard */; };
 		C740A85B27C7C58500C4518A /* EditProfileVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C740A85A27C7C58500C4518A /* EditProfileVC.swift */; };
+		C7ACE62D27CB71EA0011B23F /* SettingVC.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C7ACE62C27CB71EA0011B23F /* SettingVC.storyboard */; };
+		C7ACE62F27CB71FA0011B23F /* SettingVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ACE62E27CB71FA0011B23F /* SettingVC.swift */; };
+		C7ACE63227CB73F80011B23F /* SettingTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ACE63127CB73F80011B23F /* SettingTVC.swift */; };
 		C7C4144927C9392000296C30 /* MypageSettingAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4144827C9392000296C30 /* MypageSettingAPI.swift */; };
 		C7C4144B27C9392F00296C30 /* MypageSettingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4144A27C9392F00296C30 /* MypageSettingService.swift */; };
 		C7C4144E27C939EE00296C30 /* EditProfileRequestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4144D27C939ED00296C30 /* EditProfileRequestModel.swift */; };
@@ -450,6 +453,9 @@
 		A5D97E760E2CD0C8A8594D99 /* Pods-NadoSunbae-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NadoSunbae-iOS.release.xcconfig"; path = "Target Support Files/Pods-NadoSunbae-iOS/Pods-NadoSunbae-iOS.release.xcconfig"; sourceTree = "<group>"; };
 		C740A85827C7C55D00C4518A /* EditProfileVC.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = EditProfileVC.storyboard; sourceTree = "<group>"; };
 		C740A85A27C7C58500C4518A /* EditProfileVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileVC.swift; sourceTree = "<group>"; };
+		C7ACE62C27CB71EA0011B23F /* SettingVC.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SettingVC.storyboard; sourceTree = "<group>"; };
+		C7ACE62E27CB71FA0011B23F /* SettingVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingVC.swift; sourceTree = "<group>"; };
+		C7ACE63127CB73F80011B23F /* SettingTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTVC.swift; sourceTree = "<group>"; };
 		C7C4144827C9392000296C30 /* MypageSettingAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageSettingAPI.swift; sourceTree = "<group>"; };
 		C7C4144A27C9392F00296C30 /* MypageSettingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageSettingService.swift; sourceTree = "<group>"; };
 		C7C4144D27C939ED00296C30 /* EditProfileRequestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileRequestModel.swift; sourceTree = "<group>"; };
@@ -755,6 +761,7 @@
 		331364982785D84600E0C118 /* Mypage */ = {
 			isa = PBXGroup;
 			children = (
+				C7ACE62927CA9EC70011B23F /* Setting */,
 				C740A85527C7C50C00C4518A /* ProfileSetting */,
 				5CD4213B2790863100D09DEE /* MypageNVC */,
 				5CD4213327907E4900D09DEE /* MypageUser */,
@@ -1445,6 +1452,40 @@
 			path = SB;
 			sourceTree = "<group>";
 		};
+		C7ACE62927CA9EC70011B23F /* Setting */ = {
+			isa = PBXGroup;
+			children = (
+				C7ACE63027CB73E10011B23F /* Cell */,
+				C7ACE62B27CB6F870011B23F /* VC */,
+				C7ACE62A27CB6F800011B23F /* SB */,
+			);
+			path = Setting;
+			sourceTree = "<group>";
+		};
+		C7ACE62A27CB6F800011B23F /* SB */ = {
+			isa = PBXGroup;
+			children = (
+				C7ACE62C27CB71EA0011B23F /* SettingVC.storyboard */,
+			);
+			path = SB;
+			sourceTree = "<group>";
+		};
+		C7ACE62B27CB6F870011B23F /* VC */ = {
+			isa = PBXGroup;
+			children = (
+				C7ACE62E27CB71FA0011B23F /* SettingVC.swift */,
+			);
+			path = VC;
+			sourceTree = "<group>";
+		};
+		C7ACE63027CB73E10011B23F /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				C7ACE63127CB73F80011B23F /* SettingTVC.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
 		C7C4144C27C939BF00296C30 /* MypageSetting */ = {
 			isa = PBXGroup;
 			children = (
@@ -1565,6 +1606,7 @@
 				77AEEB462789AF380016880B /* MajorTVC.xib in Resources */,
 				33FA751427931AA800E43523 /* ClassroomSB.storyboard in Resources */,
 				5C54CECD278DF6120054136D /* SignUpCompleteVC.storyboard in Resources */,
+				C7ACE62D27CB71EA0011B23F /* SettingVC.storyboard in Resources */,
 				5CA7337B278A91BE00806B17 /* NadoAlertVC.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1619,6 +1661,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5C3280182797217E00781EBE /* MypageService.swift in Sources */,
+				C7ACE62F27CB71FA0011B23F /* SettingVC.swift in Sources */,
 				5CA73379278A8F4900806B17 /* NadoAlertVC.swift in Sources */,
 				5CC0BFD42798621600B96905 /* NotificationDataModel.swift in Sources */,
 				77AEEB442789AF380016880B /* HalfModalVC.swift in Sources */,
@@ -1779,6 +1822,7 @@
 				77A7593327984A7100A8E48B /* MajorInfoModel.swift in Sources */,
 				33CF635E2794877800E92C04 /* QuestionTVC.swift in Sources */,
 				C740A85B27C7C58500C4518A /* EditProfileVC.swift in Sources */,
+				C7ACE63227CB73F80011B23F /* SettingTVC.swift in Sources */,
 				33BAFD00278C004700BFF6BE /* ClassroomCommentTVC.swift in Sources */,
 				330DA4352790C3E300FE127F /* UIScrollView+.swift in Sources */,
 				7754A32327947F310093C230 /* ReviewDetailVC.swift in Sources */,

--- a/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
@@ -230,6 +230,8 @@
 		C7ACE63627CBD3280011B23F /* SettingAppInfoVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ACE63527CBD3280011B23F /* SettingAppInfoVC.swift */; };
 		C7ACE63827CBD8450011B23F /* SettingVersionTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ACE63727CBD8450011B23F /* SettingVersionTVC.swift */; };
 		C7ACE63A27CBDF550011B23F /* SettingTVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = C7ACE63927CBDF550011B23F /* SettingTVC.xib */; };
+		C7ACE63D27CBEAB70011B23F /* GetLatestVersionResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ACE63C27CBEAB70011B23F /* GetLatestVersionResponseModel.swift */; };
+		C7ACE63E27CBED1E0011B23F /* SettingVersionTVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = C7ACE63B27CBDF9B0011B23F /* SettingVersionTVC.xib */; };
 		C7C4144927C9392000296C30 /* MypageSettingAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4144827C9392000296C30 /* MypageSettingAPI.swift */; };
 		C7C4144B27C9392F00296C30 /* MypageSettingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4144A27C9392F00296C30 /* MypageSettingService.swift */; };
 		C7C4144E27C939EE00296C30 /* EditProfileRequestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4144D27C939ED00296C30 /* EditProfileRequestModel.swift */; };
@@ -465,6 +467,7 @@
 		C7ACE63727CBD8450011B23F /* SettingVersionTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingVersionTVC.swift; sourceTree = "<group>"; };
 		C7ACE63927CBDF550011B23F /* SettingTVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingTVC.xib; sourceTree = "<group>"; };
 		C7ACE63B27CBDF9B0011B23F /* SettingVersionTVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingVersionTVC.xib; sourceTree = "<group>"; };
+		C7ACE63C27CBEAB70011B23F /* GetLatestVersionResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetLatestVersionResponseModel.swift; sourceTree = "<group>"; };
 		C7C4144827C9392000296C30 /* MypageSettingAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageSettingAPI.swift; sourceTree = "<group>"; };
 		C7C4144A27C9392F00296C30 /* MypageSettingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageSettingService.swift; sourceTree = "<group>"; };
 		C7C4144D27C939ED00296C30 /* EditProfileRequestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileRequestModel.swift; sourceTree = "<group>"; };
@@ -1505,6 +1508,7 @@
 			children = (
 				C7C4144D27C939ED00296C30 /* EditProfileRequestModel.swift */,
 				C7C4144F27C93C4700296C30 /* EditProfileResponseModel.swift */,
+				C7ACE63C27CBEAB70011B23F /* GetLatestVersionResponseModel.swift */,
 			);
 			path = MypageSetting;
 			sourceTree = "<group>";
@@ -1608,6 +1612,7 @@
 				5C70A4FB27BA4C300096B20A /* MypagePostListVC.storyboard in Resources */,
 				33CF635227945C0900E92C04 /* NadoHorizonContainerViews.xib in Resources */,
 				334D2E0427914C8800A4CA23 /* WriteQuestionSB.storyboard in Resources */,
+				C7ACE63E27CBED1E0011B23F /* SettingVersionTVC.xib in Resources */,
 				5CB6502D27944415007694B1 /* GoogleService-Info.plist in Resources */,
 				5C3280152796F2B700781EBE /* MypageSB.storyboard in Resources */,
 				33BAFD01278C004700BFF6BE /* ClassroomCommentTVC.xib in Resources */,
@@ -1801,6 +1806,7 @@
 				777ABF74278C7947002D3214 /* ReviewMainImgTVC.swift in Sources */,
 				5C49668F27BB5C0D00983689 /* MypageMyPostListVC.swift in Sources */,
 				77AEEB4D2789AF900016880B /* TVRegisterable.swift in Sources */,
+				C7ACE63D27CBEAB70011B23F /* GetLatestVersionResponseModel.swift in Sources */,
 				33CF635827945DE300E92C04 /* QuestionMainVC.swift in Sources */,
 				5C9A93F727A64B550097310B /* SignUpBodyModel.swift in Sources */,
 				5C873A4B279978650050EE43 /* SignInDataModel.swift in Sources */,

--- a/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
@@ -226,6 +226,8 @@
 		C7ACE62D27CB71EA0011B23F /* SettingVC.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C7ACE62C27CB71EA0011B23F /* SettingVC.storyboard */; };
 		C7ACE62F27CB71FA0011B23F /* SettingVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ACE62E27CB71FA0011B23F /* SettingVC.swift */; };
 		C7ACE63227CB73F80011B23F /* SettingTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ACE63127CB73F80011B23F /* SettingTVC.swift */; };
+		C7ACE63427CBD3130011B23F /* SettingAppInfoVC.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C7ACE63327CBD3130011B23F /* SettingAppInfoVC.storyboard */; };
+		C7ACE63627CBD3280011B23F /* SettingAppInfoVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7ACE63527CBD3280011B23F /* SettingAppInfoVC.swift */; };
 		C7C4144927C9392000296C30 /* MypageSettingAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4144827C9392000296C30 /* MypageSettingAPI.swift */; };
 		C7C4144B27C9392F00296C30 /* MypageSettingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4144A27C9392F00296C30 /* MypageSettingService.swift */; };
 		C7C4144E27C939EE00296C30 /* EditProfileRequestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4144D27C939ED00296C30 /* EditProfileRequestModel.swift */; };
@@ -456,6 +458,8 @@
 		C7ACE62C27CB71EA0011B23F /* SettingVC.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SettingVC.storyboard; sourceTree = "<group>"; };
 		C7ACE62E27CB71FA0011B23F /* SettingVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingVC.swift; sourceTree = "<group>"; };
 		C7ACE63127CB73F80011B23F /* SettingTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTVC.swift; sourceTree = "<group>"; };
+		C7ACE63327CBD3130011B23F /* SettingAppInfoVC.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SettingAppInfoVC.storyboard; sourceTree = "<group>"; };
+		C7ACE63527CBD3280011B23F /* SettingAppInfoVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingAppInfoVC.swift; sourceTree = "<group>"; };
 		C7C4144827C9392000296C30 /* MypageSettingAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageSettingAPI.swift; sourceTree = "<group>"; };
 		C7C4144A27C9392F00296C30 /* MypageSettingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageSettingService.swift; sourceTree = "<group>"; };
 		C7C4144D27C939ED00296C30 /* EditProfileRequestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileRequestModel.swift; sourceTree = "<group>"; };
@@ -1466,6 +1470,7 @@
 			isa = PBXGroup;
 			children = (
 				C7ACE62C27CB71EA0011B23F /* SettingVC.storyboard */,
+				C7ACE63327CBD3130011B23F /* SettingAppInfoVC.storyboard */,
 			);
 			path = SB;
 			sourceTree = "<group>";
@@ -1474,6 +1479,7 @@
 			isa = PBXGroup;
 			children = (
 				C7ACE62E27CB71FA0011B23F /* SettingVC.swift */,
+				C7ACE63527CBD3280011B23F /* SettingAppInfoVC.swift */,
 			);
 			path = VC;
 			sourceTree = "<group>";
@@ -1587,6 +1593,7 @@
 				5C4ED92A278949AC001EA6BB /* SignInSB.storyboard in Resources */,
 				331364822785D60F00E0C118 /* Pretendard-Light.otf in Resources */,
 				7754A3142790182A0093C230 /* ReviewWriteSB.storyboard in Resources */,
+				C7ACE63427CBD3130011B23F /* SettingAppInfoVC.storyboard in Resources */,
 				7754A32127947D990093C230 /* ReviewDetailSB.storyboard in Resources */,
 				3391E498278B7AC50079EA31 /* ClassroomQuestionTVC.xib in Resources */,
 				33CF635C279464FD00E92C04 /* InfoSB.storyboard in Resources */,
@@ -1779,6 +1786,7 @@
 				331364702785B18100E0C118 /* UserDefaults+.swift in Sources */,
 				33CF634F27945C0400E92C04 /* NadoSegmentView.swift in Sources */,
 				33BE2D6A2789D605000FB6C8 /* NadoSunbaeBtn.swift in Sources */,
+				C7ACE63627CBD3280011B23F /* SettingAppInfoVC.swift in Sources */,
 				5C32801A2797284800781EBE /* MypageUserInfoModel.swift in Sources */,
 				331364C3278623C800E0C118 /* NetworkLoggerPlugin.swift in Sources */,
 				777ABF74278C7947002D3214 /* ReviewMainImgTVC.swift in Sources */,

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Mypage/MypageSetting/GetLatestVersionResponseModel.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Mypage/MypageSetting/GetLatestVersionResponseModel.swift
@@ -1,0 +1,12 @@
+//
+//  GetLatestVersionResponseModel.swift
+//  NadoSunbae-iOS
+//
+//  Created by madilyn on 2022/02/28.
+//
+
+import Foundation
+
+struct GetLatestVersionResponseModel: Codable {
+    var AOS, iOS: String
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/MypageSettingService.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/MypageSettingService.swift
@@ -10,6 +10,7 @@ import Moya
 
 enum MypageSettingService {
     case editProfile(data: EditProfileRequestModel)
+    case getLatestVersion
 }
 
 extension MypageSettingService: TargetType {
@@ -21,6 +22,8 @@ extension MypageSettingService: TargetType {
         switch self {
         case .editProfile:
             return "/user/mypage"
+        case .getLatestVersion:
+            return "/user/mypage/app-version/recent"
         }
     }
     
@@ -28,6 +31,8 @@ extension MypageSettingService: TargetType {
         switch self {
         case .editProfile:
             return .put
+        case .getLatestVersion:
+            return .get
         }
     }
     
@@ -42,6 +47,8 @@ extension MypageSettingService: TargetType {
                 "secondMajorStart": data.secondMajorStart,
                 "isOnQuestion": data.isOnQuestion
             ], encoding: JSONEncoding.default)
+        case .getLatestVersion:
+            return .requestPlain
         }
     }
     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/MypageMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/MypageMainVC.swift
@@ -55,7 +55,8 @@ class MypageMainVC: BaseVC {
     }
     
     @IBAction func tapSettingBtn(_ sender: Any) {
-        /// 4순위댱
+        guard let settingVC = UIStoryboard.init(name: SettingVC.className, bundle: nil).instantiateViewController(withIdentifier: SettingVC.className) as? SettingVC else { return }
+        self.navigationController?.pushViewController(settingVC, animated: true)
     }
     
     @IBAction func tapLikeListBtn(_ sender: Any) {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/Cell/SettingTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/Cell/SettingTVC.swift
@@ -1,0 +1,27 @@
+//
+//  SettingTVC.swift
+//  NadoSunbae-iOS
+//
+//  Created by madilyn on 2022/02/27.
+//
+
+import UIKit
+
+class SettingTVC: BaseTVC {
+    
+    // MARK: @IBOutlet
+    @IBOutlet weak var titleLabel: UILabel!
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+    }
+    
+    // MARK: Custom Methods
+    func setTitle(title: String) {
+        titleLabel.text = title
+    }
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/Cell/SettingTVC.xib
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/Cell/SettingTVC.xib
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <customFonts key="customFonts">
+        <array key="Pretendard-Regular.otf">
+            <string>Pretendard-Regular</string>
+        </array>
+    </customFonts>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SettingTVC" rowHeight="54" id="QeB-vq-dux" customClass="SettingTVC" customModule="NadoSunbae_iOS" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="54"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="QeB-vq-dux" id="fi3-uR-563">
+                <rect key="frame" x="0.0" y="0.0" width="375" height="54"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xra-72-IdV">
+                        <rect key="frame" x="20" y="17" width="39" height="20"/>
+                        <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="16"/>
+                        <color key="textColor" name="mainText"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="btn_arrow" translatesAutoresizingMaskIntoConstraints="NO" id="2JB-J1-jXt">
+                        <rect key="frame" x="319" y="3" width="48" height="48"/>
+                        <constraints>
+                            <constraint firstAttribute="width" secondItem="2JB-J1-jXt" secondAttribute="height" multiplier="1:1" id="dDR-EG-jh5"/>
+                        </constraints>
+                    </imageView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="2JB-J1-jXt" firstAttribute="centerY" secondItem="fi3-uR-563" secondAttribute="centerY" id="RBd-oA-DuP"/>
+                    <constraint firstItem="xra-72-IdV" firstAttribute="centerY" secondItem="fi3-uR-563" secondAttribute="centerY" id="RMU-4g-TaR"/>
+                    <constraint firstAttribute="trailing" secondItem="2JB-J1-jXt" secondAttribute="trailing" constant="8" id="avx-pq-W0a"/>
+                    <constraint firstItem="2JB-J1-jXt" firstAttribute="width" secondItem="fi3-uR-563" secondAttribute="width" multiplier="0.128" id="khU-nz-sdG"/>
+                    <constraint firstItem="xra-72-IdV" firstAttribute="leading" secondItem="fi3-uR-563" secondAttribute="leading" constant="20" id="uvb-Y3-AwJ"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="titleLabel" destination="xra-72-IdV" id="TFs-FV-8UO"/>
+            </connections>
+            <point key="canvasLocation" x="-114" y="82"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <image name="btn_arrow" width="48" height="48"/>
+        <namedColor name="mainText">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.23529411764705882" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/Cell/SettingVersionTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/Cell/SettingVersionTVC.swift
@@ -1,0 +1,29 @@
+//
+//  SettingVersionTVC.swift
+//  NadoSunbae-iOS
+//
+//  Created by madilyn on 2022/02/28.
+//
+
+import UIKit
+
+class SettingVersionTVC: BaseTVC {
+    
+    // MARK: @IBOutlet
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var versionLabel: UILabel!
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+    }
+    
+    // MARK: Custom Methods
+    func setData(title: String, version: String) {
+        titleLabel.text = title
+        versionLabel.text = "현재 1.0.0 / 최신 \(version)"
+    }
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/Cell/SettingVersionTVC.xib
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/Cell/SettingVersionTVC.xib
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <customFonts key="customFonts">
+        <array key="Pretendard-Regular.otf">
+            <string>Pretendard-Regular</string>
+        </array>
+    </customFonts>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SettingVersionTVC" rowHeight="54" id="Cbo-hc-Dk2" customClass="SettingVersionTVC" customModule="NadoSunbae_iOS" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="54"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Cbo-hc-Dk2" id="leu-86-Aaa">
+                <rect key="frame" x="0.0" y="0.0" width="375" height="54"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5nZ-l2-0u1">
+                        <rect key="frame" x="20" y="17" width="39" height="20"/>
+                        <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="16"/>
+                        <color key="textColor" name="mainText"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4aW-a6-IfO">
+                        <rect key="frame" x="320.5" y="18.5" width="34.5" height="17"/>
+                        <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="14"/>
+                        <color key="textColor" name="gray4"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailing" secondItem="4aW-a6-IfO" secondAttribute="trailing" constant="20" id="Ed8-zy-95v"/>
+                    <constraint firstItem="4aW-a6-IfO" firstAttribute="centerY" secondItem="leu-86-Aaa" secondAttribute="centerY" id="NdD-Ey-PGz"/>
+                    <constraint firstItem="5nZ-l2-0u1" firstAttribute="leading" secondItem="leu-86-Aaa" secondAttribute="leading" constant="20" id="byg-j2-DxS"/>
+                    <constraint firstItem="5nZ-l2-0u1" firstAttribute="centerY" secondItem="leu-86-Aaa" secondAttribute="centerY" id="tsY-Ye-YKw"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="titleLabel" destination="5nZ-l2-0u1" id="8MB-7k-Qud"/>
+                <outlet property="versionLabel" destination="4aW-a6-IfO" id="XHu-NM-dF1"/>
+            </connections>
+            <point key="canvasLocation" x="131" y="96"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <namedColor name="gray4">
+            <color red="0.33725490196078434" green="0.33725490196078434" blue="0.37254901960784315" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="mainText">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.23529411764705882" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/SB/SettingAppInfoVC.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/SB/SettingAppInfoVC.storyboard
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Setting App InfoVC-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="SettingAppInfoVC" id="Y6W-OH-hqX" customClass="SettingAppInfoVC" customModule="NadoSunbae_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6wm-Fa-bke" customClass="NadoSunbaeNaviBar" customModule="NadoSunbae_iOS" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="104"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="104" id="IPU-Eh-J0c"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="6wm-Fa-bke" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="UPz-8j-kBW"/>
+                            <constraint firstItem="6wm-Fa-bke" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="nnm-97-mvd"/>
+                            <constraint firstItem="6wm-Fa-bke" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" id="tU2-fY-k3M"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="navView" destination="6wm-Fa-bke" id="4jK-ph-8u9"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-16" y="81"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/SB/SettingAppInfoVC.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/SB/SettingAppInfoVC.storyboard
@@ -23,22 +23,34 @@
                                     <constraint firstAttribute="height" constant="104" id="IPU-Eh-J0c"/>
                                 </constraints>
                             </view>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="8OM-Sa-I08">
+                                <rect key="frame" x="0.0" y="104" width="375" height="300"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="300" id="Qmh-yV-usi"/>
+                                </constraints>
+                            </tableView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="8OM-Sa-I08" secondAttribute="trailing" id="1A7-Xu-Y08"/>
+                            <constraint firstItem="8OM-Sa-I08" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="Hj0-FO-dNa"/>
                             <constraint firstItem="6wm-Fa-bke" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="UPz-8j-kBW"/>
+                            <constraint firstItem="8OM-Sa-I08" firstAttribute="top" secondItem="6wm-Fa-bke" secondAttribute="bottom" id="dQO-dm-ALl"/>
                             <constraint firstItem="6wm-Fa-bke" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="nnm-97-mvd"/>
                             <constraint firstItem="6wm-Fa-bke" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" id="tU2-fY-k3M"/>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="appInfoTV" destination="8OM-Sa-I08" id="Cah-Mh-Z74"/>
+                        <outlet property="appInfoTVHeight" destination="Qmh-yV-usi" id="UqT-u1-QYu"/>
                         <outlet property="navView" destination="6wm-Fa-bke" id="4jK-ph-8u9"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-16" y="81"/>
+            <point key="canvasLocation" x="-16.800000000000001" y="80.541871921182263"/>
         </scene>
     </scenes>
     <resources>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/SB/SettingVC.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/SB/SettingVC.storyboard
@@ -35,6 +35,7 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="320" id="uEs-03-8OT"/>
                                 </constraints>
+                                <inset key="separatorInset" minX="16" minY="0.0" maxX="16" maxY="0.0"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SettingTVC" rowHeight="54" id="ASQ-7P-ds0" customClass="SettingTVC" customModule="NadoSunbae_iOS" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="44.666666030883789" width="375" height="54"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/SB/SettingVC.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/SB/SettingVC.storyboard
@@ -36,40 +36,6 @@
                                     <constraint firstAttribute="height" constant="320" id="uEs-03-8OT"/>
                                 </constraints>
                                 <inset key="separatorInset" minX="16" minY="0.0" maxX="16" maxY="0.0"/>
-                                <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SettingTVC" rowHeight="54" id="ASQ-7P-ds0" customClass="SettingTVC" customModule="NadoSunbae_iOS" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.666666030883789" width="375" height="54"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ASQ-7P-ds0" id="Qqg-rr-fKp">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="54"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8pf-7H-Aix">
-                                                    <rect key="frame" x="20" y="17" width="39" height="20"/>
-                                                    <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="16"/>
-                                                    <color key="textColor" name="mainText"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="btn_arrow" translatesAutoresizingMaskIntoConstraints="NO" id="ko7-R3-dji">
-                                                    <rect key="frame" x="319" y="3" width="48" height="48"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="width" secondItem="ko7-R3-dji" secondAttribute="height" multiplier="1:1" id="Rew-Xx-0v2"/>
-                                                    </constraints>
-                                                </imageView>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="ko7-R3-dji" firstAttribute="width" secondItem="Qqg-rr-fKp" secondAttribute="width" multiplier="0.128" id="Akg-cz-iuT"/>
-                                                <constraint firstItem="8pf-7H-Aix" firstAttribute="centerY" secondItem="Qqg-rr-fKp" secondAttribute="centerY" id="Hq6-3E-uW0"/>
-                                                <constraint firstItem="ko7-R3-dji" firstAttribute="centerY" secondItem="Qqg-rr-fKp" secondAttribute="centerY" id="XXU-NE-ygB"/>
-                                                <constraint firstItem="8pf-7H-Aix" firstAttribute="leading" secondItem="Qqg-rr-fKp" secondAttribute="leading" constant="20" id="b3m-WV-V0X"/>
-                                                <constraint firstAttribute="trailing" secondItem="ko7-R3-dji" secondAttribute="trailing" constant="8" id="vVq-mf-7Gy"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                        <connections>
-                                            <outlet property="titleLabel" destination="8pf-7H-Aix" id="0g2-jc-GT2"/>
-                                        </connections>
-                                    </tableViewCell>
-                                </prototypes>
                             </tableView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DJc-HG-40I">
                                 <rect key="frame" x="16" y="432" width="49" height="29"/>
@@ -134,12 +100,8 @@
         </scene>
     </scenes>
     <resources>
-        <image name="btn_arrow" width="48" height="48"/>
         <namedColor name="gray4">
             <color red="0.33725490196078434" green="0.33725490196078434" blue="0.37254901960784315" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-        <namedColor name="mainText">
-            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.23529411764705882" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/SB/SettingVC.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/SB/SettingVC.storyboard
@@ -86,6 +86,7 @@
                     <connections>
                         <outlet property="navView" destination="DjM-IW-1d3" id="ifV-z1-5To"/>
                         <outlet property="settingTV" destination="9u4-kQ-yIE" id="n2d-dv-edu"/>
+                        <outlet property="settingTVHeight" destination="uEs-03-8OT" id="QB5-B0-Vmj"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/SB/SettingVC.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/SB/SettingVC.storyboard
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <customFonts key="customFonts">
+        <array key="Pretendard-Regular.otf">
+            <string>Pretendard-Regular</string>
+        </array>
+    </customFonts>
+    <scenes>
+        <!--SettingVC-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="SettingVC" id="Y6W-OH-hqX" customClass="SettingVC" customModule="NadoSunbae_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DjM-IW-1d3" customClass="NadoSunbaeNaviBar" customModule="NadoSunbae_iOS" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="104"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="104" id="FSb-tc-eSz"/>
+                                </constraints>
+                            </view>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="9u4-kQ-yIE">
+                                <rect key="frame" x="0.0" y="104" width="375" height="320"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="320" id="uEs-03-8OT"/>
+                                </constraints>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SettingTVC" rowHeight="54" id="ASQ-7P-ds0" customClass="SettingTVC" customModule="NadoSunbae_iOS" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="44.666666030883789" width="375" height="54"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ASQ-7P-ds0" id="Qqg-rr-fKp">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="54"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8pf-7H-Aix">
+                                                    <rect key="frame" x="20" y="17" width="39" height="20"/>
+                                                    <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="16"/>
+                                                    <color key="textColor" name="mainText"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="btn_arrow" translatesAutoresizingMaskIntoConstraints="NO" id="ko7-R3-dji">
+                                                    <rect key="frame" x="319" y="3" width="48" height="48"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" secondItem="ko7-R3-dji" secondAttribute="height" multiplier="1:1" id="Rew-Xx-0v2"/>
+                                                    </constraints>
+                                                </imageView>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="ko7-R3-dji" firstAttribute="width" secondItem="Qqg-rr-fKp" secondAttribute="width" multiplier="0.128" id="Akg-cz-iuT"/>
+                                                <constraint firstItem="8pf-7H-Aix" firstAttribute="centerY" secondItem="Qqg-rr-fKp" secondAttribute="centerY" id="Hq6-3E-uW0"/>
+                                                <constraint firstItem="ko7-R3-dji" firstAttribute="centerY" secondItem="Qqg-rr-fKp" secondAttribute="centerY" id="XXU-NE-ygB"/>
+                                                <constraint firstItem="8pf-7H-Aix" firstAttribute="leading" secondItem="Qqg-rr-fKp" secondAttribute="leading" constant="20" id="b3m-WV-V0X"/>
+                                                <constraint firstAttribute="trailing" secondItem="ko7-R3-dji" secondAttribute="trailing" constant="8" id="vVq-mf-7Gy"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="titleLabel" destination="8pf-7H-Aix" id="0g2-jc-GT2"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="9u4-kQ-yIE" secondAttribute="trailing" id="3pA-MR-YNm"/>
+                            <constraint firstItem="DjM-IW-1d3" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="6JQ-FL-l0u"/>
+                            <constraint firstItem="DjM-IW-1d3" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="COh-go-dbB"/>
+                            <constraint firstItem="9u4-kQ-yIE" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="TLx-gF-vZ6"/>
+                            <constraint firstItem="9u4-kQ-yIE" firstAttribute="top" secondItem="DjM-IW-1d3" secondAttribute="bottom" id="Vfs-9W-Ifu"/>
+                            <constraint firstItem="DjM-IW-1d3" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" id="z0O-oT-pc7"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="navView" destination="DjM-IW-1d3" id="ifV-z1-5To"/>
+                        <outlet property="settingTV" destination="9u4-kQ-yIE" id="n2d-dv-edu"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-16.800000000000001" y="80.541871921182263"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="btn_arrow" width="48" height="48"/>
+        <namedColor name="mainText">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.23529411764705882" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/SB/SettingVC.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/SB/SettingVC.storyboard
@@ -71,6 +71,39 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DJc-HG-40I">
+                                <rect key="frame" x="16" y="432" width="49" height="29"/>
+                                <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="14"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title="로그아웃">
+                                    <color key="titleColor" name="gray4"/>
+                                </state>
+                                <connections>
+                                    <action selector="tapSignOutBtn:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="lQz-84-T91"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ts8-or-Q9q">
+                                <rect key="frame" x="16" y="461" width="30" height="29"/>
+                                <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="14"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title="탈퇴">
+                                    <color key="titleColor" name="gray4"/>
+                                </state>
+                                <connections>
+                                    <action selector="tapWithDrawBtn:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="RBY-L7-mzu"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Z7N-oH-hjd">
+                                <rect key="frame" x="16" y="490" width="65" height="29"/>
+                                <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="14"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title="서비스 문의">
+                                    <color key="titleColor" name="gray4"/>
+                                </state>
+                                <connections>
+                                    <action selector="tapServiceContactBtn:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="GLz-VU-7fc"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -78,8 +111,14 @@
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="9u4-kQ-yIE" secondAttribute="trailing" id="3pA-MR-YNm"/>
                             <constraint firstItem="DjM-IW-1d3" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="6JQ-FL-l0u"/>
                             <constraint firstItem="DjM-IW-1d3" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="COh-go-dbB"/>
+                            <constraint firstItem="DJc-HG-40I" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="GaW-Xf-ZyL"/>
                             <constraint firstItem="9u4-kQ-yIE" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="TLx-gF-vZ6"/>
                             <constraint firstItem="9u4-kQ-yIE" firstAttribute="top" secondItem="DjM-IW-1d3" secondAttribute="bottom" id="Vfs-9W-Ifu"/>
+                            <constraint firstItem="ts8-or-Q9q" firstAttribute="leading" secondItem="DJc-HG-40I" secondAttribute="leading" id="Vqu-0q-dDI"/>
+                            <constraint firstItem="Z7N-oH-hjd" firstAttribute="top" secondItem="ts8-or-Q9q" secondAttribute="bottom" id="etC-NU-k2j"/>
+                            <constraint firstItem="Z7N-oH-hjd" firstAttribute="leading" secondItem="DJc-HG-40I" secondAttribute="leading" id="h3Y-qg-AUQ"/>
+                            <constraint firstItem="ts8-or-Q9q" firstAttribute="top" secondItem="DJc-HG-40I" secondAttribute="bottom" id="mBN-ai-czG"/>
+                            <constraint firstItem="DJc-HG-40I" firstAttribute="top" secondItem="9u4-kQ-yIE" secondAttribute="bottom" constant="8" id="uNe-yB-Qb3"/>
                             <constraint firstItem="DjM-IW-1d3" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" id="z0O-oT-pc7"/>
                         </constraints>
                     </view>
@@ -96,6 +135,9 @@
     </scenes>
     <resources>
         <image name="btn_arrow" width="48" height="48"/>
+        <namedColor name="gray4">
+            <color red="0.33725490196078434" green="0.33725490196078434" blue="0.37254901960784315" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <namedColor name="mainText">
             <color red="0.23529411764705882" green="0.23529411764705882" blue="0.23529411764705882" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingAppInfoVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingAppInfoVC.swift
@@ -96,11 +96,11 @@ extension SettingAppInfoVC: UITableViewDelegate {
             
         /// 서비스 이용약관
         case 1:
-            break
+            presentSafariVC(link: "https://nadosunbae.notion.site/V-1-0-2022-3-1-d1d15e411b0b417198b2405468894dea")
             
         /// 오픈소스 라이선스
         case 2:
-            break
+            presentSafariVC(link: "https://nadosunbae.notion.site/V-1-0-2442b1af796041d09bc6e8729c172438")
             
         default:
             break

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingAppInfoVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingAppInfoVC.swift
@@ -19,16 +19,85 @@ class SettingAppInfoVC: BaseVC {
             }
         }
     }
+    @IBOutlet weak var appInfoTV: UITableView! {
+        didSet {
+            appInfoTV.dataSource = self
+            appInfoTV.delegate = self
+            appInfoTV.isScrollEnabled = false
+            appInfoTV.rowHeight = 63.adjustedH
+        }
+    }
+    @IBOutlet weak var appInfoTVHeight: NSLayoutConstraint! {
+        didSet {
+            appInfoTVHeight.constant = 256.adjustedH
+        }
+    }
+    
+    // MARK: Properties
+    let menuList = ["서비스 이용규칙", "서비스 이용약관", "오픈소스 라이선스", "버전 정보"]
+    var latestVersion = ""
     
     // MARK: Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        registerXIB()
+    }
+    
     
     // MARK: Custom Methods
     private func registerXIB() {
         SettingTVC.register(target: appInfoTV)
         SettingVersionTVC.register(target: appInfoTV)
     }
+}
+
+// MARK: - UITableViewDataSource
+extension SettingAppInfoVC: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return menuList.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        switch indexPath.row {
+        case 3:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: SettingVersionTVC.className, for: indexPath) as? SettingVersionTVC else { return UITableViewCell() }
+            cell.setData(title: menuList[indexPath.row], version: latestVersion)
+            
+            return cell
+        default:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: SettingTVC.className, for: indexPath) as? SettingTVC else { return UITableViewCell() }
+            cell.setTitle(title: menuList[indexPath.row])
+            
+            return cell
+        }
+    }
+}
+
+// MARK: - UITableViewDelegate
+extension SettingAppInfoVC: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        switch indexPath.row {
+        // TODO: 나머지 case들 뷰 구현되는 대로 추가
+            
+        /// 서비스 이용규칙
+        case 0:
+            break
+            
+        /// 서비스 이용약관
+        case 1:
+            break
+            
+        /// 오픈소스 라이선스
+        case 2:
+            break
+            
+        default:
+            break
+        }
         
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
+}
+
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingAppInfoVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingAppInfoVC.swift
@@ -1,0 +1,28 @@
+//
+//  SettingAppInfoVC.swift
+//  NadoSunbae-iOS
+//
+//  Created by madilyn on 2022/02/28.
+//
+
+import UIKit
+
+class SettingAppInfoVC: BaseVC {
+    
+    // MARK: @IBOutlet
+    @IBOutlet weak var navView: NadoSunbaeNaviBar! {
+        didSet {
+            navView.setUpNaviStyle(state: .backDefault)
+            navView.configureTitleLabel(title: "앱정보")
+            navView.backBtn.press {
+                self.navigationController?.popViewController(animated: true)
+            }
+        }
+    }
+    
+    // MARK: Life Cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+    }
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingAppInfoVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingAppInfoVC.swift
@@ -23,6 +23,12 @@ class SettingAppInfoVC: BaseVC {
     // MARK: Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+    
+    // MARK: Custom Methods
+    private func registerXIB() {
+        SettingTVC.register(target: appInfoTV)
+        SettingVersionTVC.register(target: appInfoTV)
+    }
         
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingAppInfoVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingAppInfoVC.swift
@@ -43,6 +43,10 @@ class SettingAppInfoVC: BaseVC {
         registerXIB()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        getLatestVersion()
+    }
     
     // MARK: Custom Methods
     private func registerXIB() {
@@ -99,5 +103,26 @@ extension SettingAppInfoVC: UITableViewDelegate {
     }
 }
 
+// MARK: - Network
+extension SettingAppInfoVC {
+    private func getLatestVersion() {
+        MypageSettingAPI.shared.getLatestVersion { networkResult in
+            switch networkResult {
+            case .success(let res):
+                if let response = res as? GetLatestVersionResponseModel {
+                    self.latestVersion = response.iOS
+                    self.appInfoTV.reloadRows(at: [IndexPath(row: 3, section: 0)], with: .none)
+                }
+            case .requestErr(let msg):
+                if let message = msg as? String {
+                    print("request err: ", message)
+                }
+                self.activityIndicator.stopAnimating()
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+            default:
+                self.activityIndicator.stopAnimating()
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+            }
+        }
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingAppInfoVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingAppInfoVC.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SafariServices
 
 class SettingAppInfoVC: BaseVC {
     
@@ -52,6 +53,12 @@ class SettingAppInfoVC: BaseVC {
     private func registerXIB() {
         SettingTVC.register(target: appInfoTV)
         SettingVersionTVC.register(target: appInfoTV)
+    }
+    
+    private func presentSafariVC(link: String) {
+        let webLink = NSURL(string: link)
+        let safariVC = SFSafariViewController(url: webLink! as URL)
+        self.present(safariVC, animated: true, completion: nil)
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
@@ -39,6 +39,7 @@ class SettingVC: BaseVC {
     // MARK: Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        registerXIB()
     }
     
     // MARK: @IBAction
@@ -55,6 +56,10 @@ class SettingVC: BaseVC {
     private func pushVC(vc: BaseVC) {
         guard let pushedVC = UIStoryboard.init(name: vc.className, bundle: nil).instantiateViewController(withIdentifier: vc.className) as? BaseVC else { return }
         self.navigationController?.pushViewController(pushedVC, animated: true)
+    }
+    
+    private func registerXIB() {
+        SettingTVC.register(target: settingTV)
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
@@ -14,12 +14,17 @@ class SettingVC: BaseVC {
         didSet {
             navView.setUpNaviStyle(state: .backDefault)
             navView.configureTitleLabel(title: "내 설정")
+            navView.backBtn.press {
+                self.navigationController?.popViewController(animated: true)
+            }
         }
     }
     @IBOutlet weak var settingTV: UITableView! {
         didSet {
             settingTV.dataSource = self
             settingTV.delegate = self
+            settingTV.isScrollEnabled = false
+            settingTV.rowHeight = 63.adjustedH
         }
     }
     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
@@ -1,0 +1,60 @@
+//
+//  SettingVC.swift
+//  NadoSunbae-iOS
+//
+//  Created by madilyn on 2022/02/27.
+//
+
+import UIKit
+
+class SettingVC: BaseVC {
+    
+    // MARK: @IBOutlet
+    @IBOutlet weak var navView: NadoSunbaeNaviBar! {
+    }
+    @IBOutlet weak var settingTV: UITableView! {
+        didSet {
+            settingTV.dataSource = self
+            settingTV.delegate = self
+        }
+    }
+    
+    // MARK: Properties
+    let menuList = ["프로필 수정", "비밀번호 변경", "알림 설정", "앱정보", "차단 사용자 목록"]
+    // MARK: Life Cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}
+
+// MARK: - UITableViewDataSource
+extension SettingVC: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return menuList.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: SettingTVC.className, for: indexPath) as? SettingTVC else { return UITableViewCell() }
+        cell.setTitle(title: menuList[indexPath.row])
+        
+        return cell
+    }
+}
+
+// MARK: - UITableViewDelegate
+extension SettingVC: UITableViewDelegate {
+//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+//        switch indexPath.row {
+//        case 0:
+//            guard let editProfileVC = UIStoryboard.init(name: EditProfileVC.className, bundle: nil).instantiateViewController(withIdentifier: EditProfileVC.className) as? EditProfileVC else { return }
+//            self.navigationController?.pushViewController(editProfileVC, animated: true)
+//        case 1:
+//        case 2:
+//        case 3:
+//        case 4:
+//        default:
+//            print("SettingVC TableView err")
+//            break
+//        }
+//    }
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
@@ -35,6 +35,7 @@ class SettingVC: BaseVC {
     
     // MARK: Properties
     let menuList = ["프로필 수정", "비밀번호 변경", "알림 설정", "앱정보", "차단 사용자 목록"]
+    
     // MARK: Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -63,18 +64,25 @@ extension SettingVC: UITableViewDataSource {
 
 // MARK: - UITableViewDelegate
 extension SettingVC: UITableViewDelegate {
-//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-//        switch indexPath.row {
-//        case 0:
-//            guard let editProfileVC = UIStoryboard.init(name: EditProfileVC.className, bundle: nil).instantiateViewController(withIdentifier: EditProfileVC.className) as? EditProfileVC else { return }
-//            self.navigationController?.pushViewController(editProfileVC, animated: true)
-//        case 1:
-//        case 2:
-//        case 3:
-//        case 4:
-//        default:
-//            print("SettingVC TableView err")
-//            break
-//        }
-//    }
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        switch indexPath.row {
+        // TODO: 나머지 case들 뷰 구현되는 대로 추가
+        case 0:
+            let editProfileVC = EditProfileVC()
+            pushVC(vc: editProfileVC)
+        case 1:
+            break
+        case 2:
+            break
+        case 3:
+            break
+        case 4:
+            break
+        default:
+            print("SettingVC TableView err")
+            break
+        }
+        
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
@@ -72,6 +72,9 @@ class SettingVC: BaseVC {
     }
     
     @IBAction func tapServiceContactBtn(_ sender: Any) {
+        if let url = URL(string: "http://pf.kakao.com/_pxcFib") {
+            UIApplication.shared.open(url, options: [:])
+        }
     }
     
     // MARK: Custom Methods

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
@@ -77,15 +77,26 @@ extension SettingVC: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         switch indexPath.row {
         // TODO: 나머지 case들 뷰 구현되는 대로 추가
+            
+        /// 프로필 수정
         case 0:
             let editProfileVC = EditProfileVC()
             pushVC(vc: editProfileVC)
+            
+        /// 비밀번호 변경
         case 1:
             break
+            
+        /// 알림 설정
         case 2:
             break
+            
+        /// 앱정보
         case 3:
-            break
+            let settingAppInfoVC = SettingAppInfoVC()
+            pushVC(vc: settingAppInfoVC)
+            
+        /// 차단 사용자 목록
         case 4:
             break
         default:

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
@@ -44,9 +44,31 @@ class SettingVC: BaseVC {
     
     // MARK: @IBAction
     @IBAction func tapSignOutBtn(_ sender: Any) {
+        guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+        
+        alert.cancelBtn.press {
+            alert.dismiss(animated: true, completion: nil)
+        }
+        
+        alert.confirmBtn.press {
+            self.requestSignOut()
+        }
+        
+        alert.showNadoAlert(vc: self, message: "로그아웃할래?(미정)", confirmBtnTitle: "네", cancelBtnTitle: "아니요")
     }
     
     @IBAction func tapWithDrawBtn(_ sender: Any) {
+        guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+        
+        alert.cancelBtn.press {
+            alert.dismiss(animated: true, completion: nil)
+        }
+        
+        alert.confirmBtn.press {
+            self.requestWithDraw()
+        }
+        
+        alert.showNadoAlert(vc: self, message: "탈퇴할래?(미정)", confirmBtnTitle: "네", cancelBtnTitle: "아니요")
     }
     
     @IBAction func tapServiceContactBtn(_ sender: Any) {
@@ -110,5 +132,16 @@ extension SettingVC: UITableViewDelegate {
         }
         
         tableView.deselectRow(at: indexPath, animated: true)
+    }
+}
+
+// MARK: - Network
+extension SettingVC {
+    private func requestSignOut() {
+        
+    }
+    
+    private func requestWithDraw() {
+        
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
@@ -39,6 +39,12 @@ class SettingVC: BaseVC {
     override func viewDidLoad() {
         super.viewDidLoad()
     }
+    
+    // MARK: Custom Methods
+    private func pushVC(vc: BaseVC) {
+        guard let pushedVC = UIStoryboard.init(name: vc.className, bundle: nil).instantiateViewController(withIdentifier: vc.className) as? BaseVC else { return }
+        self.navigationController?.pushViewController(pushedVC, animated: true)
+    }
 }
 
 // MARK: - UITableViewDataSource

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
@@ -41,6 +41,16 @@ class SettingVC: BaseVC {
         super.viewDidLoad()
     }
     
+    // MARK: @IBAction
+    @IBAction func tapSignOutBtn(_ sender: Any) {
+    }
+    
+    @IBAction func tapWithDrawBtn(_ sender: Any) {
+    }
+    
+    @IBAction func tapServiceContactBtn(_ sender: Any) {
+    }
+    
     // MARK: Custom Methods
     private func pushVC(vc: BaseVC) {
         guard let pushedVC = UIStoryboard.init(name: vc.className, bundle: nil).instantiateViewController(withIdentifier: vc.className) as? BaseVC else { return }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
@@ -27,6 +27,11 @@ class SettingVC: BaseVC {
             settingTV.rowHeight = 63.adjustedH
         }
     }
+    @IBOutlet weak var settingTVHeight: NSLayoutConstraint! {
+        didSet {
+            settingTVHeight.constant = 320.adjustedH
+        }
+    }
     
     // MARK: Properties
     let menuList = ["프로필 수정", "비밀번호 변경", "알림 설정", "앱정보", "차단 사용자 목록"]

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
@@ -11,6 +11,10 @@ class SettingVC: BaseVC {
     
     // MARK: @IBOutlet
     @IBOutlet weak var navView: NadoSunbaeNaviBar! {
+        didSet {
+            navView.setUpNaviStyle(state: .backDefault)
+            navView.configureTitleLabel(title: "내 설정")
+        }
     }
     @IBOutlet weak var settingTV: UITableView! {
         didSet {


### PR DESCRIPTION
## 🍎 관련 이슈
closed #168 

## 🍎 변경 사항 및 이유
* 마이페이지_설정~앱정보 플로우 구현

## 🍎 PR Point
* 인앱/외부 브라우저 연결 구현 (서비스 이용규칙 제외)
* 구현 안 된 뷰들은 이슈 파 뒀고, 구현되는 대로 설정 뷰랑 연결 예정!!
* 탈퇴/로그아웃 같은 큼지막한 기능/네트워킹 코드는 따로 이슈 생성해 작업 예정(코드리뷰 하기 싫은 PR 생성 방지 차원 ..)
* 최신버전받기 (간단한API연결이라) 이건 네트워킹 코드 작성함!
* 설정 부분 테이블뷰 동적/정적 뭘 쓸지 고민을 많이 했는데... 정적 테이블뷰는 뷰 > 컨테이너뷰 > 정적 테이블뷰 이렇게 관리해야 돼서 좀 별로였음. 걍 동적 테이블뷰 썼어욤!
* 단순한 UI 작업 위주라 코드가 길고 딱히 중요한 부분은 없습니다..

## 📸 ScreenShot

https://user-images.githubusercontent.com/43312096/155894541-4f36f213-82de-468a-9045-f14157287475.MP4


