### PR TITLE
♻️ [REFACTOR] NadoHorizonContainerView, NadoSegmentView 재사용 컴포넌트 확장

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		331C538027961C9D0052B309 /* EntireQuestionListVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C537F27961C9D0052B309 /* EntireQuestionListVC.swift */; };
 		331C5382279629620052B309 /* BaseQuestionTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C5381279629620052B309 /* BaseQuestionTVC.swift */; };
 		331C5384279629D30052B309 /* EntireQuestionListTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C5383279629D30052B309 /* EntireQuestionListTVC.swift */; };
+		33393ADF27D4E85E007F2585 /* NSLayoutConstraint+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33393ADE27D4E85E007F2585 /* NSLayoutConstraint+.swift */; };
 		334D2E0427914C8800A4CA23 /* WriteQuestionSB.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 334D2E0327914C8800A4CA23 /* WriteQuestionSB.storyboard */; };
 		33856370278DC74D003C60A6 /* BaseTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3385636F278DC74D003C60A6 /* BaseTVC.swift */; };
 		3386010427988D0500C47D36 /* ActionSheetCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3386010327988D0500C47D36 /* ActionSheetCase.swift */; };
@@ -309,6 +310,7 @@
 		331C537F27961C9D0052B309 /* EntireQuestionListVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntireQuestionListVC.swift; sourceTree = "<group>"; };
 		331C5381279629620052B309 /* BaseQuestionTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseQuestionTVC.swift; sourceTree = "<group>"; };
 		331C5383279629D30052B309 /* EntireQuestionListTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntireQuestionListTVC.swift; sourceTree = "<group>"; };
+		33393ADE27D4E85E007F2585 /* NSLayoutConstraint+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLayoutConstraint+.swift"; sourceTree = "<group>"; };
 		334D2E0327914C8800A4CA23 /* WriteQuestionSB.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = WriteQuestionSB.storyboard; sourceTree = "<group>"; };
 		3385636F278DC74D003C60A6 /* BaseTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTVC.swift; sourceTree = "<group>"; };
 		3386010327988D0500C47D36 /* ActionSheetCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSheetCase.swift; sourceTree = "<group>"; };
@@ -658,6 +660,7 @@
 				331364BE27861D0600E0C118 /* Adjusted+.swift */,
 				330DA4342790C3E300FE127F /* UIScrollView+.swift */,
 				5CC0BFD72798768F00B96905 /* Int+.swift */,
+				33393ADE27D4E85E007F2585 /* NSLayoutConstraint+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1766,6 +1769,7 @@
 				3313646E2785AF9A00E0C118 /* UILabel+.swift in Sources */,
 				3313644F2785A84B00E0C118 /* NetworkResult.swift in Sources */,
 				77A759202797645E00A8E48B /* WriterData.swift in Sources */,
