### PR TITLE
🔨 [FIX] 질문 채팅 스레드 삭제 로직 수정

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomCommentTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomCommentTVC.swift
@@ -15,6 +15,9 @@ class ClassroomCommentTVC: BaseTVC {
     @IBOutlet var majorLabel: UILabel!
     @IBOutlet var commentContentTextView: UITextView!
     @IBOutlet weak var uploadDateLabel: UILabel!
+    @IBOutlet var moreBtn: UIButton!
+    @IBOutlet var titleLabelTopConstraint: NSLayoutConstraint!
+    @IBOutlet var contentTextViewTopConstriaint: NSLayoutConstraint!
     
     // MARK: Properties
     weak var dynamicUpdateDelegate: TVCHeightDynamicUpdate?

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomCommentTVC.xib
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomCommentTVC.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -55,17 +55,6 @@
                                     <action selector="tapMoreBtn:" destination="SVq-Rl-eLx" eventType="touchUpInside" id="p33-6s-BuR"/>
                                 </connections>
                             </button>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="벌써.. 6시 .. 36분이네 .. 굿나잇이 아니" translatesAutoresizingMaskIntoConstraints="NO" id="LMH-SD-I1n">
-                                <rect key="frame" x="16" y="75" width="240" height="82"/>
-                                <color key="backgroundColor" name="chatFill"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="2MN-Nb-oRn"/>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="32" id="6cw-fg-h34"/>
-                                </constraints>
-                                <color key="textColor" name="mainText"/>
-                                <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                            </textView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2022/01/10" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5pt-bF-h5S">
                                 <rect key="frame" x="180" y="165" width="76" height="20"/>
                                 <constraints>
@@ -75,6 +64,17 @@
                                 <color key="textColor" name="gray2"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="벌써.. 6시 .. 36분이네 .. 굿나잇이 아니" translatesAutoresizingMaskIntoConstraints="NO" id="LMH-SD-I1n">
+                                <rect key="frame" x="16" y="75" width="240" height="82"/>
+                                <color key="backgroundColor" name="chatFill"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="2MN-Nb-oRn"/>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="6cw-fg-h34"/>
+                                </constraints>
+                                <color key="textColor" name="mainText"/>
+                                <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
                         </subviews>
                         <color key="backgroundColor" name="chatFill"/>
                         <constraints>
@@ -91,7 +91,7 @@
                             <constraint firstAttribute="trailing" secondItem="LMH-SD-I1n" secondAttribute="trailing" constant="16" id="WcF-ac-ez0"/>
                             <constraint firstItem="LMH-SD-I1n" firstAttribute="leading" secondItem="OlX-jq-iUU" secondAttribute="leading" id="YCo-fW-BeS"/>
                             <constraint firstItem="5pt-bF-h5S" firstAttribute="leading" relation="lessThanOrEqual" secondItem="38o-sG-EsX" secondAttribute="leading" constant="180" id="a8O-1p-bd6"/>
-                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="150" id="u5x-eI-IfJ"/>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="12" id="u5x-eI-IfJ"/>
                             <constraint firstItem="OlX-jq-iUU" firstAttribute="leading" secondItem="38o-sG-EsX" secondAttribute="leading" constant="16" id="xmc-BG-enZ"/>
                             <constraint firstItem="XsY-Xa-ot0" firstAttribute="top" secondItem="OlX-jq-iUU" secondAttribute="bottom" id="yax-7h-ZWo"/>
                             <constraint firstAttribute="trailing" secondItem="5pt-bF-h5S" secondAttribute="trailing" constant="16" id="yxF-BB-d3o"/>
@@ -110,8 +110,11 @@
             <connections>
                 <outlet property="backView" destination="38o-sG-EsX" id="iqJ-Fx-0Lj"/>
                 <outlet property="commentContentTextView" destination="LMH-SD-I1n" id="jrP-Nj-oQm"/>
+                <outlet property="contentTextViewTopConstriaint" destination="OPb-lD-xjE" id="Ah6-q2-G3j"/>
                 <outlet property="majorLabel" destination="XsY-Xa-ot0" id="OI9-E1-ICU"/>
+                <outlet property="moreBtn" destination="kYD-bX-I2J" id="950-L3-0U8"/>
                 <outlet property="nicknameLabel" destination="OlX-jq-iUU" id="jRy-ln-VIy"/>
+                <outlet property="titleLabelTopConstraint" destination="Off-Po-Uer" id="bhG-Jp-GHl"/>
                 <outlet property="uploadDateLabel" destination="5pt-bF-h5S" id="dca-j1-002"/>
             </connections>
             <point key="canvasLocation" x="42.028985507246382" y="100.78125"/>
@@ -120,7 +123,7 @@
     <resources>
         <image name="btnMoreVertMint" width="24" height="24"/>
         <namedColor name="chatFill">
-            <color red="0.91764705882352937" green="0.98039215686274506" blue="0.97254901960784312" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.9179999828338623" green="0.98000001907348633" blue="0.97299998998641968" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="gray2">
             <color red="0.75294117647058822" green="0.75294117647058822" blue="0.79607843137254897" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomQuestionTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomQuestionTVC.swift
@@ -23,6 +23,8 @@ class ClassroomQuestionTVC: BaseTVC {
     }
     @IBOutlet weak var likeCountLabel: UILabel!
     @IBOutlet weak var uploadDateLabel: UILabel!
+    @IBOutlet var contentTextViewTopConstriaint: NSLayoutConstraint!
+    @IBOutlet var titleLabelTopConstraint: NSLayoutConstraint!
     
     // MARK: Properties
     weak var dynamicUpdateDelegate: TVCHeightDynamicUpdate?

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomQuestionTVC.xib
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomQuestionTVC.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -113,7 +113,7 @@
                             <constraint firstAttribute="trailing" secondItem="CFZ-tM-j9m" secondAttribute="trailing" constant="16" id="WJP-tx-ted"/>
                             <constraint firstAttribute="width" relation="lessThanOrEqual" constant="311" id="WPb-Oa-v2T"/>
                             <constraint firstItem="CFZ-tM-j9m" firstAttribute="top" secondItem="OT9-0t-ckE" secondAttribute="bottom" constant="24" id="Wbm-tV-X35"/>
-                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="197" id="a5E-LZ-l2U"/>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="120" id="a5E-LZ-l2U"/>
                             <constraint firstItem="4Jn-Qv-vH7" firstAttribute="leading" secondItem="YaZ-yA-JAB" secondAttribute="leading" constant="16" id="a7O-Kl-MdW"/>
                             <constraint firstItem="hkZ-Xq-Tbg" firstAttribute="leading" secondItem="YaZ-yA-JAB" secondAttribute="leading" constant="8" id="aOP-yq-N38"/>
                             <constraint firstItem="hkZ-Xq-Tbg" firstAttribute="top" secondItem="CFZ-tM-j9m" secondAttribute="bottom" id="c9Y-1S-n24"/>
@@ -141,6 +141,7 @@
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="backView" destination="YaZ-yA-JAB" id="bVz-xJ-Csb"/>
+                <outlet property="contentTextViewTopConstriaint" destination="Wbm-tV-X35" id="k3G-6S-jPF"/>
                 <outlet property="likeBtn" destination="hkZ-Xq-Tbg" id="gCE-k2-DwT"/>
                 <outlet property="likeCountLabel" destination="XwU-wy-Tk1" id="UnP-Yo-4dO"/>
                 <outlet property="majorLabel" destination="OT9-0t-ckE" id="oDy-Ih-rX3"/>
@@ -148,6 +149,7 @@
                 <outlet property="nicknameLabel" destination="udq-eX-F8j" id="TlL-ky-WBX"/>
                 <outlet property="questionContentTextView" destination="CFZ-tM-j9m" id="2pc-09-apb"/>
                 <outlet property="titleLabel" destination="4Jn-Qv-vH7" id="J2H-fQ-gLK"/>
+                <outlet property="titleLabelTopConstraint" destination="A2q-Ul-nWi" id="WHC-au-fRm"/>
                 <outlet property="uploadDateLabel" destination="1Ac-01-sRD" id="6bP-ig-1jj"/>
             </connections>
             <point key="canvasLocation" x="137.68115942028987" y="177.12053571428569"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -794,12 +794,8 @@ extension DefaultQuestionChatVC {
         ClassroomAPI.shared.deletePostCommentAPI(commentID: commentID) { networkResult in
             switch networkResult {
             case .success(_):
-                self.questionChatData.remove(at: indexPath.first!.row)
                 self.defaultQuestionChatTV.performBatchUpdates {
-                    self.defaultQuestionChatTV.deleteRows(at: indexPath, with: .fade)
-                } completion: { (done) in
-                    let indexPathsToUpdate = (0...self.defaultQuestionChatTV.numberOfRows(inSection: 0)).map { IndexPath(row: $0, section: 0) }
-                    self.defaultQuestionChatTV.reloadRows(at: indexPathsToUpdate, with: .none)
+                    self.requestGetDetailQuestionData(postID: self.postID ?? 0)
                 }
                 self.activityIndicator.stopAnimating()
             case .requestErr(let msg):

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -422,6 +422,22 @@ extension DefaultQuestionChatVC: UITableViewDataSource {
                     questionCell.likeCountLabel.isHidden = true
                 }
                 
+                /// 1:1 질문자 셀 중 데이터가 삭제된 셀
+                if questionChatData[indexPath.row].isDeleted {
+                    [questionCell.titleLabelTopConstraint, questionCell.contentTextViewTopConstriaint].forEach {
+                        $0?.constant = 0
+                    }
+                    [questionCell.majorLabel, questionCell.nicknameLabel, questionCell.moreBtn, questionCell.uploadDateLabel].forEach {
+                        $0?.isHidden = true
+                    }
+                } else {
+                    questionCell.titleLabelTopConstraint.constant = 16
+                    questionCell.contentTextViewTopConstriaint.constant = 24
+                    [questionCell.majorLabel, questionCell.nicknameLabel, questionCell.moreBtn, questionCell.uploadDateLabel].forEach {
+                        $0?.isHidden = false
+                    }
+                }
+                
                 questionCell.dynamicUpdateDelegate = self
                 questionCell.changeCellDelegate = self
                 questionCell.tapMoreBtnAction = { [unowned self] in

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -413,7 +413,7 @@ extension DefaultQuestionChatVC: UITableViewDataSource {
                 return questionEditCell
             } else if questionChatData[indexPath.row].writer.isQuestioner {
                 
-                /// 1:1 질문자 셀
+                /// 1:1 질문자 질문원글 셀
                 if indexPath.row == 0 {
                     questionCell.likeBtn.isHidden = false
                     questionCell.likeCountLabel.isHidden = false

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -533,6 +533,23 @@ extension DefaultQuestionChatVC: UITableViewDataSource {
                 
             } else {
                 /// 1:1 답변자 셀
+                
+                /// 1:1 답변자 셀 중 데이터가 삭제된 셀
+                if questionChatData[indexPath.row].isDeleted {
+                    [commentCell.titleLabelTopConstraint, commentCell.contentTextViewTopConstriaint].forEach {
+                        $0?.constant = 0
+                    }
+                    [commentCell.majorLabel, commentCell.nicknameLabel, commentCell.moreBtn, commentCell.uploadDateLabel].forEach {
+                        $0?.isHidden = true
+                    }
+                } else {
+                    commentCell.titleLabelTopConstraint.constant = 16
+                    commentCell.contentTextViewTopConstriaint.constant = 24
+                    [commentCell.majorLabel, commentCell.nicknameLabel, commentCell.moreBtn, commentCell.uploadDateLabel].forEach {
+                        $0?.isHidden = false
+                    }
+                }
+                
                 commentCell.dynamicUpdateDelegate = self
                 commentCell.changeCellDelegate = self
                 commentCell.tapMoreBtnAction = { [unowned self] in


### PR DESCRIPTION
## 🍎 관련 이슈
closed #255

## 🍎 변경 사항 및 이유
- 삭제된 답변일 경우를 고려해 채팅 말풍선들의 최소높이를 수정했습니다. -> `120`

## 🍎 PR Point
- 채팅 스레드를 삭제할 때 해당 셀이 사라지고 fade되는 애니메이션을 구현했었는데, 셀과 데이터가 아예 사라지는 것이 아니라 (삭제된 답변입니다.) 라고 남아있어야 해서 해당 코드를 지우고, 삭제 시 질문상세get API를 호출해주었습니다.
- 셀마다 isDeleted상태를 받아서 삭제된 답변일 경우 닉네임, 전공정보, 점3개버튼, 좋아요버튼, 작성일을 숨겨주었습니다.
- view의 로직이 tableView로 이루어져 있고, 셀들이 재사용되기 때문에 if-else문을 사용하여 재사용 문제가 없게끔 예외 처리를 해주었습니다.

## 📸 ScreenShot
<img width=375 src="https://user-images.githubusercontent.com/63224278/156579827-3c5175ed-b3de-4071-bafb-266252aaf5a7.gif">

