### PR TITLE
✨ [FEAT] 회원가입 메일 인증 플로우

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
@@ -231,8 +231,8 @@
 		C71BF23527CCD4A20030DCB9 /* NotificationSettingBasicTVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = C71BF23327CCD4A20030DCB9 /* NotificationSettingBasicTVC.xib */; };
 		C71BF23A27CD0CB50030DCB9 /* ResetPWVC.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C71BF23927CD0CB50030DCB9 /* ResetPWVC.storyboard */; };
 		C71BF23C27CD0CC80030DCB9 /* ResetPWVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71BF23B27CD0CC80030DCB9 /* ResetPWVC.swift */; };
-		C71BF23E27CD0CDF0030DCB9 /* ResetPWCompleteVC.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C71BF23D27CD0CDF0030DCB9 /* ResetPWCompleteVC.storyboard */; };
-		C71BF24027CD0CEB0030DCB9 /* ResetPWCompleteVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71BF23F27CD0CEB0030DCB9 /* ResetPWCompleteVC.swift */; };
+		C71BF23E27CD0CDF0030DCB9 /* MailCompleteVC.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C71BF23D27CD0CDF0030DCB9 /* MailCompleteVC.storyboard */; };
+		C71BF24027CD0CEB0030DCB9 /* MailCompleteVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71BF23F27CD0CEB0030DCB9 /* MailCompleteVC.swift */; };
 		C71BF24227CDC2B30030DCB9 /* SignOutResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71BF24127CDC2B30030DCB9 /* SignOutResponseModel.swift */; };
 		C740A85927C7C55D00C4518A /* EditProfileVC.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C740A85827C7C55D00C4518A /* EditProfileVC.storyboard */; };
 		C740A85B27C7C58500C4518A /* EditProfileVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C740A85A27C7C58500C4518A /* EditProfileVC.swift */; };
@@ -482,8 +482,8 @@
 		C71BF23327CCD4A20030DCB9 /* NotificationSettingBasicTVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NotificationSettingBasicTVC.xib; sourceTree = "<group>"; };
 		C71BF23927CD0CB50030DCB9 /* ResetPWVC.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ResetPWVC.storyboard; sourceTree = "<group>"; };
 		C71BF23B27CD0CC80030DCB9 /* ResetPWVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPWVC.swift; sourceTree = "<group>"; };
-		C71BF23D27CD0CDF0030DCB9 /* ResetPWCompleteVC.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ResetPWCompleteVC.storyboard; sourceTree = "<group>"; };
-		C71BF23F27CD0CEB0030DCB9 /* ResetPWCompleteVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPWCompleteVC.swift; sourceTree = "<group>"; };
+		C71BF23D27CD0CDF0030DCB9 /* MailCompleteVC.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MailCompleteVC.storyboard; sourceTree = "<group>"; };
+		C71BF23F27CD0CEB0030DCB9 /* MailCompleteVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailCompleteVC.swift; sourceTree = "<group>"; };
 		C71BF24127CDC2B30030DCB9 /* SignOutResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutResponseModel.swift; sourceTree = "<group>"; };
 		C740A85827C7C55D00C4518A /* EditProfileVC.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = EditProfileVC.storyboard; sourceTree = "<group>"; };
 		C740A85A27C7C58500C4518A /* EditProfileVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileVC.swift; sourceTree = "<group>"; };
@@ -1486,7 +1486,7 @@
 			isa = PBXGroup;
 			children = (
 				C71BF23927CD0CB50030DCB9 /* ResetPWVC.storyboard */,
-				C71BF23D27CD0CDF0030DCB9 /* ResetPWCompleteVC.storyboard */,
+				C71BF23D27CD0CDF0030DCB9 /* MailCompleteVC.storyboard */,
 			);
 			path = SB;
 			sourceTree = "<group>";
@@ -1495,7 +1495,7 @@
 			isa = PBXGroup;
 			children = (
 				C71BF23B27CD0CC80030DCB9 /* ResetPWVC.swift */,
-				C71BF23F27CD0CEB0030DCB9 /* ResetPWCompleteVC.swift */,
+				C71BF23F27CD0CEB0030DCB9 /* MailCompleteVC.swift */,
 			);
 			path = VC;
 			sourceTree = "<group>";
