### PR TITLE
🔨 [FIX] 과방 질문 채팅 스레드뷰 QA 반영

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/BaseVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/BaseVC.swift
@@ -34,4 +34,19 @@ class BaseVC: UIViewController {
     func showTabbar() {
         self.tabBarController?.tabBar.isHidden = false
     }
+    
+    /// 화면 터치시 키보드 내리는 메서드
+    func hideKeyboardWhenTappedAround() {
+        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
+        tap.delegate = self
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+}
+
+// MARK: - UIGestureRecognizerDelegate
+extension BaseVC: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        return !(touch.view is UIButton)
+    }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/UIViewController+.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/UIViewController+.swift
@@ -27,19 +27,12 @@ extension UIViewController {
     
     /**
      - Description: 화면 터치시 키보드 내리는 Extension
-     */
-    /// 화면 터치시 키보드 내리는 메서드
-    func hideKeyboardWhenTappedAround() {
-        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
-        tap.cancelsTouchesInView = false
-        view.addGestureRecognizer(tap)
-    }
-    
+     */    
     @objc
     func dismissKeyboard() {
         view.endEditing(true)
     }
-    
+
     /**
      - Description: Alert
      */

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomCommentEditTVC.xib
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomCommentEditTVC.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -62,7 +62,7 @@
                                 </constraints>
                                 <color key="textColor" name="mainText"/>
                                 <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                <textInputTraits key="textInputTraits" autocorrectionType="no"/>
                             </textView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DmU-Wz-mYu" customClass="NadoSunbaeBtn" customModule="NadoSunbae_iOS" customModuleProvider="target">
                                 <rect key="frame" x="204" y="145" width="52" height="36"/>
@@ -135,7 +135,7 @@
     <resources>
         <image name="btnMoreVertMint" width="24" height="24"/>
         <namedColor name="chatFill">
-            <color red="0.91764705882352937" green="0.98039215686274506" blue="0.97254901960784312" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.9179999828338623" green="0.98000001907348633" blue="0.97299998998641968" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="gray4">
             <color red="0.33725490196078434" green="0.33725490196078434" blue="0.37254901960784315" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomQuestionEditTVC.xib
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomQuestionEditTVC.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -63,7 +63,7 @@
                                 </constraints>
                                 <color key="textColor" name="nadoBlack"/>
                                 <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                <textInputTraits key="textInputTraits" autocorrectionType="no"/>
                             </textView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GYp-lU-cWu" customClass="NadoSunbaeBtn" customModule="NadoSunbae_iOS" customModuleProvider="target">
                                 <rect key="frame" x="236" y="145" width="52" height="36"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/SB/QuestionChatSB.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/SB/QuestionChatSB.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="lih-71-Zdd">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="lih-71-Zdd">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -36,7 +36,7 @@
                                 </constraints>
                                 <color key="textColor" name="gray4"/>
                                 <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                <textInputTraits key="textInputTraits" autocorrectionType="no" textContentType="nickname"/>
                             </textView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="R1m-v3-OEB">
                                 <rect key="frame" x="327" y="734" width="44" height="44"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
@@ -239,6 +239,7 @@ extension InfoMainVC: UITableViewDelegate {
         
         if infoList.count != 0 {
             infoDetailVC.postID = infoList[indexPath.row].postID
+            infoDetailVC.hidesBottomBarWhenPushed = true
             self.navigationController?.pushViewController(infoDetailVC, animated: true)
         }
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -73,6 +73,7 @@ class DefaultQuestionChatVC: BaseVC {
     private let screenHeight = UIScreen.main.bounds.size.height
     private var isTextViewEmpty: Bool = true
     private var sendTextViewLineCount: Int = 1
+    private var keyboardShowUpY: CGFloat = 0
     private let textViewMaxHeight: CGFloat = 85
     
     // MARK: Life Cycle
@@ -655,18 +656,24 @@ extension DefaultQuestionChatVC {
 
             let beginFrame = ((notification as NSNotification).userInfo![UIResponder.keyboardFrameBeginUserInfoKey] as! NSValue).cgRectValue
             let endFrame = ((notification as NSNotification).userInfo![UIResponder.keyboardFrameEndUserInfoKey] as! NSValue).cgRectValue
-            let keyboardShowUpY = (endFrame.origin.y - beginFrame.origin.y)
+            
+            guard !beginFrame.equalTo(endFrame) else {
+                    return
+            }
+            
+            keyboardShowUpY = (endFrame.origin.y - beginFrame.origin.y)
             self.defaultQuestionChatTV.contentOffset = CGPoint(x: 0, y: self.defaultQuestionChatTV.contentOffset.y - keyboardShowUpY)
             self.view.layoutIfNeeded()
         }
     }
     
     @objc
-    private func keyboardWillHide(_ notification:Notification) {
+    private func keyboardWillHide(_ notification: Notification) {
         if ((notification.userInfo?[UIResponder.keyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue) != nil {
             sendAreaTextViewBottom.constant = 5
             sendBtnBottom.constant = 0
-            defaultQuestionChatTV.fitContentInset(inset: .zero)
+            self.defaultQuestionChatTV.contentOffset = CGPoint(x: 0, y: self.defaultQuestionChatTV.contentOffset.y + keyboardShowUpY)
+            self.view.layoutIfNeeded()
         }
     }
     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -488,6 +488,7 @@ extension DefaultQuestionChatVC: UITableViewDataSource {
                                 self.present(editPostVC, animated: true, completion: nil)
                             } else {
                                 /// 질문 답변일 경우
+                                self.dismissKeyboard()
                                 editIndex = [0,indexPath.row]
                             }
                             defaultQuestionChatTV.reloadData()
@@ -586,6 +587,7 @@ extension DefaultQuestionChatVC: UITableViewDataSource {
                         /// 작성자 본인이 민트색 말풍선의 더보기 버튼을 눌렀을 경우
                         self.makeTwoAlertWithCancel(okTitle: actionSheetString[0], secondOkTitle: actionSheetString[1], okAction: { _ in
                             if actionSheetString[0] == "수정" {
+                                self.dismissKeyboard()
                                 editIndex = [1,indexPath.row]
                             }
                             defaultQuestionChatTV.reloadData()
@@ -703,6 +705,7 @@ extension DefaultQuestionChatVC {
                     /// 댓글 수정되었을 때
                     if self.isCommentEdited {
                         self.defaultQuestionChatTV.performBatchUpdates {
+                            self.dismissKeyboard()
                             self.defaultQuestionChatTV.reloadRows(at: self.editedCommentIndexPath, with: .automatic)
                         }
                         self.isCommentEdited = false

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -80,6 +80,7 @@ class DefaultQuestionChatVC: BaseVC {
         super.viewDidLoad()
         setUpNaviInitStyle()
         registerXib()
+        hideKeyboardWhenTappedAround()
     }
     
     override func viewDidLayoutSubviews() {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -23,7 +23,6 @@ class DefaultQuestionChatVC: BaseVC {
             defaultQuestionChatTV.allowsSelection = false
             defaultQuestionChatTV.separatorStyle = .none
             defaultQuestionChatTV.rowHeight  = UITableView.automaticDimension
-            defaultQuestionChatTV.keyboardDismissMode = UIScrollView.KeyboardDismissMode.onDrag
         }
     }
     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -635,9 +635,6 @@ extension DefaultQuestionChatVC: TVCContentUpdate {
     /// TableView의 내용 or UI를 업데이트하는 메서드
     func updateTV() {
         defaultQuestionChatTV.reloadData()
-        if moreBtnTapIndex?.isEmpty == false {
-            defaultQuestionChatTV.scrollToRow(at: IndexPath(row: moreBtnTapIndex?[1] ?? 0, section: 0), at: .top, animated: true)
-        }
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -652,16 +652,15 @@ extension DefaultQuestionChatVC {
     
     @objc
     private func keyboardWillShow(_ notification: Notification) {
-        if screenHeight == 667 {
-            if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
-                sendAreaTextViewBottom.constant = keyboardSize.height + 6
-                sendBtnBottom.constant = keyboardSize.height + 1
-            }
-        } else {
-            if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
-                sendAreaTextViewBottom.constant = keyboardSize.height - 25
-                sendBtnBottom.constant = keyboardSize.height - 30
-            }
+        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+            sendAreaTextViewBottom.constant = screenHeight == 667 ? keyboardSize.height + 6 : keyboardSize.height - 25
+            sendBtnBottom.constant = screenHeight == 667 ? keyboardSize.height  + 1 : keyboardSize.height - 30
+
+            let beginFrame = ((notification as NSNotification).userInfo![UIResponder.keyboardFrameBeginUserInfoKey] as! NSValue).cgRectValue
+            let endFrame = ((notification as NSNotification).userInfo![UIResponder.keyboardFrameEndUserInfoKey] as! NSValue).cgRectValue
+            let keyboardShowUpY = (endFrame.origin.y - beginFrame.origin.y)
+            self.defaultQuestionChatTV.contentOffset = CGPoint(x: 0, y: self.defaultQuestionChatTV.contentOffset.y - keyboardShowUpY)
+            self.view.layoutIfNeeded()
         }
     }
     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionMainVC.swift
@@ -316,6 +316,7 @@ extension QuestionMainVC: UITableViewDelegate {
                 groupChatVC.questionType = .group
                 groupChatVC.naviStyle = .push
                 groupChatVC.postID = questionList[indexPath.row].postID
+                groupChatVC.hidesBottomBarWhenPushed = true
                 self.navigationController?.pushViewController(groupChatVC, animated: true)
             }
         } else if indexPath.section == 2 {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/MypageMainVC+TV.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/MypageMainVC+TV.swift
@@ -39,6 +39,7 @@ extension MypageMainVC: UITableViewDelegate {
         personalChatVC.questionType = .personal
         personalChatVC.naviStyle = .push
         personalChatVC.postID = self.questionList[indexPath.row].postID
+        personalChatVC.hidesBottomBarWhenPushed = true
         
         self.navigationController?.pushViewController(personalChatVC, animated: true)
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/SB/MypageMyReviewVC.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/SB/MypageMyReviewVC.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -63,10 +63,10 @@
                                         </constraints>
                                     </view>
                                     <view hidden="YES" clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b6Y-qI-j4A">
-                                        <rect key="frame" x="16" y="32" width="343" height="762"/>
+                                        <rect key="frame" x="16" y="32" width="343" height="626"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="등록된 학과후기가 없습니다." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xFT-vg-5BE">
-                                                <rect key="frame" x="93.666666666666686" y="372.66666666666669" width="156" height="17"/>
+                                                <rect key="frame" x="93.666666666666686" y="304.66666666666669" width="156" height="17"/>
                                                 <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="14"/>
                                                 <color key="textColor" name="gray2"/>
                                                 <nil key="highlightedColor"/>
@@ -109,6 +109,7 @@
                     <connections>
                         <outlet property="contentView" destination="Ifb-p1-FlH" id="DeM-YK-5G5"/>
                         <outlet property="emptyView" destination="b6Y-qI-j4A" id="3lt-20-iiX"/>
+                        <outlet property="mypageReviewSV" destination="8mL-F0-YDQ" id="8vt-ln-gG6"/>
                         <outlet property="navView" destination="UUN-r1-6Kk" id="gbK-f3-xDp"/>
                         <outlet property="reviewTV" destination="vr6-O5-Gfy" id="pnA-Ok-TFW"/>
                         <outlet property="reviewTVHeight" destination="6gW-fB-NUv" id="LWN-k1-hJ5"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyReviewVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyReviewVC.swift
@@ -19,6 +19,7 @@ class MypageMyReviewVC: BaseVC {
             }
         }
     }
+    @IBOutlet weak var mypageReviewSV: UIScrollView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var contentView: UIView!
     @IBOutlet weak var reviewTV: UITableView!
@@ -31,6 +32,7 @@ class MypageMyReviewVC: BaseVC {
     
     // MARK: Properties
     var reviewList: [MypageMyReviewPostModel] = []
+    var userID: Int = 0
     
     // MARK: Life Cycle
     override func viewDidLoad() {
@@ -62,6 +64,7 @@ extension MypageMyReviewVC {
     
     private func setEmptyView() {
         emptyView.isHidden = !(reviewList.isEmpty)
+        self.mypageReviewSV.contentSize.height = 1.0
     }
     
     private func setUpTV() {
@@ -75,7 +78,7 @@ extension MypageMyReviewVC {
     }
 }
 
-// MARK: -
+// MARK: - UITableViewDataSource
 extension MypageMyReviewVC: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return reviewList.count
@@ -89,6 +92,7 @@ extension MypageMyReviewVC: UITableViewDataSource {
     }
 }
 
+// MARK: - UITableViewDelegate
 extension MypageMyReviewVC: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let ReviewDetailSB = UIStoryboard.init(name: "ReviewDetailSB", bundle: nil)
@@ -106,7 +110,7 @@ extension MypageMyReviewVC: UITableViewDelegate {
 extension MypageMyReviewVC {
     private func getMypageMyReview() {
         self.activityIndicator.startAnimating()
-        MypageAPI.shared.getMypageMyReviewList(userID: UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID)) { networkResult in
+        MypageAPI.shared.getMypageMyReviewList(userID: self.userID == 0 ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID) : self.userID) { networkResult in
             switch networkResult {
             case .success(let res):
                 if let reviewData = res as? MypageMyReviewModel {
@@ -119,6 +123,8 @@ extension MypageMyReviewVC {
                         self.reviewTVHeight.constant = self.reviewTV.contentSize.height
                         self.contentView.layoutIfNeeded()
                     }
+                } else {
+                    self.setEmptyView()
                 }
                 self.activityIndicator.stopAnimating()
             case .requestErr(let msg):

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/SB/MypageUserVC.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/SB/MypageUserVC.storyboard
@@ -186,11 +186,23 @@
                                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                         <state key="normal" image="btn_arrow"/>
                                                     </button>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oGq-cz-wAK">
+                                                        <rect key="frame" x="0.0" y="0.0" width="327" height="65.333333333333329"/>
+                                                        <state key="normal" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="plain"/>
+                                                        <connections>
+                                                            <action selector="tapReviewBtn:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="rNb-S8-TjV"/>
+                                                        </connections>
+                                                    </button>
                                                 </subviews>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
+                                                    <constraint firstAttribute="bottom" secondItem="oGq-cz-wAK" secondAttribute="bottom" id="1E1-Wf-i65"/>
                                                     <constraint firstAttribute="bottom" secondItem="hq4-js-NDg" secondAttribute="bottom" constant="4" id="36U-Cc-ih1"/>
                                                     <constraint firstItem="SWl-yB-pDv" firstAttribute="centerY" secondItem="esB-wA-MD4" secondAttribute="centerY" id="EcN-3D-eL3"/>
+                                                    <constraint firstItem="oGq-cz-wAK" firstAttribute="top" secondItem="ifh-6A-2YM" secondAttribute="top" id="HgX-4x-GcO"/>
+                                                    <constraint firstAttribute="trailing" secondItem="oGq-cz-wAK" secondAttribute="trailing" id="PvQ-Up-8Tn"/>
+                                                    <constraint firstItem="oGq-cz-wAK" firstAttribute="leading" secondItem="ifh-6A-2YM" secondAttribute="leading" id="S4I-Za-zR4"/>
                                                     <constraint firstItem="esB-wA-MD4" firstAttribute="leading" secondItem="ifh-6A-2YM" secondAttribute="leading" constant="16" id="euw-wl-bhF"/>
                                                     <constraint firstItem="hq4-js-NDg" firstAttribute="top" secondItem="ifh-6A-2YM" secondAttribute="top" constant="4" id="fOj-I9-GRy"/>
                                                     <constraint firstAttribute="trailing" secondItem="hq4-js-NDg" secondAttribute="trailing" constant="1" id="ilb-KS-VkW"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC+TV.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC+TV.swift
@@ -35,10 +35,11 @@ extension MypageUserVC: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let chatSB: UIStoryboard = UIStoryboard(name: Identifiers.QuestionChatSB, bundle: nil)
         guard let personalChatVC = chatSB.instantiateViewController(identifier: DefaultQuestionChatVC.className) as? DefaultQuestionChatVC else { return }
-        
+       
         personalChatVC.questionType = .personal
         personalChatVC.naviStyle = .push
         personalChatVC.postID = self.questionList[indexPath.row].postID
+        personalChatVC.hidesBottomBarWhenPushed = true
         
         self.navigationController?.pushViewController(personalChatVC, animated: true)
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC.swift
@@ -99,6 +99,12 @@ class MypageUserVC: BaseVC {
         self.present(optionMenu, animated: true, completion: nil)
     }
     
+    @IBAction func tapReviewBtn(_ sender: UIButton) {
+        guard let reviewVC = UIStoryboard.init(name: MypageMyReviewVC.className, bundle: nil).instantiateViewController(withIdentifier: MypageMyReviewVC.className) as? MypageMyReviewVC else { return }
+        
+        reviewVC.userID = userInfo.userID
+        self.navigationController?.pushViewController(reviewVC, animated: true)
+    }
 }
 
 // MARK: - UI
@@ -174,10 +180,12 @@ extension MypageUserVC {
     }
     
     private func getUserPersonalQuestionList(sort: ListSortType) {
+        self.activityIndicator.startAnimating()
         MypageAPI.shared.getUserPersonalQuestionList(userID: targetUserID, sort: sort, completion: { networkResult in
             switch networkResult {
             case .success(let res):
                 if let data = res as? QuestionOrInfoListModel {
+                    self.activityIndicator.stopAnimating()
                     self.questionList = []
                     self.questionList = data.classroomPostList
                     DispatchQueue.main.async {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Notification/VC/NotificationMainVC+TV.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Notification/VC/NotificationMainVC+TV.swift
@@ -40,7 +40,13 @@ extension NotificationMainVC: UITableViewDelegate {
         /// 뷰 이동 및 읽음 처리, 현재 질문글만 뷰 이동 가능
         switch notificationList[indexPath.section].notificationTypeID.getNotiType() {
         case .writtenInfo:
-            break
+            guard let infoDetailVC = UIStoryboard(name: Identifiers.InfoSB, bundle: nil).instantiateViewController(identifier: InfoDetailVC.className) as? InfoDetailVC else { return }
+            
+            infoDetailVC.postID = notificationList[indexPath.row].postID
+            infoDetailVC.hidesBottomBarWhenPushed = true
+            
+            readNoti(notiID: notificationList[indexPath.section].notificationID)
+            self.navigationController?.pushViewController(infoDetailVC, animated: true)
             
         case .writtenQuestion:
             guard let groupChatVC = UIStoryboard(name: Identifiers.QuestionChatSB, bundle: nil).instantiateViewController(identifier: DefaultQuestionChatVC.className) as? DefaultQuestionChatVC else { return }
@@ -54,7 +60,13 @@ extension NotificationMainVC: UITableViewDelegate {
             self.navigationController?.pushViewController(groupChatVC, animated: true)
             
         case .answerInfo:
-            break
+            guard let infoDetailVC = UIStoryboard(name: Identifiers.InfoSB, bundle: nil).instantiateViewController(identifier: InfoDetailVC.className) as? InfoDetailVC else { return }
+            
+            infoDetailVC.postID = notificationList[indexPath.row].postID
+            infoDetailVC.hidesBottomBarWhenPushed = true
+            
+            readNoti(notiID: notificationList[indexPath.section].notificationID)
+            self.navigationController?.pushViewController(infoDetailVC, animated: true)
             
         case .answerQuestion:
             guard let groupChatVC = UIStoryboard(name: Identifiers.QuestionChatSB, bundle: nil).instantiateViewController(identifier: DefaultQuestionChatVC.className) as? DefaultQuestionChatVC else { return }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Notification/VC/NotificationMainVC+TV.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Notification/VC/NotificationMainVC+TV.swift
@@ -48,6 +48,7 @@ extension NotificationMainVC: UITableViewDelegate {
             groupChatVC.questionType = notificationList[indexPath.section].isQuestionToPerson ? .personal : .group
             groupChatVC.naviStyle = .push
             groupChatVC.postID = notificationList[indexPath.section].postID
+            groupChatVC.hidesBottomBarWhenPushed = true
 
             readNoti(notiID: notificationList[indexPath.section].notificationID)
             self.navigationController?.pushViewController(groupChatVC, animated: true)
@@ -61,6 +62,7 @@ extension NotificationMainVC: UITableViewDelegate {
             groupChatVC.questionType = notificationList[indexPath.section].isQuestionToPerson ? .personal : .group
             groupChatVC.naviStyle = .push
             groupChatVC.postID = notificationList[indexPath.section].postID
+            groupChatVC.hidesBottomBarWhenPushed = true
             
             readNoti(notiID: notificationList[indexPath.section].notificationID)
             self.navigationController?.pushViewController(groupChatVC, animated: true)
@@ -71,6 +73,7 @@ extension NotificationMainVC: UITableViewDelegate {
             groupChatVC.questionType = .personal
             groupChatVC.naviStyle = .push
             groupChatVC.postID = notificationList[indexPath.section].postID
+            groupChatVC.hidesBottomBarWhenPushed = true
             
             readNoti(notiID: notificationList[indexPath.section].notificationID)
             self.navigationController?.pushViewController(groupChatVC, animated: true)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/TabBar/VC/NadoSunbaeTBC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/TabBar/VC/NadoSunbaeTBC.swift
@@ -48,7 +48,7 @@ extension NadoSunbaeTBC {
         let mypageTab = makeTabVC(vcType: .mypage, tabBarTitle: "마이페이지", tabBarImg: "icMypageGray", tabBarSelectedImg: "icMypage")
         
         // 탭 구성
-        let tabs =  [reviewTab, classroomTab, alarmTab, mypageTab]
+        let tabs = [reviewTab, classroomTab, alarmTab, mypageTab]
         
         // VC에 루트로 설정
         self.setViewControllers(tabs, animated: false)


### PR DESCRIPTION
## 🍎 관련 이슈
closed #258 

## 🍎 변경 사항 및 이유
1. 앱잼 당시 채팅 스레드에서 send 버튼을 누를 때 버튼에도 탭 제스처가 적용되는 문제가 발생해서 채팅을 보낼 때 키보드가 내려가는 현상이 있었습니다.
2. 그래서 채팅 스레드 뷰에서 `hideKeyboardWhenTappedAround()`함수를 사용하지 않고, 드래그 시에만 키보드가 내려가도록 구현했었습니다.
3. 그런데 QA과정을 거치면서 카톡과 비슷하게 키보드 인터랙션이 되는 것이 유저 입장에서 편할 것 같다는 생각이 들어서 드래그 함수를 제거하고 `hideKeyboardWhenTappedAround()`함수를 써보자는 생각이 들었습니다.
4. 그런데 이 함수를 쓰려면 채팅 스레드 내에서 '전송' 버튼을 누를 때는 키보드가 내려가지 않고 전송 버튼이 눌려야 하므로 -> tap 되는 대상이 `UIButton`일 때는 탭 제스처가 동작하지 않도록 구현하는 방법이 필요했습니다. 
`    ==>  tap Delegate 대리자를 위임해서 gestureRecognizerDelegate함수가 호출될 때 그 호출하는 대상이 UIButton이면 제스처를 동작시키지 않는 구현원리가 필요했습니다.`
5. 따라서....!!!!! `UIViewController+` 에 위치했던 `hideKeyboardWhenTappedAround()` 함수를 저희가 공통적으로 사용하는 `BaseVC()` 내로 옮기고, 대리자를 위임해주었습니다 :)

## 🍎 PR Point
-  채팅뷰 하단 텍스트영역 뒤로가기하고 재진입시 위로 올라오는 현상 해결
- 키보드 영역만큼 스크롤이 안되는 현상 해결 (바닥부분) -> 뷰가 더 늘어나게 수정 (키보드 올라올 때)
- 키보드 영역 제외 다른 뷰 탭 시 키보드 사라지도록 구현
- 키보드 애니메이션과 겹쳐서 기존 점3개버튼 눌렀을 때 해당 셀로 스크롤하는 애니메이션 제거

## 📸 ScreenShot
### 💡 [채팅뷰 하단 텍스트영역 뒤로가기하고 재진입시 위로 올라오는 현상 해결 영상]
<img width=375 src="https://user-images.githubusercontent.com/63224278/156638736-6a23095d-3bf3-4356-9ba4-8c6bb0ec8394.gif">

### 💡 [채팅뷰 키보드 관련 수정 영상]
<img width=375 src="https://user-images.githubusercontent.com/63224278/156638677-6868a20d-f345-4e60-b71d-58b2a239665a.gif">