### PR TITLE
✅ [CHORE] 스플래시 화면 적용

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
@@ -2084,7 +2084,7 @@
 				INFOPLIST_FILE = "NadoSunbae-iOS/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "나도선배";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UILaunchStoryboardName = SignInSB;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
@@ -2115,7 +2115,7 @@
 				INFOPLIST_FILE = "NadoSunbae-iOS/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "나도선배";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UILaunchStoryboardName = SignInSB;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UIUserInterfaceStyle = Light;

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/SB/SignInSB.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/SB/SignInSB.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="RDp-6C-syV">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="RDp-6C-syV">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -210,18 +210,31 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="~ 대충 런치스크린과 동일한 이미지 ~" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xz7-fP-PqO">
-                                <rect key="frame" x="63" y="395.66666666666669" width="249" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logoLogin" translatesAutoresizingMaskIntoConstraints="NO" id="Sil-ob-9Yz">
+                                <rect key="frame" x="75" y="344" width="225" height="76"/>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="© nadosunbae" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g4Y-B9-ein">
+                                <rect key="frame" x="147.66666666666666" y="771" width="80" height="15"/>
+                                <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="12"/>
+                                <color key="textColor" name="mainText"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="학과 후기 열람부터 전공생과의 질의응답까지!" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7SI-hQ-xtF">
+                                <rect key="frame" x="81" y="428" width="213" height="15"/>
+                                <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="12"/>
+                                <color key="textColor" name="mainDark"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="5VA-lh-SpP"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="xz7-fP-PqO" firstAttribute="centerX" secondItem="PkO-Ju-Iqk" secondAttribute="centerX" id="GcA-i3-h0G"/>
-                            <constraint firstItem="xz7-fP-PqO" firstAttribute="centerY" secondItem="PkO-Ju-Iqk" secondAttribute="centerY" id="zVQ-6H-kOh"/>
+                            <constraint firstAttribute="bottom" secondItem="g4Y-B9-ein" secondAttribute="bottom" constant="26" id="A4j-X7-fcq"/>
+                            <constraint firstItem="g4Y-B9-ein" firstAttribute="centerX" secondItem="5VA-lh-SpP" secondAttribute="centerX" id="Jkx-6i-3jx"/>
+                            <constraint firstItem="7SI-hQ-xtF" firstAttribute="top" secondItem="Sil-ob-9Yz" secondAttribute="bottom" constant="8" id="ax6-VB-XT5"/>
+                            <constraint firstItem="7SI-hQ-xtF" firstAttribute="centerX" secondItem="5VA-lh-SpP" secondAttribute="centerX" id="kJ2-Dm-8fk"/>
+                            <constraint firstItem="Sil-ob-9Yz" firstAttribute="centerX" secondItem="5VA-lh-SpP" secondAttribute="centerX" id="uJO-QJ-uCi"/>
+                            <constraint firstItem="Sil-ob-9Yz" firstAttribute="top" secondItem="PkO-Ju-Iqk" secondAttribute="top" constant="344" id="w1K-Tp-zQJ"/>
                         </constraints>
                     </view>
                 </viewController>
@@ -241,6 +254,9 @@
         </namedColor>
         <namedColor name="mainDark">
             <color red="0.019607843137254902" green="0.63137254901960782" blue="0.5607843137254902" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="mainText">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.23529411764705882" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="paleGray">
             <color red="0.98431372549019602" green="0.98431372549019602" blue="0.99215686274509807" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/VC/AutoSignInVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/VC/AutoSignInVC.swift
@@ -41,11 +41,9 @@ extension AutoSignInVC {
     
     /// 로그인 요청하는 메서드
     private func requestSignIn() {
-        self.activityIndicator.startAnimating()
         SignAPI.shared.requestSignIn(email: email, PW: PW, deviceToken: UserDefaults.standard.string(forKey: UserDefaults.Keys.FCMTokenForDevice) ?? "") { networkResult in
             switch networkResult {
             case .success(let res):
-                self.activityIndicator.stopAnimating()
                 if let data = res as? SignInDataModel {
                     self.setUpUserdefaultValues(data: data)
                     let nadoSunbaeTBC = NadoSunbaeTBC()
@@ -53,7 +51,6 @@ extension AutoSignInVC {
                     self.present(nadoSunbaeTBC, animated: true, completion: nil)
                 }
             default:
-                self.activityIndicator.stopAnimating()
                 print("Failed Auto SignIn")
                 guard let signInVC = self.storyboard?.instantiateViewController(withIdentifier: SignInVC.className) as? SignInVC else { return }
                 signInVC.modalPresentationStyle = .fullScreen

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Support/AppDelegate.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Support/AppDelegate.swift
@@ -13,6 +13,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         UNUserNotificationCenter.current().delegate = self
         
+        // 스플래시 지속시간 고려한 지연시간
+        sleep(1)
+        
         // MARK: Firebase 초기화
         FirebaseApp.configure()
         

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Support/Assets.xcassets/logoLogin.imageset/Contents.json
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Support/Assets.xcassets/logoLogin.imageset/Contents.json
@@ -2,18 +2,18 @@
   "images" : [
     {
       "filename" : "logoLogin.png",
-      "scale" : "1x",
-      "idiom" : "universal"
-    },
-    {
-      "filename" : "logoLogin@2x.png",
-      "scale" : "2x",
-      "idiom" : "universal"
+      "idiom" : "universal",
+      "scale" : "1x"
     },
     {
       "idiom" : "universal",
-      "filename" : "logoLogin@3x.png",
-      "scale" : "3x"
+      "filename" : "logoLogin@2x.png",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x",
+      "filename" : "logoLogin@3x.png"
     }
   ],
   "info" : {


### PR DESCRIPTION
## 🍎 관련 이슈
closed #278

## 🍎 변경 사항 및 이유
- 스플래시 화면을 구성했습니다.

## 🍎 PR Point
- General에 LaunchScreen File을 디폴트 `LaunchScreen`에서 `SignInSB`로 변경했습니다.
- 스크럼때 스플래시 지속시간 2초로 픽스되어서 데이터 로딩시간까지 2초정도로 보이도록 
appDelegate에 지연시간을 1초로 해두었습니다.
- 자동로그인 API 호출 부분에 loading Indicator설정 코드를 지워 자동로그인 통신 시간까지 스플래시 처럼 보이도록 하였습니다.

## 📸 ScreenShot

https://user-images.githubusercontent.com/63277563/156994852-24d83b42-5917-4a48-9cbc-75ad29d2465a.mp4