@@ -1664,7 +1664,7 @@
 				7754A32F279583A00093C230 /* ReviewDetailProfileTVC.xib in Resources */,
 				338CDB07278C9F9B00F8227A /* ClassroomQuestionEditTVC.xib in Resources */,
 				33B9B0DC27B8EB4400066C1F /* InfoQuestionTVC.xib in Resources */,
-				C71BF23E27CD0CDF0030DCB9 /* ResetPWCompleteVC.storyboard in Resources */,
+				C71BF23E27CD0CDF0030DCB9 /* MailCompleteVC.storyboard in Resources */,
 				3313648E2785D76400E0C118 /* ReviewSB.storyboard in Resources */,
 				331364B82786198000E0C118 /* Colorsets.xcassets in Resources */,
 				77A7591B279712B700A8E48B /* ReviewPostTagCVC.xib in Resources */,
@@ -1794,7 +1794,7 @@
 				77A7592A2798028900A8E48B /* PublicAPI.swift in Sources */,
 				5CF1F37D278C4E4E007B8DE9 /* SelectMajorModalTVC.swift in Sources */,
 				77A7593C2799C81B00A8E48B /* ReviewPostDetailData.swift in Sources */,
-				C71BF24027CD0CEB0030DCB9 /* ResetPWCompleteVC.swift in Sources */,
+				C71BF24027CD0CEB0030DCB9 /* MailCompleteVC.swift in Sources */,
 				5C32801C2797292B00781EBE /* MypageAPI.swift in Sources */,
 				5CF0EC2C279317FA00AF63E4 /* MypageUserVC+TV.swift in Sources */,
 				77ED045327AEBDAF00D077CA /* SendUpdateStatusDelegate.swift in Sources */,

--- a/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
@@ -251,6 +251,7 @@
 		C7C4145027C93C4700296C30 /* EditProfileResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4144F27C93C4700296C30 /* EditProfileResponseModel.swift */; };
 		C7F3F6D927D3858600E12888 /* AppLinkResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F3F6D827D3858600E12888 /* AppLinkResponseModel.swift */; };
 		C7F3F6DB27D3E38000E12888 /* WithDrawResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F3F6DA27D3E38000E12888 /* WithDrawResponseModel.swift */; };
+		C7F3F6DD27D5192D00E12888 /* ResendSignUpMailResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F3F6DC27D5192D00E12888 /* ResendSignUpMailResponseModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -502,6 +503,7 @@
 		C7C4144F27C93C4700296C30 /* EditProfileResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileResponseModel.swift; sourceTree = "<group>"; };
 		C7F3F6D827D3858600E12888 /* AppLinkResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLinkResponseModel.swift; sourceTree = "<group>"; };
 		C7F3F6DA27D3E38000E12888 /* WithDrawResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithDrawResponseModel.swift; sourceTree = "<group>"; };
+		C7F3F6DC27D5192D00E12888 /* ResendSignUpMailResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResendSignUpMailResponseModel.swift; sourceTree = "<group>"; };
 		CDEC227AA3B5687CFBF977B8 /* Pods-NadoSunbae-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NadoSunbae-iOS.debug.xcconfig"; path = "Target Support Files/Pods-NadoSunbae-iOS/Pods-NadoSunbae-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		FB09018B14FDA66E03F11D78 /* Pods_NadoSunbae_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NadoSunbae_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -1226,6 +1228,7 @@
 				5C9A93F827A64FB20097310B /* SignUpDataModel.swift */,
 				C71BF24127CDC2B30030DCB9 /* SignOutResponseModel.swift */,
 				C7F3F6DA27D3E38000E12888 /* WithDrawResponseModel.swift */,
+				C7F3F6DC27D5192D00E12888 /* ResendSignUpMailResponseModel.swift */,
 			);
 			path = Sign;
 			sourceTree = "<group>";
@@ -1878,6 +1881,7 @@
 				77A7591A279712B700A8E48B /* ReviewPostTagCVC.swift in Sources */,
 				338601062798B1F800C47D36 /* NaviType.swift in Sources */,
 				3313642A2784D3BD00E0C118 /* AppDelegate.swift in Sources */,
