### PR TITLE
✅ [CHORE] 후기 수정 시 학과 변경 버튼 비활성화

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
@@ -38,16 +38,7 @@ class ReviewWriteVC: BaseVC {
             majorNameLabel.text = UserDefaults.standard.string(forKey: UserDefaults.Keys.FirstMajorName)
         }
     }
-    @IBOutlet weak var majorChangeBtn: UIButton! {
-        
-        /// 회원가입 시 본전공만 존재하는 유저인 경우 버튼 비활성화 처리
-        didSet {
-            if UserDefaults.standard.string(forKey: UserDefaults.Keys.SecondMajorName) == "미진입" {
-                majorChangeBtn.isEnabled = false
-                majorChangeBtn.tintColor = UIColor.gray3
-            }
-        }
-    }
+    @IBOutlet weak var majorChangeBtn: UIButton!
     @IBOutlet weak var oneLineReviewTextView: NadoTextView!
     @IBOutlet weak var prosAndConsTextView: NadoTextView!
     @IBOutlet weak var learnInfoTextView: NadoTextView!
@@ -95,6 +86,7 @@ class ReviewWriteVC: BaseVC {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        configureChangeBtnUI()
         [oneLineReviewTextView, prosAndConsTextView, learnInfoTextView, recommendClassTextView, badClassTextView, futureTextView, tipTextView].forEach {
             textView in setUpCompleteBtnStatus(textView: textView)
         }
@@ -124,17 +116,26 @@ class ReviewWriteVC: BaseVC {
 
 // MARK: - UI
 extension ReviewWriteVC {
+    private func configureChangeBtnUI() {
+        
+        /// 회원가입 시 본전공만 존재하는 유저인 경우 혹은 후기글 수정 시  버튼 비활성화 처리
+        if UserDefaults.standard.string(forKey: UserDefaults.Keys.SecondMajorName) == "미진입" || !isPosting {
+            majorChangeBtn.isEnabled = false
+            majorChangeBtn.tintColor = UIColor.gray3
+        }
+    }
+    
     private func configureNaviUI() {
         reviewWriteNaviBar.setUpNaviStyle(state: .dismissWithNadoBtn)
         reviewWriteNaviBar.configureTitleLabel(title: "후기작성")
     }
-    
+
     private func configureTagViewUI() {
         essentialTagView.makeRounded(cornerRadius: 4.adjusted)
         choiceTagView.makeRounded(cornerRadius: 4.adjusted)
     }
-    
-    func configureMajorNameViewUI() {
+
+    private func configureMajorNameViewUI() {
         majorNameView.makeRounded(cornerRadius: 4.adjusted)
         majorNameView.layer.borderColor = UIColor.gray0.cgColor
         majorNameView.layer.borderWidth = 1

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
@@ -118,7 +118,7 @@ class ReviewWriteVC: BaseVC {
 extension ReviewWriteVC {
     private func configureChangeBtnUI() {
         
-        /// 회원가입 시 본전공만 존재하는 유저인 경우 혹은 후기글 수정 시  버튼 비활성화 처리
+        /// 회원가입 시 본전공만 존재하는 유저인 경우 혹은 후기글 수정 시 버튼 비활성화 처리
         if UserDefaults.standard.string(forKey: UserDefaults.Keys.SecondMajorName) == "미진입" || !isPosting {
             majorChangeBtn.isEnabled = false
             majorChangeBtn.tintColor = UIColor.gray3


### PR DESCRIPTION
## 🍎 관련 이슈
closed #246

## 🍎 변경 사항 및 이유
- 후기 수정 시 학과 변경 버튼을 누를 수 없도록 비활성화 처리하였습니다.

## 🍎 PR Point
- 제2전공 미진입 여부 판단해줄때 isPosting 변수 활용해서 같이 판단해주었습니다.

## 📸 ScreenShot
- 후기글 작성 시

https://user-images.githubusercontent.com/63277563/156213857-9887f1b2-bf30-4ce9-9730-47f1ba03b12f.mp4

- 후기글 수정 시

https://user-images.githubusercontent.com/63277563/156213875-93ab8bab-04c5-47cc-babd-a07192c1b5a7.mp4


