### PR TITLE
✨ [FEAT] 선배 개인페이지 학과 후기 UI 구성

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/SB/MypageMyReviewVC.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/SB/MypageMyReviewVC.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -63,10 +63,10 @@
                                         </constraints>
                                     </view>
                                     <view hidden="YES" clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b6Y-qI-j4A">
-                                        <rect key="frame" x="16" y="32" width="343" height="762"/>
+                                        <rect key="frame" x="16" y="32" width="343" height="626"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="등록된 학과후기가 없습니다." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xFT-vg-5BE">
-                                                <rect key="frame" x="93.666666666666686" y="372.66666666666669" width="156" height="17"/>
+                                                <rect key="frame" x="93.666666666666686" y="304.66666666666669" width="156" height="17"/>
                                                 <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="14"/>
                                                 <color key="textColor" name="gray2"/>
                                                 <nil key="highlightedColor"/>
@@ -112,6 +112,7 @@
                         <outlet property="navView" destination="UUN-r1-6Kk" id="gbK-f3-xDp"/>
                         <outlet property="reviewTV" destination="vr6-O5-Gfy" id="pnA-Ok-TFW"/>
                         <outlet property="reviewTVHeight" destination="6gW-fB-NUv" id="LWN-k1-hJ5"/>
+                        <outlet property="scrollView" destination="8mL-F0-YDQ" id="oVd-7w-nIj"/>
                         <outlet property="titleLabel" destination="GtB-MD-8ew" id="qAs-hA-tTW"/>
                     </connections>
                 </viewController>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/SB/MypageMyReviewVC.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/SB/MypageMyReviewVC.storyboard
@@ -109,10 +109,10 @@
                     <connections>
                         <outlet property="contentView" destination="Ifb-p1-FlH" id="DeM-YK-5G5"/>
                         <outlet property="emptyView" destination="b6Y-qI-j4A" id="3lt-20-iiX"/>
+                        <outlet property="mypageReviewSV" destination="8mL-F0-YDQ" id="8vt-ln-gG6"/>
                         <outlet property="navView" destination="UUN-r1-6Kk" id="gbK-f3-xDp"/>
                         <outlet property="reviewTV" destination="vr6-O5-Gfy" id="pnA-Ok-TFW"/>
                         <outlet property="reviewTVHeight" destination="6gW-fB-NUv" id="LWN-k1-hJ5"/>
-                        <outlet property="scrollView" destination="8mL-F0-YDQ" id="oVd-7w-nIj"/>
                         <outlet property="titleLabel" destination="GtB-MD-8ew" id="qAs-hA-tTW"/>
                     </connections>
                 </viewController>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyReviewVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyReviewVC.swift
@@ -19,7 +19,7 @@ class MypageMyReviewVC: BaseVC {
             }
         }
     }
-    @IBOutlet weak var scrollView: UIScrollView!
+    @IBOutlet weak var mypageReviewSV: UIScrollView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var contentView: UIView!
     @IBOutlet weak var reviewTV: UITableView!
@@ -64,7 +64,7 @@ extension MypageMyReviewVC {
     
     private func setEmptyView() {
         emptyView.isHidden = !(reviewList.isEmpty)
-        self.scrollView.contentSize.height = 1.0
+        self.mypageReviewSV.contentSize.height = 1.0
     }
     
     private func setUpTV() {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyReviewVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyReviewVC.swift
@@ -19,6 +19,7 @@ class MypageMyReviewVC: BaseVC {
             }
         }
     }
+    @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var contentView: UIView!
     @IBOutlet weak var reviewTV: UITableView!