+				C7F3F6DD27D5192D00E12888 /* ResendSignUpMailResponseModel.swift in Sources */,
 				3391E497278B7AC50079EA31 /* ClassroomQuestionTVC.swift in Sources */,
 				331364702785B18100E0C118 /* UserDefaults+.swift in Sources */,
 				33CF634F27945C0400E92C04 /* NadoSegmentView.swift in Sources */,

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Sign/ResendSignUpMailResponseModel.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Sign/ResendSignUpMailResponseModel.swift
@@ -1,0 +1,12 @@
+//
+//  ResendSignUpMailResponseModel.swift
+//  NadoSunbae-iOS
+//
+//  Created by madilyn on 2022/03/07.
+//
+
+import Foundation
+
+struct ResendSignUpMailResponseModel: Codable {
+    var email: String
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Sign/SignUpDataModel.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Sign/SignUpDataModel.swift
@@ -8,16 +8,19 @@
 import Foundation
 
 struct SignUpDataModel: Codable {
-    let user: User
-    let accesstoken: String
+    var user: User
+
+    enum CodingKeys: String, CodingKey {
+        case user = "user"
+    }
     
     struct User: Codable {
-        let userID: Int
-        let createdAt: String
+        var userID: Int
+        var createdAt: String
 
         enum CodingKeys: String, CodingKey {
             case userID = "userId"
-            case createdAt
+            case createdAt = "createdAt"
         }
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/SignService.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/SignService.swift
@@ -15,6 +15,7 @@ enum SignService {
     case checkEmailDuplicate(email: String)
     case requestSignOut
     case requestWithDraw(PW: String)
+    case resendSignUpMail(email: String, PW: String)
 }
 
 extension SignService: TargetType {
@@ -36,12 +37,14 @@ extension SignService: TargetType {
             return "/auth/logout"
         case .requestWithDraw:
             return "/auth/secession"
+        case .resendSignUpMail:
+            return "/auth/certification/email"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .requestSignIn, .requestSignUp, .checkNickNameDuplicate, .checkEmailDuplicate, .requestSignOut, .requestWithDraw:
+        case .requestSignIn, .requestSignUp, .checkNickNameDuplicate, .checkEmailDuplicate, .requestSignOut, .resendSignUpMail, .requestWithDraw:
             return .post
         }
     }
@@ -69,6 +72,8 @@ extension SignService: TargetType {
             return .requestPlain
         case .requestWithDraw(let PW):
             return .requestParameters(parameters: ["password": PW], encoding: JSONEncoding.default)
+        case .resendSignUpMail(let email, let PW):
+            return .requestParameters(parameters: ["email": email, "password": PW], encoding: JSONEncoding.default)
         }
     }
     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/ResetPW/SB/MailCompleteVC.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/ResetPW/SB/MailCompleteVC.storyboard
@@ -17,10 +17,10 @@
         </array>
     </customFonts>
     <scenes>
-        <!--ResetPW CompleteVC-->
+        <!--Mail CompleteVC-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController storyboardIdentifier="ResetPWCompleteVC" id="Y6W-OH-hqX" customClass="ResetPWCompleteVC" customModule="NadoSunbae_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="MailCompleteVC" id="Y6W-OH-hqX" customClass="MailCompleteVC" customModule="NadoSunbae_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -88,6 +88,7 @@
                     </view>
                     <connections>
                         <outlet property="goSignInBtn" destination="TZe-qr-9Oe" id="4lL-Ok-qPh"/>
+                        <outlet property="infoLabel" destination="Zsm-0a-KLt" id="4aV-yY-7wl"/>
                         <outlet property="resendBtn" destination="pKJ-NL-rWk" id="Xh6-Sh-4OL"/>
                     </connections>
                 </viewController>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/ResetPW/VC/MailCompleteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/ResetPW/VC/MailCompleteVC.swift
@@ -7,7 +7,12 @@
 
 import UIKit
 
-class ResetPWCompleteVC: BaseVC {
+enum MailCompleteType {
+    case resetPW
+    case signUp
+}
+
+class MailCompleteVC: BaseVC {
     
     // MARK: @IBOutlet
     @IBOutlet weak var goSignInBtn: NadoSunbaeBtn! {
@@ -32,9 +37,20 @@ class ResetPWCompleteVC: BaseVC {
             }
         }
     }
+    @IBOutlet weak var infoLabel: UILabel! {
+        didSet {
+            switch completeType {
+            case .resetPW:
+                infoLabel.text = "비밀번호를 재설정할 수 있는 링크가 전송되었습니다."
+            case .signUp:
+                infoLabel.text = "학교 이메일 인증 링크가 전송되었어요.\n인증을 실시하면 회원가입이 완료됩니다."
+            }
+        }
+    }
     
     // MARK: Properties
     var email = ""
+    var completeType: MailCompleteType = .resetPW
     
     // MARK: Life Cycle
     override func viewDidLoad() {
@@ -54,7 +70,7 @@ class ResetPWCompleteVC: BaseVC {
 }
 
 // MARK: - Network
-extension ResetPWCompleteVC {
+extension MailCompleteVC {
     private func resendEmail(email: String) {
         self.activityIndicator.startAnimating()
         MypageSettingAPI.shared.requestResetPW(email: email) { networkResult in

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/ResetPW/VC/MailCompleteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/ResetPW/VC/MailCompleteVC.swift
@@ -50,6 +50,7 @@ class MailCompleteVC: BaseVC {
     
     // MARK: Properties
     var email = ""
+    var PW = ""
     var completeType: MailCompleteType = .resetPW
     
     // MARK: Life Cycle
@@ -73,17 +74,34 @@ class MailCompleteVC: BaseVC {
 extension MailCompleteVC {
     private func resendEmail(email: String) {
         self.activityIndicator.startAnimating()
-        MypageSettingAPI.shared.requestResetPW(email: email) { networkResult in
-            switch networkResult {
-            case .success:
-                self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "메일이 재전송되었습니다.")
-            case .requestErr:
-                self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
-            default:
-                self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+        switch completeType {
+        case .resetPW:
+            MypageSettingAPI.shared.requestResetPW(email: email) { networkResult in
+                switch networkResult {
+                case .success:
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "메일이 재전송되었습니다.")
+                case .requestErr:
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                default:
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                }
+            }
+        case .signUp:
+            SignAPI.shared.resendSignUpMail(email: email, PW: PW) { networkResult in
+                switch networkResult {
+                case .success:
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "메일이 재전송되었습니다.")
+                case .requestErr:
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                default:
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                }
             }
         }
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/ResetPW/VC/ResetPWVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/ResetPW/VC/ResetPWVC.swift
@@ -100,7 +100,7 @@ class ResetPWVC: BaseVC {
     }
     
     private func goResetPWComplete() {
-        guard let resetPWCompleteVC = UIStoryboard.init(name: ResetPWCompleteVC.className, bundle: nil).instantiateViewController(withIdentifier: ResetPWCompleteVC.className) as? ResetPWCompleteVC else { return }
+        guard let resetPWCompleteVC = UIStoryboard.init(name: MailCompleteVC.className, bundle: nil).instantiateViewController(withIdentifier: MailCompleteVC.className) as? MailCompleteVC else { return }
         resetPWCompleteVC.email = self.emailTextField.text ?? ""
         if isLogin() {
             self.navigationController?.pushViewController(resetPWCompleteVC, animated: true)
@@ -156,6 +156,7 @@ extension ResetPWVC {
             case .success:
                 self.setRemoveUserdefaultValues()
                 self.goResetPWComplete()
+                self.activityIndicator.stopAnimating()
             default:
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/SignUpMajorInfo/VC/SignUpMajorInfoVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/SignUpMajorInfo/VC/SignUpMajorInfoVC.swift
@@ -129,14 +129,17 @@ extension SignUpMajorInfoVC {
     /// textField에 값이 들어올 때마다 NextBtn 활성화할지를 체크하는 함수
     private func checkNextBtnIsEnabled() {
         if !(univTextField.isEmpty) && !(firstMajorTextField.isEmpty) && !(firstMajorStartTextField.isEmpty) {
-            if !(secondMajorTextField.isEmpty) && (secondMajorStartTextField.isEmpty) {
+            if secondMajorTextField.isEmpty {
+                secondMajorStartSelectBtn.isEnabled = true
                 nextBtn.isActivated = false
                 nextBtn.isEnabled = false
             } else {
-                nextBtn.isActivated = true
-                nextBtn.isEnabled = true
+                secondMajorStartSelectBtn.isEnabled = !(secondMajorTextField.text == "미진입")
+                nextBtn.isActivated = !(secondMajorStartTextField.isEmpty) || secondMajorTextField.text == "미진입"
+                nextBtn.isEnabled = !(secondMajorStartTextField.isEmpty) || secondMajorTextField.text == "미진입"
             }
         } else {
+            secondMajorStartSelectBtn.isEnabled = true
             nextBtn.isActivated = false
             nextBtn.isEnabled = false
         }
@@ -171,9 +174,9 @@ extension SignUpMajorInfoVC: SendUpdateModalDelegate {
             if let majorInfoData = data as? MajorInfoModel {
                 self.secondMajorTextField.text = majorInfoData.majorName
                 self.signUpData.secondMajorID = majorInfoData.majorID
-                // TODO: 서버 어떻게 나오는지에 따라 "미진입" 수정 가능
                 if majorInfoData.majorName == "미진입" {
                     self.signUpData.secondMajorStart = "미진입"
+                    self.secondMajorStartTextField.text = ""
                 }
             }
         case 3:

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/SignUpUserInfo/VC/SignUpUserInfoVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/SignUpUserInfo/VC/SignUpUserInfoVC.swift
@@ -341,15 +341,18 @@ extension SignUpUserInfoVC {
         SignAPI.shared.requestSignUp(userData: userData) { networkResult in
             switch networkResult {
             case .success(let res):
-                if let res = res as? SignUpDataModel {
+                if res is SignUpDataModel {
                     self.activityIndicator.stopAnimating()
-                    print("signUp response data: ", res)
-                    guard let vc = UIStoryboard.init(name: SignUpCompleteVC.className, bundle: nil).instantiateViewController(withIdentifier: SignUpCompleteVC.className) as? SignUpCompleteVC else { return }
-                    self.navigationController?.pushViewController(vc, animated: true)
+                    guard let mailCompleteVC = UIStoryboard.init(name: MailCompleteVC.className, bundle: nil).instantiateViewController(withIdentifier: MailCompleteVC.className) as? MailCompleteVC else { return }
+                    mailCompleteVC.completeType = .signUp
+                    mailCompleteVC.email = userData.email
+                    mailCompleteVC.modalPresentationStyle = .fullScreen
+                    self.present(mailCompleteVC, animated: true, completion: nil)
                 }
+                self.activityIndicator.stopAnimating()
             case .requestErr(let msg):
                 if let message = msg as? String {
-                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    self.makeAlert(title: message)
                     print("requestSignUp requestErr", message)
                     self.activityIndicator.stopAnimating()
                 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/SignUpUserInfo/VC/SignUpUserInfoVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/SignUpUserInfo/VC/SignUpUserInfoVC.swift
@@ -346,6 +346,7 @@ extension SignUpUserInfoVC {
                     guard let mailCompleteVC = UIStoryboard.init(name: MailCompleteVC.className, bundle: nil).instantiateViewController(withIdentifier: MailCompleteVC.className) as? MailCompleteVC else { return }
                     mailCompleteVC.completeType = .signUp
                     mailCompleteVC.email = userData.email
+                    mailCompleteVC.PW = userData.PW
                     mailCompleteVC.modalPresentationStyle = .fullScreen
                     self.present(mailCompleteVC, animated: true, completion: nil)
                 }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #277

## 🍎 변경 사항 및 이유
* 회원가입 후 메일 인증 뷰 구현
* 회원가입 후 메일 재전송 구현
* 로그인 시 메일인증 안 된 유저면 로그인 막고, 재전송 가능하도록 구현

## 🍎 PR Point
* 기존 ResetPWCompleteVC를 MailCompleteVC로 변경하면서 폴더도 옮기고 싶었는데 ㅎㅎ 컨플릭트 두려워서 우선 냅뒀어요..릴리즈 후 고칠것......

## 📸 ScreenShot
* 회원가입 후 메일 뷰

https://user-images.githubusercontent.com/43312096/156933492-e93fc1a9-5e22-4bd0-af42-eb6da868a704.mov

* 로그인 시 메일인증 안 된 유저 처리

https://user-images.githubusercontent.com/43312096/156933515-5d061466-2f12-460a-a851-093796eb7811.mov