+				33393ADF27D4E85E007F2585 /* NSLayoutConstraint+.swift in Sources */,
 				331364562785A90F00E0C118 /* TypeOfViewController.swift in Sources */,
 				77A7591E279762BF00A8E48B /* ReviewPostRegisterData.swift in Sources */,
 				33CF63602794A03300E92C04 /* QuestionHeaderTVC.swift in Sources */,

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/BaseVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/BaseVC.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class BaseVC: UIViewController {
     
+    // MARK: Properties
     lazy var activityIndicator: UIActivityIndicatorView = {
         let activityIndicator = UIActivityIndicatorView()
         activityIndicator.frame = CGRect(x: 0, y: 0, width: 100, height: 100)
@@ -22,11 +23,18 @@ class BaseVC: UIViewController {
         return activityIndicator
     }()
     
+    let screenWidth = UIScreen.main.bounds.size.width
+    let screenHeight = UIScreen.main.bounds.size.height
+    
+    // MARK: Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
         view.addSubview(activityIndicator)
     }
-    
+}
+
+// MARK: - Custom Methods
+extension BaseVC {
     func hideTabbar() {
         self.tabBarController?.tabBar.isHidden = true
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/NSLayoutConstraint+.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/NSLayoutConstraint+.swift
@@ -1,0 +1,32 @@
+//
+//  NSLayoutConstraint+.swift
+//  NadoSunbae-iOS
+//
+//  Created by hwangJi on 2022/03/06.
+//
+
+import UIKit
+
+extension NSLayoutConstraint {
+    
+    /// Constraint의 Multiplier 반환하는 함수
+    func setMultiplier(multiplier: CGFloat) -> NSLayoutConstraint {
+        NSLayoutConstraint.deactivate([self])
+        
+        let newConstraint = NSLayoutConstraint(
+            item: firstItem!,
+            attribute: firstAttribute,
+            relatedBy: relation,
+            toItem: secondItem,
+            attribute: secondAttribute,
+            multiplier: multiplier,
+            constant: constant)
+        
+        newConstraint.priority = priority
+        newConstraint.shouldBeArchived = shouldBeArchived
+        newConstraint.identifier = identifier
+        
+        NSLayoutConstraint.activate([newConstraint])
+        return newConstraint
+    }
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Class/NadoHorizonContainerViews.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Class/NadoHorizonContainerViews.swift
@@ -10,14 +10,19 @@ import UIKit
 class NadoHorizonContainerViews: UIView {
     
     @IBOutlet var externalSV: UIScrollView!
+    @IBOutlet var containerStackView: UIStackView!
     @IBOutlet var firstContainerView: UIView!
     @IBOutlet var secondContainerView: UIView!
+    @IBOutlet var contentViewWidth: NSLayoutConstraint!
     
     let xibName = NadoHorizonContainerViews.className
     
-    override init(frame: CGRect) {
+    init(frame: CGRect, containerCount: CGFloat) {
         super.init(frame: frame)
         self.commonInit()
+        
+        /// contentView의 width를 컨테이너의 수만큼 곱해준다
+        contentViewWidth = contentViewWidth.setMultiplier(multiplier: containerCount)
     }
     
     required init?(coder aDecoder: NSCoder) {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Class/NadoHorizonContainerViews.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Class/NadoHorizonContainerViews.swift
@@ -17,12 +17,9 @@ class NadoHorizonContainerViews: UIView {
     
     let xibName = NadoHorizonContainerViews.className
     
-    init(frame: CGRect, containerCount: CGFloat) {
+    override init(frame: CGRect) {
         super.init(frame: frame)
         self.commonInit()
-        
-        /// contentView의 width를 컨테이너의 수만큼 곱해준다
-        contentViewWidth = contentViewWidth.setMultiplier(multiplier: containerCount)
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -34,5 +31,14 @@ class NadoHorizonContainerViews: UIView {
         let view = Bundle.main.loadNibNamed(xibName, owner: self, options: nil)?.first as! UIView
         view.frame = self.bounds
         self.addSubview(view)
+    }
+}
+
+// MARK: - Custom Methods
+extension NadoHorizonContainerViews {
+
+    /// contentView의 width를 컨테이너의 수만큼 곱해주는 메서드
+    func setMultiplier(containerCount: CGFloat) {
+        contentViewWidth = contentViewWidth.setMultiplier(multiplier: containerCount)
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Class/NadoSegmentView.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Class/NadoSegmentView.swift
@@ -16,16 +16,20 @@ class NadoSegmentView: UIView {
         $0.backgroundColor = .paleGray
     }
     
-    let questionBtn = NadoSunbaeBtn().then {
+    let firstBtn = NadoSunbaeBtn().then {
         $0.setBtnColors(normalBgColor: .paleGray, normalFontColor: .gray3, activatedBgColor: .mainLight, activatedFontColor: .mainDefault)
-        $0.setTitleWithStyle(title: "질문", size: 14.0)
         $0.isActivated = true
         $0.isEnabled = true
     }
     
-    let infoBtn = NadoSunbaeBtn().then {
+    let secondBtn = NadoSunbaeBtn().then {
         $0.setBtnColors(normalBgColor: .paleGray, normalFontColor: .gray3, activatedBgColor: .mainLight, activatedFontColor: .mainDefault)
-        $0.setTitleWithStyle(title: "정보", size: 14.0)
+        $0.isActivated = false
+        $0.isEnabled = true
+    }
+    
+    let thirdBtn = NadoSunbaeBtn().then {
+        $0.setBtnColors(normalBgColor: .paleGray, normalFontColor: .gray3, activatedBgColor: .mainLight, activatedFontColor: .mainDefault)
         $0.isActivated = false
         $0.isEnabled = true
     }
@@ -46,22 +50,29 @@ class NadoSegmentView: UIView {
 // MARK: - UI
 extension NadoSegmentView {
     func configureUI() {
-        self.addSubviews([backView, questionBtn, infoBtn])
+        self.addSubviews([backView, firstBtn, secondBtn, thirdBtn])
         
         backView.snp.makeConstraints {
             $0.top.leading.trailing.bottom.equalToSuperview()
         }
         
-        questionBtn.snp.makeConstraints {
+        firstBtn.snp.makeConstraints {
             $0.top.bottom.equalToSuperview()
             $0.leading.equalTo(backView).offset(24)
             $0.width.equalTo(56)
             $0.height.equalToSuperview()
         }
         
-        infoBtn.snp.makeConstraints {
+        secondBtn.snp.makeConstraints {
             $0.top.bottom.equalToSuperview()
-            $0.leading.equalTo(questionBtn.snp.trailing).offset(16)
+            $0.leading.equalTo(firstBtn.snp.trailing).offset(16)
+            $0.width.equalTo(56)
+            $0.height.equalToSuperview()
+        }
+        
+        thirdBtn.snp.makeConstraints {
+            $0.top.bottom.equalToSuperview()
+            $0.leading.equalTo(secondBtn.snp.trailing).offset(16)
             $0.width.equalTo(56)
             $0.height.equalToSuperview()
         }
@@ -71,7 +82,7 @@ extension NadoSegmentView {
 // MARK: - Custom Methods
 extension NadoSegmentView {
     func setUpBtnVibrateAction() {
-        [questionBtn, infoBtn].forEach() {
+        [firstBtn, secondBtn, thirdBtn].forEach() {
             $0.press(vibrate: true, for: .touchUpInside) {
                 return
             }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/NadoHorizonContainerViews.xib
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/NadoHorizonContainerViews.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -10,7 +10,9 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="NadoHorizonContainerViews" customModule="NadoSunbae_iOS" customModuleProvider="target">
             <connections>
-                <outlet property="externalSV" destination="rv7-ya-V6l" id="rVC-x1-MnL"/>
+                <outlet property="containerStackView" destination="Pxq-n3-pgb" id="9P0-to-Bg6"/>
+                <outlet property="contentViewWidth" destination="zcE-mB-f1K" id="dDe-0B-ZJ4"/>
+                <outlet property="externalSV" destination="rv7-ya-V6l" id="vJX-3a-StI"/>
                 <outlet property="firstContainerView" destination="crx-MA-fub" id="A1T-67-EV3"/>
                 <outlet property="secondContainerView" destination="iQL-OW-TLe" id="kPR-B3-IGw"/>
             </connections>
@@ -24,17 +26,17 @@
                     <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CLa-ye-x0J">
-                            <rect key="frame" x="0.0" y="0.0" width="828" height="818"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="818"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         </view>
                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Pxq-n3-pgb">
-                            <rect key="frame" x="0.0" y="0.0" width="828" height="818"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="818"/>
                             <subviews>
                                 <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="crx-MA-fub">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="818"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="207" height="818"/>
                                 </containerView>
                                 <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iQL-OW-TLe">
-                                    <rect key="frame" x="414" y="0.0" width="414" height="818"/>
+                                    <rect key="frame" x="207" y="0.0" width="207" height="818"/>
                                 </containerView>
                             </subviews>
                         </stackView>
@@ -51,7 +53,7 @@
                         <constraint firstAttribute="trailing" secondItem="CLa-ye-x0J" secondAttribute="trailing" id="qxG-BC-nMu"/>
                         <constraint firstItem="CLa-ye-x0J" firstAttribute="leading" secondItem="rv7-ya-V6l" secondAttribute="leading" id="seK-6R-pZu"/>
                         <constraint firstItem="CLa-ye-x0J" firstAttribute="height" secondItem="rv7-ya-V6l" secondAttribute="height" id="yL5-G8-5NO"/>
-                        <constraint firstItem="CLa-ye-x0J" firstAttribute="width" secondItem="rv7-ya-V6l" secondAttribute="width" multiplier="2" id="zcE-mB-f1K"/>
+                        <constraint firstItem="CLa-ye-x0J" firstAttribute="width" secondItem="rv7-ya-V6l" secondAttribute="width" id="zcE-mB-f1K"/>
                     </constraints>
                 </scrollView>
             </subviews>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/ClassroomMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/ClassroomMainVC.swift
@@ -25,7 +25,9 @@ class ClassroomMainVC: UIViewController {
     }
     
     private let majorSelectBtn = UIButton()
-    private var classroomContainerView: NadoHorizonContainerViews?
+    private var classroomContainerView = NadoHorizonContainerViews().then {
+        $0.setMultiplier(containerCount: 2)
+    }
     
     // MARK: IBOutlet
     @IBOutlet var topNaviView: UIView!
@@ -49,8 +51,7 @@ class ClassroomMainVC: UIViewController {
 extension ClassroomMainVC {
     private func configureUI() {
         topNaviView.addSubviews([majorLabel, bottomArrowImgView, majorSelectBtn])
-        classroomContainerView = NadoHorizonContainerViews(frame: self.view.frame, containerCount: 2)
-        self.view.addSubview(classroomContainerView!)
+        self.view.addSubview(classroomContainerView)
         
         majorLabel.snp.makeConstraints {
             $0.bottom.equalTo(topNaviView.snp.bottom).offset(-24)
@@ -68,7 +69,7 @@ extension ClassroomMainVC {
             $0.leading.equalTo(majorLabel)
         }
         
-        classroomContainerView?.snp.makeConstraints {
+        classroomContainerView.snp.makeConstraints {
             $0.top.equalTo(topNaviView.snp.bottom)
             $0.leading.trailing.bottom.equalToSuperview()
         }
@@ -90,15 +91,15 @@ extension ClassroomMainVC {
             $0.view.translatesAutoresizingMaskIntoConstraints = false
         }
         
-        classroomContainerView?.firstContainerView.addSubview(questionMainVC.view)
-        classroomContainerView?.secondContainerView.addSubview(infoMainVC.view)
+        classroomContainerView.firstContainerView.addSubview(questionMainVC.view)
+        classroomContainerView.secondContainerView.addSubview(infoMainVC.view)
         
         questionMainVC.view.snp.makeConstraints {
-            $0.top.leading.trailing.bottom.equalTo(self.classroomContainerView!)
+            $0.top.leading.trailing.bottom.equalTo(self.classroomContainerView)
         }
         
         infoMainVC.view.snp.makeConstraints {
-            $0.top.leading.trailing.bottom.equalTo(classroomContainerView!.secondContainerView)
+            $0.top.leading.trailing.bottom.equalTo(classroomContainerView.secondContainerView)
         }
         
         questionMainVC.didMove(toParent: self)
@@ -145,9 +146,9 @@ extension ClassroomMainVC: SendSegmentStateDelegate {
     /// segment가 클릭되면 index에 따라 ContainerView의 ContentOffset.x 좌표를 바꿔주는 메서드
     func sendSegmentClicked(index: Int) {
         if index == 0 {
-            classroomContainerView?.externalSV.contentOffset.x = 0
+            classroomContainerView.externalSV.contentOffset.x = 0
         } else {
-            classroomContainerView?.externalSV.contentOffset.x += screenWidth
+            classroomContainerView.externalSV.contentOffset.x += screenWidth
         }
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/ClassroomMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/ClassroomMainVC.swift
@@ -25,7 +25,7 @@ class ClassroomMainVC: UIViewController {
     }
     
     private let majorSelectBtn = UIButton()
-    private let classroomContainerView = NadoHorizonContainerViews()
+    private var classroomContainerView: NadoHorizonContainerViews?
     
     // MARK: IBOutlet
     @IBOutlet var topNaviView: UIView!
@@ -49,7 +49,8 @@ class ClassroomMainVC: UIViewController {
 extension ClassroomMainVC {
     private func configureUI() {
         topNaviView.addSubviews([majorLabel, bottomArrowImgView, majorSelectBtn])
-        self.view.addSubview(classroomContainerView)
+        classroomContainerView = NadoHorizonContainerViews(frame: self.view.frame, containerCount: 2)
+        self.view.addSubview(classroomContainerView!)
         
         majorLabel.snp.makeConstraints {
             $0.bottom.equalTo(topNaviView.snp.bottom).offset(-24)
@@ -67,7 +68,7 @@ extension ClassroomMainVC {
             $0.leading.equalTo(majorLabel)
         }
         
-        classroomContainerView.snp.makeConstraints {
+        classroomContainerView?.snp.makeConstraints {
             $0.top.equalTo(topNaviView.snp.bottom)
             $0.leading.trailing.bottom.equalToSuperview()
         }
@@ -89,15 +90,15 @@ extension ClassroomMainVC {
             $0.view.translatesAutoresizingMaskIntoConstraints = false
         }
         
-        classroomContainerView.firstContainerView.addSubview(questionMainVC.view)
-        classroomContainerView.secondContainerView.addSubview(infoMainVC.view)
+        classroomContainerView?.firstContainerView.addSubview(questionMainVC.view)
+        classroomContainerView?.secondContainerView.addSubview(infoMainVC.view)
         
         questionMainVC.view.snp.makeConstraints {
-            $0.top.leading.trailing.bottom.equalTo(self.classroomContainerView)
+            $0.top.leading.trailing.bottom.equalTo(self.classroomContainerView!)
         }
         
         infoMainVC.view.snp.makeConstraints {
-            $0.top.leading.trailing.bottom.equalTo(classroomContainerView.secondContainerView)
+            $0.top.leading.trailing.bottom.equalTo(classroomContainerView!.secondContainerView)
         }
         
         questionMainVC.didMove(toParent: self)
@@ -144,9 +145,9 @@ extension ClassroomMainVC: SendSegmentStateDelegate {
     /// segment가 클릭되면 index에 따라 ContainerView의 ContentOffset.x 좌표를 바꿔주는 메서드
     func sendSegmentClicked(index: Int) {
         if index == 0 {
-            classroomContainerView.externalSV.contentOffset.x = 0
+            classroomContainerView?.externalSV.contentOffset.x = 0
         } else {
-            classroomContainerView.externalSV.contentOffset.x += screenWidth
+            classroomContainerView?.externalSV.contentOffset.x += screenWidth
         }
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
@@ -60,7 +60,6 @@ class InfoDetailVC: BaseVC {
     private var isTextViewEmpty: Bool = true
     private var sendTextViewLineCount: Int = 1
     private var isWriter: Bool?
-    private let screenHeight = UIScreen.main.bounds.size.height
     private let textViewMaxHeight: CGFloat = 85.adjustedH
     private let whiteBackView = UIView()
     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
@@ -20,6 +20,7 @@ class InfoMainVC: BaseVC {
         [$0.firstBtn, $0.secondBtn].forEach() {
             $0.isEnabled = true
         }
+        $0.thirdBtn.isHidden = true
     }
     
     private let infoSV = UIScrollView().then {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
@@ -13,9 +13,11 @@ class InfoMainVC: BaseVC {
     
     // MARK: Properties
     let infoSegmentView = NadoSegmentView().then {
-        $0.questionBtn.isActivated = false
-        $0.infoBtn.isActivated = true
-        [$0.questionBtn, $0.infoBtn].forEach() {
+        $0.firstBtn.setTitleWithStyle(title: "질문", size: 14.0)
+        $0.secondBtn.setTitleWithStyle(title: "정보", size: 14.0)
+        $0.firstBtn.isActivated = false
+        $0.secondBtn.isActivated = true
+        [$0.firstBtn, $0.secondBtn].forEach() {
             $0.isEnabled = true
         }
     }
@@ -182,7 +184,7 @@ extension InfoMainVC {
     
     /// 정보 segment를 눌렀을 때 실행되는 액션 메서드
     func setUpTapQuestionBtn() {
-        infoSegmentView.questionBtn.press {
+        infoSegmentView.firstBtn.press {
             if let delegate = self.sendSegmentStateDelegate {
                 delegate.sendSegmentClicked(index: 0)
             }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -70,7 +70,6 @@ class DefaultQuestionChatVC: BaseVC {
     private var editedCommentIndexPath: [IndexPath] = []
     private var isCommentSend: Bool = false
     private var actionSheetString: [String] = []
-    private let screenHeight = UIScreen.main.bounds.size.height
     private var isTextViewEmpty: Bool = true
     private var sendTextViewLineCount: Int = 1
     private var keyboardShowUpY: CGFloat = 0

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionMainVC.swift
@@ -55,7 +55,11 @@ class QuestionMainVC: BaseVC {
         $0.removeSeparatorsOfEmptyCellsAndLastCell()
     }
     
-    let questionSegmentView = NadoSegmentView()
+    let questionSegmentView = NadoSegmentView().then {
+        $0.firstBtn.setTitleWithStyle(title: "질문", size: 14.0)
+        $0.secondBtn.setTitleWithStyle(title: "정보", size: 14.0)
+    }
+    
     private var questionList: [ClassroomPostList] = []
     weak var sendSegmentStateDelegate: SendSegmentStateDelegate?
     let halfVC = HalfModalVC()
@@ -171,7 +175,7 @@ extension QuestionMainVC {
     
     /// '정보' 버튼을 눌렀을 때 액션 set 메서드
     private func setUpTapInfoBtn() {
-        questionSegmentView.infoBtn.press {
+        questionSegmentView.secondBtn.press {
             
             if let delegate = self.sendSegmentStateDelegate {
                 delegate.sendSegmentClicked(index: 1)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionMainVC.swift
@@ -58,6 +58,7 @@ class QuestionMainVC: BaseVC {
     let questionSegmentView = NadoSegmentView().then {
         $0.firstBtn.setTitleWithStyle(title: "질문", size: 14.0)
         $0.secondBtn.setTitleWithStyle(title: "정보", size: 14.0)
+        $0.thirdBtn.isHidden = true
     }
     
     private var questionList: [ClassroomPostList] = []

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyPostListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyPostListVC.swift
@@ -16,10 +16,10 @@ class MypageMyPostListVC: BaseVC {
             case .question:
                 break
             case .information:
-                segmentView.questionBtn.isActivated = false
-                segmentView.questionBtn.isEnabled = true
-                segmentView.infoBtn.isActivated = true
-                segmentView.infoBtn.isEnabled = false
+                segmentView.firstBtn.isActivated = false
+                segmentView.firstBtn.isEnabled = true
+                segmentView.secondBtn.isActivated = true
+                segmentView.secondBtn.isEnabled = false
             }
         }
     }
@@ -57,12 +57,12 @@ class MypageMyPostListVC: BaseVC {
 // MARK: - Custom Methods
 extension MypageMyPostListVC {
     private func setUpTapSegmentBtn() {
-        segmentView.infoBtn.press {
+        segmentView.secondBtn.press {
             if let delegate = self.sendSegmentStateDelegate {
                 delegate.sendSegmentClicked(index: 1)
             }
         }
-        segmentView.questionBtn.press {
+        segmentView.firstBtn.press {
             if let delegate = self.sendSegmentStateDelegate {
                 delegate.sendSegmentClicked(index: 0)
             }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyPostListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyPostListVC.swift
@@ -12,6 +12,10 @@ class MypageMyPostListVC: BaseVC {
     // MARK: @IBOutlet
     @IBOutlet weak var segmentView: NadoSegmentView! {
         didSet {
+            segmentView.firstBtn.setTitleWithStyle(title: "질문", size: 14.0)
+            segmentView.secondBtn.setTitleWithStyle(title: "정보", size: 14.0)
+            segmentView.thirdBtn.isHidden = true
+            
             switch postType {
             case .question:
                 break

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
@@ -24,7 +24,6 @@ class MypagePostListVC: BaseVC {
     
     // MARK: Properties
     var isPostOrAnswer = true
-    private let screenWidth = UIScreen.main.bounds.size.width
 
     // MARK: LifeCycle
     override func viewDidLoad() {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
@@ -20,7 +20,11 @@ class MypagePostListVC: BaseVC {
         }
     }
     
-    @IBOutlet weak var postListContainerView: NadoHorizonContainerViews!
+    @IBOutlet weak var postListContainerView: NadoHorizonContainerViews! {
+        didSet {
+            postListContainerView.setMultiplier(containerCount: 2)
+        }
+    }
     
     // MARK: Properties
     var isPostOrAnswer = true

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
@@ -63,7 +63,6 @@ class ReviewWriteVC: BaseVC {
     
     /// 데이터 삽입을 위한 리스트 변수
     private var bgImgList: [ReviewWriteBgImgData] = []
-    let screenHeight = UIScreen.main.bounds.size.height
     
     // 새글 작성, 기존글 수정 구분 위한 변수
     var isPosting: Bool = true

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/SignUpUserInfo/VC/SignUpUserInfoVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/SignUpUserInfo/VC/SignUpUserInfoVC.swift
@@ -36,7 +36,6 @@ class SignUpUserInfoVC: BaseVC {
     let disposeBag = DisposeBag()
     var isCompleteList = [false, false, false]
     var signUpData = SignUpBodyModel()
-    let screenHeight = UIScreen.main.bounds.size.height
     
     // MARK: LifeCycle
     override func viewDidLoad() {


### PR DESCRIPTION
## 🍎 관련 이슈
closed #272

## 🍎 변경 사항 및 이유
- NadoHorizonContainerView는 추후 몇개가 되든 상관없게끔 확장가능성을 열어두어 리펙토링했습니다. (디폴트는 2개입니다.)
- NadoSegmentView내 btn을 3개로 확장했습니다. (그에 따른 네이밍도 수정 --> first, second, third)

## 🍎 PR Point
- NadoHorizonContainerView의 viewWidth의 Multiplier를 containerCount만큼 곱해주게되면, stackView의 너비도 해당 너비만큼 커지므로, stackView에 들어갈 수 있는 컨테이너의 개수가 해당 갯수만큼 늘어나게 됩니다.
- 어떻게 확장해서 사용하느냐. 예를 들어 3개의 컨테이너를 사용하고 싶다면, 디폴트인 2개 container는 IBOutlet으로 연결되어있으나 한개 container는 코드로 심어주어야합니다! -> 요건 좋아요목록 구현시 코드로 보여드리겠습니다!

## 📸 ScreenShot
[NadoSegmentView 3개 사용 시]
<img width=375 src = "https://user-images.githubusercontent.com/63224278/156936669-a8ab25f4-12c7-47c9-b68d-edc9e9ba48d0.png">