### PR TITLE
✨ [FEAT] NadoAlert case 만들기

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Class/NadoAlertVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Class/NadoAlertVC.swift
@@ -6,6 +6,20 @@
 //
 
 import UIKit
+import SnapKit
+import Then
+
+enum NadoAlertType {
+    
+    /// confirmBtn, cancelBtn 사용
+    case withDoubleBtn
+    
+    /// confirmBtn만 사용
+    case withSingleBtn
+    
+    /// confirmBtn, cancelBtn 사용
+    case withTextField
+}
 
 class NadoAlertVC: BaseVC {
     
@@ -38,12 +52,32 @@ class NadoAlertVC: BaseVC {
         self.modalTransitionStyle = .crossDissolve
     }
     
-    func showNadoAlert(vc: UIViewController, message: String, confirmBtnTitle: String, cancelBtnTitle: String) {
+    func showNadoAlert(vc: UIViewController, message: String, confirmBtnTitle: String, cancelBtnTitle: String, type: NadoAlertType? = .withDoubleBtn) {
         messageLabel.text = message
-        DispatchQueue.main.async {
-            self.confirmBtn.setTitleWithStyle(title: confirmBtnTitle, size: 14, weight: .bold)
-            self.cancelBtn.setTitleWithStyle(title: cancelBtnTitle, size: 14, weight: .bold)
+        switch type {
+        case .withSingleBtn:
+            DispatchQueue.main.async {
+                self.confirmBtn.setTitleWithStyle(title: confirmBtnTitle, size: 14, weight: .bold)
+                self.cancelBtn.removeFromSuperview()
+                self.confirmBtn.snp.makeConstraints {
+                    $0.leading.equalTo(self.containerView.snp.leading).offset(14)
+                    $0.trailing.equalTo(self.containerView.snp.trailing).offset(-14)
+                    $0.bottom.equalTo(self.containerView.snp.bottom).offset(-14)
+                    $0.height.equalTo(self.containerView.frame.height * 0.3095)
+                }
+            }
+        case .withTextField:
+            DispatchQueue.main.async {
+                self.confirmBtn.setTitleWithStyle(title: confirmBtnTitle, size: 14, weight: .bold)
+                self.cancelBtn.setTitleWithStyle(title: cancelBtnTitle, size: 14, weight: .bold)
+            }
+        default:
+            DispatchQueue.main.async {
+                self.confirmBtn.setTitleWithStyle(title: confirmBtnTitle, size: 14, weight: .bold)
+                self.cancelBtn.setTitleWithStyle(title: cancelBtnTitle, size: 14, weight: .bold)
+            }
         }
+
         vc.present(self, animated: true, completion: nil)
     }
     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/NadoAlertVC.xib
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/NadoAlertVC.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -57,12 +57,12 @@
                             <constraint firstAttribute="bottom" secondItem="CCK-SR-a1R" secondAttribute="bottom" constant="14" id="PcJ-UE-7aB"/>
                             <constraint firstItem="ELo-xG-zpK" firstAttribute="width" secondItem="jV9-hc-CUq" secondAttribute="width" multiplier="0.4242" id="QYP-tT-Ve5"/>
                             <constraint firstAttribute="trailing" secondItem="CCK-SR-a1R" secondAttribute="trailing" constant="14" id="SPf-0R-4sf"/>
+                            <constraint firstItem="CCK-SR-a1R" firstAttribute="top" secondItem="Cz8-zP-5TM" secondAttribute="bottom" constant="2" id="Vib-rs-J0W"/>
                             <constraint firstItem="ELo-xG-zpK" firstAttribute="leading" secondItem="jV9-hc-CUq" secondAttribute="leading" constant="14" id="ciR-TS-52U"/>
                             <constraint firstAttribute="trailing" secondItem="Cz8-zP-5TM" secondAttribute="trailing" constant="24" id="dYy-l3-qtZ"/>
                             <constraint firstAttribute="bottom" secondItem="ELo-xG-zpK" secondAttribute="bottom" constant="14" id="kOd-Hs-zUU"/>
                             <constraint firstItem="CCK-SR-a1R" firstAttribute="width" secondItem="ELo-xG-zpK" secondAttribute="width" id="pTv-i0-GpC"/>
                             <constraint firstItem="CCK-SR-a1R" firstAttribute="height" secondItem="ELo-xG-zpK" secondAttribute="height" id="uke-h2-OKh"/>
-                            <constraint firstItem="ELo-xG-zpK" firstAttribute="top" secondItem="Cz8-zP-5TM" secondAttribute="bottom" constant="2" id="voe-nh-g45"/>
                         </constraints>
                     </view>
                 </subviews>
@@ -81,7 +81,7 @@
                 <outlet property="containerView" destination="jV9-hc-CUq" id="1a8-V5-0Zt"/>
                 <outlet property="messageLabel" destination="Cz8-zP-5TM" id="N6i-58-FJp"/>
             </connections>
-            <point key="canvasLocation" x="874" y="97"/>
+            <point key="canvasLocation" x="873.91304347826099" y="96.428571428571431"/>
         </viewController>
     </objects>
     <resources>


### PR DESCRIPTION
## 🍎 관련 이슈
#267 

## 🍎 변경 사항 및 이유
* NadoAlert With SingleBtn 만들었습니다
* with TextField는 좀이따.. ㅎㅎ 일단 은주 언니 급하게 써야해서 먼저 올림!!

## 🍎 PR Point
* 우선 기본적으로 `showNadoAlert` 함수를 쓸 때 원래 type 파라미터가 없었기 때문에... 분기처리를 위해 새로 만들었고, optional로 만들어서 기존에 있던 애들은 기본적으로 `withDoubleBtn`으로 적용됨니다!!
* 은주언니가 SingleBtn 쓰고 싶을 때에는 꼭 `type: .singleBtn` 지정해 줘야 함!!
### 사용법
```
        guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
        
        alert.confirmBtn.press {
            self.requestSignOut()
        }
        
        alert.showNadoAlert(vc: self, message: "로그아웃할래?(미정)", confirmBtnTitle: "네", cancelBtnTitle: "", type: .withSingleBtn)
```

* SingleBtn에는 cancelBtn이 없기 때문에 거기에 press 후 코드 추가하거나, cancelBtnTitle에 파라미터 넣어줘도 안보임! 걍 cancelBtnTitle에는 빈 String이나 아무거나 넣어 주시면 됨ㄴㅣ다...


## 📸 ScreenShot

https://user-images.githubusercontent.com/43312096/156915223-9ee0e218-b25a-4065-a2d9-a80bceb59de6.mov