@@ -63,6 +64,7 @@ extension MypageMyReviewVC {
     
     private func setEmptyView() {
         emptyView.isHidden = !(reviewList.isEmpty)
+        self.scrollView.contentSize.height = 1.0
     }
     
     private func setUpTV() {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyReviewVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyReviewVC.swift
@@ -121,6 +121,8 @@ extension MypageMyReviewVC {
                         self.reviewTVHeight.constant = self.reviewTV.contentSize.height
                         self.contentView.layoutIfNeeded()
                     }
+                } else {
+                    self.setEmptyView()
                 }
                 self.activityIndicator.stopAnimating()
             case .requestErr(let msg):

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyReviewVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyReviewVC.swift
@@ -31,6 +31,7 @@ class MypageMyReviewVC: BaseVC {
     
     // MARK: Properties
     var reviewList: [MypageMyReviewPostModel] = []
+    var userID: Int = 0
     
     // MARK: Life Cycle
     override func viewDidLoad() {
@@ -106,7 +107,7 @@ extension MypageMyReviewVC: UITableViewDelegate {
 extension MypageMyReviewVC {
     private func getMypageMyReview() {
         self.activityIndicator.startAnimating()
-        MypageAPI.shared.getMypageMyReviewList(userID: UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID)) { networkResult in
+        MypageAPI.shared.getMypageMyReviewList(userID: self.userID == 0 ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID) : self.userID) { networkResult in
             switch networkResult {
             case .success(let res):
                 if let reviewData = res as? MypageMyReviewModel {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyReviewVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyReviewVC.swift
@@ -76,7 +76,7 @@ extension MypageMyReviewVC {
     }
 }
 
-// MARK: -
+// MARK: - UITableViewDataSource
 extension MypageMyReviewVC: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return reviewList.count
@@ -90,6 +90,7 @@ extension MypageMyReviewVC: UITableViewDataSource {
     }
 }
 
+// MARK: - UITableViewDelegate
 extension MypageMyReviewVC: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let ReviewDetailSB = UIStoryboard.init(name: "ReviewDetailSB", bundle: nil)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/SB/MypageUserVC.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/SB/MypageUserVC.storyboard
@@ -185,6 +185,9 @@
                                                         </constraints>
                                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                         <state key="normal" image="btn_arrow"/>
+                                                        <connections>
+                                                            <action selector="tapReviewBtn:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="L7b-cV-8uM"/>
+                                                        </connections>
                                                     </button>
                                                 </subviews>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/SB/MypageUserVC.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/SB/MypageUserVC.storyboard
@@ -185,15 +185,24 @@
                                                         </constraints>
                                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                         <state key="normal" image="btn_arrow"/>
+                                                    </button>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oGq-cz-wAK">
+                                                        <rect key="frame" x="0.0" y="0.0" width="327" height="65.333333333333329"/>
+                                                        <state key="normal" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="plain"/>
                                                         <connections>
-                                                            <action selector="tapReviewBtn:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="L7b-cV-8uM"/>
+                                                            <action selector="tapReviewBtn:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="rNb-S8-TjV"/>
                                                         </connections>
                                                     </button>
                                                 </subviews>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
+                                                    <constraint firstAttribute="bottom" secondItem="oGq-cz-wAK" secondAttribute="bottom" id="1E1-Wf-i65"/>
                                                     <constraint firstAttribute="bottom" secondItem="hq4-js-NDg" secondAttribute="bottom" constant="4" id="36U-Cc-ih1"/>
                                                     <constraint firstItem="SWl-yB-pDv" firstAttribute="centerY" secondItem="esB-wA-MD4" secondAttribute="centerY" id="EcN-3D-eL3"/>
+                                                    <constraint firstItem="oGq-cz-wAK" firstAttribute="top" secondItem="ifh-6A-2YM" secondAttribute="top" id="HgX-4x-GcO"/>
+                                                    <constraint firstAttribute="trailing" secondItem="oGq-cz-wAK" secondAttribute="trailing" id="PvQ-Up-8Tn"/>
+                                                    <constraint firstItem="oGq-cz-wAK" firstAttribute="leading" secondItem="ifh-6A-2YM" secondAttribute="leading" id="S4I-Za-zR4"/>
                                                     <constraint firstItem="esB-wA-MD4" firstAttribute="leading" secondItem="ifh-6A-2YM" secondAttribute="leading" constant="16" id="euw-wl-bhF"/>
                                                     <constraint firstItem="hq4-js-NDg" firstAttribute="top" secondItem="ifh-6A-2YM" secondAttribute="top" constant="4" id="fOj-I9-GRy"/>
                                                     <constraint firstAttribute="trailing" secondItem="hq4-js-NDg" secondAttribute="trailing" constant="1" id="ilb-KS-VkW"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC.swift
@@ -99,6 +99,12 @@ class MypageUserVC: BaseVC {
         self.present(optionMenu, animated: true, completion: nil)
     }
     
+    @IBAction func tapReviewBtn(_ sender: UIButton) {
+        guard let reviewVC = UIStoryboard.init(name: MypageMyReviewVC.className, bundle: nil).instantiateViewController(withIdentifier: MypageMyReviewVC.className) as? MypageMyReviewVC else { return }
+        
+        reviewVC.userID = userInfo.userID
+        self.navigationController?.pushViewController(reviewVC, animated: true)
+    }
 }
 
 // MARK: - UI

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC.swift
@@ -174,10 +174,12 @@ extension MypageUserVC {
     }
     
     private func getUserPersonalQuestionList(sort: ListSortType) {
+        self.activityIndicator.startAnimating()
         MypageAPI.shared.getUserPersonalQuestionList(userID: targetUserID, sort: sort, completion: { networkResult in
             switch networkResult {
             case .success(let res):
                 if let data = res as? QuestionOrInfoListModel {
+                    self.activityIndicator.stopAnimating()
                     self.questionList = []
                     self.questionList = data.classroomPostList
                     DispatchQueue.main.async {


### PR DESCRIPTION
## 🍎 관련 이슈
closed #256

## 🍎 변경 사항 및 이유
- 과방 탭의 선배 개인페이지 학과 후기 UI를 구성하였습니다.

## 🍎 PR Point
- 선배 개인페이지에서 최신순, 좋아요순 정렬을 바꾸었을때 서버통신 과정이 보이도록
loading indicator를 추가해주었습니다.
- 선배 개인페이지 학과 후기 버튼을 누르면 학과 리스트 뷰로 이동하도록 화면전환을 구현하였습니다.
- 학과 후기 버튼 클릭 시 정빈이가 마이페이지 학과 후기 뷰 구성 시 만들어놓았던 `MypageMyReviewVC`에서 
userID로 분기처리를 해서 해당 선배가 쓴 글이 보일 수 있도록 구현하였습니다.

## 📸 ScreenShot
- 좋아요 클릭 시 


https://user-images.githubusercontent.com/63277563/156878548-2ef49771-9484-4d33-aec2-a92e93658737.mp4


- reviewList.isEmpty일 경우 emptyView가 보이고, scroll이 불가하도록 구현


https://user-images.githubusercontent.com/63277563/156821537-c56a9a17-6d5b-4ea2-ac33-33909360f4a0.mp4

**+** 학과 후기 버튼 터치영역 수정

<img width="242" alt="스크린샷 2022-03-05 오후 6 57 37" src="https://user-images.githubusercontent.com/63277563/156878425-2fd9f183-2d02-42eb-8710-8995835404f9.png">



