### PR TITLE
🔨 [FIX] 정보 메인뷰 마지막 스레드 길이 버그 수정

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
@@ -47,6 +47,7 @@ class InfoMainVC: BaseVC {
     private var selectActionSheetIndex = 0
     private var infoList: [ClassroomPostList] = []
     weak var sendSegmentStateDelegate: SendSegmentStateDelegate?
+    private let contentSizeObserverKeyPath = "contentSize"
     
     // MARK: Life Cycle
     override func viewDidLoad() {
@@ -179,6 +180,18 @@ extension InfoMainVC {
         infoSegmentView.questionBtn.press {
             if let delegate = self.sendSegmentStateDelegate {
                 delegate.sendSegmentClicked(index: 0)
+            }
+        }
+    }
+    
+    /// infoQuestionListTV height값이 바뀌면 값을 비교하여 constraint를 업데이트하는 메서드
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
+        if (keyPath == contentSizeObserverKeyPath) {
+            if let newValue = change?[.newKey] {
+                let newSize  = newValue as! CGSize
+                self.infoQuestionListTV.snp.updateConstraints {
+                    $0.height.equalTo(newSize.height)
+                }
             }
         }
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
@@ -63,7 +63,12 @@ class InfoMainVC: BaseVC {
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        self.infoQuestionListTV.addObserver(self, forKeyPath: contentSizeObserverKeyPath, options: .new, context: nil)
         setUpRequestData(sortType: .recent)
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        self.infoQuestionListTV.removeObserver(self, forKeyPath: contentSizeObserverKeyPath)
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
@@ -189,7 +189,7 @@ extension InfoMainVC {
         }
     }
     
-    /// infoQuestionListTV height값이 바뀌면 값을 비교하여 constraint를 업데이트하는 메서드
+    /// infoQuestionListTV size값이 바뀌면 값을 비교하여 constraint를 업데이트하는 메서드
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
         if (keyPath == contentSizeObserverKeyPath) {
             if let newValue = change?[.newKey] {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
@@ -217,11 +217,7 @@ extension InfoMainVC: UITableViewDelegate {
     
     /// estimatedHeightForRowAt
     func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        if infoList.count == 0 {
-            return 515
-        } else {
-            return 120
-        }
+        return 0
     }
     
     /// heightForRowAt
@@ -256,12 +252,7 @@ extension InfoMainVC {
             case .success(let res):
                 if let data = res as? [ClassroomPostList] {
                     self.infoList = data
-                    DispatchQueue.main.async {
-                        self.infoQuestionListTV.reloadData()
-                        self.infoQuestionListTV.snp.updateConstraints {
-                            $0.height.equalTo(self.infoQuestionListTV.contentSize.height)
-                        }
-                    }
+                    self.infoQuestionListTV.reloadData()
                     self.activityIndicator.stopAnimating()
                 }
             case .requestErr(let msg):


### PR DESCRIPTION
## 🍎 관련 이슈
closed #270

## 🍎 변경 사항 및 이유
- infoQuestionListTV에 옵저버를 추가했습니다.

## 🍎 PR Point
- 지긋지긋한 tableView dynamic height.. 종결냈다 ..
- 이 옵저버 하나면 tableView size값이 변경될 때(스크롤 시 셀 재사용과 함께 tableView height가 늘어나야 할 때) 체크해서 tableView height를 업데이트할 수 있어서 estimatedHeight가 정확하지 않아도 서버통신 완료 후 받아온 데이터 개수만큼 문제없이 fit하게 tableView height 만들 수 있음!

## 📸 ScreenShot
<버그 있었던 사진>
<img width=375 src="https://user-images.githubusercontent.com/63224278/156918308-ea9f9b62-c200-4469-b4ae-ecd5547a843c.png">

<해결 후 사진>
<img width=375 src="https://user-images.githubusercontent.com/63224278/156918269-2a144761-6c58-47eb-846e-94afd7262984.png">