### PR TITLE
🔨 [FIX] 마이페이지 프로필 수정 제2전공 변경 버그

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Mypage/MypageUserInfoModel.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Mypage/MypageUserInfoModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct MypageUserInfoModel: Codable {
+struct MypageUserInfoModel: Codable, Equatable {
     var userID: Int = 0
     var profileImageID: Int = 0
     var nickname: String = ""


### PR DESCRIPTION
## 🍎 관련 이슈
closed #233

## 🍎 변경 사항 및 이유
* 마이페이지 프로필 수정 제2전공 변경 시, 미진입으로 선택했을 때 "수정 버튼" 활성화가 안 되는 문제 수정
* 마이페이지 프로필 수정 "수정 버튼" 활성화/비활성화 판단 로직 수정

## 🍎 PR Point
* changedInfo를 따로 만들어 변경 전/후 user의 info를 비교해, 달라진 부분이 있는 경우만 "수정 버튼"을 활성화시키도록 수정하였습니다!

## 📸 ScreenShot
없슴