### PR TITLE
✨ [FEAT] access 토큰 만료 시 처리

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ClassroomAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ClassroomAPI.swift
@@ -214,7 +214,9 @@ extension ClassroomAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr
@@ -232,7 +234,9 @@ extension ClassroomAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr
@@ -250,7 +254,9 @@ extension ClassroomAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr
@@ -268,7 +274,9 @@ extension ClassroomAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr
@@ -287,7 +295,9 @@ extension ClassroomAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr
@@ -305,7 +315,9 @@ extension ClassroomAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr
@@ -323,7 +335,9 @@ extension ClassroomAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr
@@ -341,7 +355,9 @@ extension ClassroomAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr
@@ -359,7 +375,9 @@ extension ClassroomAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr
@@ -377,7 +395,9 @@ extension ClassroomAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/MypageAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/MypageAPI.swift
@@ -10,7 +10,7 @@ import Moya
 
 class MypageAPI {
     static let shared = MypageAPI()
-    private var provider = MoyaProvider<MypageService>()
+    private var provider = MoyaProvider<MypageService>(plugins: [NetworkLoggerPlugin()])
     
     private init() {}
 }
@@ -126,7 +126,9 @@ extension MypageAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/MypageAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/MypageAPI.swift
@@ -145,7 +145,9 @@ extension MypageAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr
@@ -162,7 +164,9 @@ extension MypageAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr
@@ -179,7 +183,9 @@ extension MypageAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/MypageSettingAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/MypageSettingAPI.swift
@@ -90,7 +90,9 @@ extension MypageSettingAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr
@@ -106,7 +108,9 @@ extension MypageSettingAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr
@@ -122,7 +126,9 @@ extension MypageSettingAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/NotificationAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/NotificationAPI.swift
@@ -77,7 +77,9 @@ extension NotificationAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr
@@ -94,7 +96,9 @@ extension NotificationAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr
@@ -111,7 +115,9 @@ extension NotificationAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/PublicAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/PublicAPI.swift
@@ -111,7 +111,9 @@ extension PublicAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr
@@ -128,7 +130,9 @@ extension PublicAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ReviewAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ReviewAPI.swift
@@ -123,13 +123,15 @@ extension ReviewAPI {
     /// createReviewPostJudgeData
     func createReviewPostJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
-        let decodedData = try? decoder.decode(GenericResponse<ReviewPostRegisterData>.self, from: data)
+        guard let decodedData = try? decoder.decode(GenericResponse<ReviewPostRegisterData>.self, from: data) else { return .pathErr }
         
         switch status {
         case 200...204:
-            return .success(decodedData?.data ?? "None-Data")
-        case 400...409:
-            return .requestErr(decodedData?.message)
+            return .success(decodedData.data ?? "None-Data")
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
+            return .requestErr(decodedData.message)
         case 500:
             return .serverErr
         default:
@@ -140,13 +142,15 @@ extension ReviewAPI {
     /// getReviewPostListJudgeData
     func getReviewPostListJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
-        let decodedData = try? decoder.decode(GenericResponse<[ReviewMainPostListData]>.self, from: data)
+        guard let decodedData = try? decoder.decode(GenericResponse<[ReviewMainPostListData]>.self, from: data) else { return .pathErr }
         
         switch status {
         case 200...204:
-            return .success(decodedData?.data ?? "None-Data")
-        case 400...409:
-            return .requestErr(decodedData?.message)
+            return .success(decodedData.data ?? "None-Data")
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
+            return .requestErr(decodedData.message)
         case 500:
             return .serverErr
         default:
@@ -157,13 +161,15 @@ extension ReviewAPI {
     /// getReviewPostDetailJudgeData
     func getReviewPostDetailJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
-        let decodedData = try? decoder.decode(GenericResponse<ReviewPostDetailData>.self, from: data)
+        guard let decodedData = try? decoder.decode(GenericResponse<ReviewPostDetailData>.self, from: data) else { return .pathErr }
         
         switch status {
         case 200...204:
-            return .success(decodedData?.data ?? "None-Data")
-        case 400...409:
-            return .requestErr(decodedData?.message)
+            return .success(decodedData.data ?? "None-Data")
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
+            return .requestErr(decodedData.message)
         case 500:
             return .serverErr
         default:
@@ -174,13 +180,13 @@ extension ReviewAPI {
     /// getReviewHomepageJudgeData
     func getReviewHomepageJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
-        let decodedData = try? decoder.decode(GenericResponse<ReviewHomePageData>.self, from: data)
+        guard let decodedData = try? decoder.decode(GenericResponse<ReviewHomePageData>.self, from: data) else { return .pathErr }
         
         switch status {
         case 200...204:
-            return .success(decodedData?.data ?? "None-Data")
+            return .success(decodedData.data ?? "None-Data")
         case 400...409:
-            return .requestErr(decodedData?.message)
+            return .requestErr(decodedData.message)
         case 500:
             return .serverErr
         default:
@@ -191,13 +197,15 @@ extension ReviewAPI {
     /// deleteReviewPostJudgeData
     func deleteReviewPostJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
-        let decodedData = try? decoder.decode(GenericResponse<ReviewDeleteResModel>.self, from: data)
+        guard let decodedData = try? decoder.decode(GenericResponse<ReviewDeleteResModel>.self, from: data) else { return .pathErr }
         
         switch status {
         case 200...204:
-            return .success(decodedData?.data ?? "None-Data")
-        case 400...409:
-            return .requestErr(decodedData?.message)
+            return .success(decodedData.data ?? "None-Data")
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
+            return .requestErr(decodedData.message)
         case 500:
             return .serverErr
         default:
@@ -208,13 +216,15 @@ extension ReviewAPI {
     /// editReviewPostJudgeData
     func editReviewPostJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
-        let decodedData = try? decoder.decode(GenericResponse<ReviewEditData>.self, from: data)
+        guard let decodedData = try? decoder.decode(GenericResponse<ReviewEditData>.self, from: data) else { return .pathErr }
         
         switch status {
         case 200...204:
-            return .success(decodedData?.data ?? "None-Data")
-        case 400...409:
-            return .requestErr(decodedData?.message)
+            return .success(decodedData.data ?? "None-Data")
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
+            return .requestErr(decodedData.message)
         case 500:
             return .serverErr
         default:

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/SignAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/SignAPI.swift
@@ -232,7 +232,9 @@ extension SignAPI {
         switch status {
         case 200...204:
             return .success(decodedData.message)
-        case 400...409:
+        case 401:
+            return .requestErr(false)
+        case 400, 402...409:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/SignAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/SignAPI.swift
@@ -279,7 +279,7 @@ extension SignAPI {
         guard let decodedData = try? decoder.decode(GenericResponse<SignInDataModel>.self, from: data) else { return .pathErr }
         switch status {
         case 200...204:
-            return .success(decodedData.message)
+            return .success(decodedData.data ?? "None-Data")
         case 400...409:
             return .requestErr(decodedData.message)
         case 500:

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
@@ -397,11 +397,15 @@ extension InfoDetailVC {
                         self.activityIndicator.stopAnimating()
                     }
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
                     self.activityIndicator.stopAnimating()
                     self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.optionalBindingData()
+                    }
                 }
             default:
                 self.activityIndicator.stopAnimating()
@@ -423,11 +427,15 @@ extension InfoDetailVC {
                         self.activityIndicator.stopAnimating()
                     }
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
                     self.activityIndicator.stopAnimating()
                     self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.requestCreateComment(postID: self.postID ?? 0, comment: self.commentTextView.text)
+                    }
                 }
             default:
                 self.activityIndicator.stopAnimating()
@@ -448,11 +456,15 @@ extension InfoDetailVC {
                     }
                     self.activityIndicator.stopAnimating()
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
                     self.activityIndicator.stopAnimating()
                     self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.requestPostLikeData(postID: self.postID ?? 0, postTypeID: .info)
+                    }
                 }
             default:
                 self.activityIndicator.stopAnimating()
@@ -469,12 +481,16 @@ extension InfoDetailVC {
             case .success(_):
                 self.navigationController?.popViewController(animated: true)
                 self.activityIndicator.stopAnimating()
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.requestDeletePostQuestion(postID: self.postID ?? 0)
+                    }
                 }
-                self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
@@ -490,12 +506,17 @@ extension InfoDetailVC {
             case .success(_):
                 self.requestGetDetailInfoData(postID: self.postID ?? 0, addLoadBackView: false)
                 self.activityIndicator.stopAnimating()
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.activityIndicator.stopAnimating()
+                        self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    }
                 }
-                self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
@@ -511,11 +532,17 @@ extension InfoDetailVC {
             case .success(_):
                 self.makeAlert(title: "신고되었습니다.")
                 self.activityIndicator.stopAnimating()
-            case .requestErr(let msg):
-                if let message = msg as? String {
-                    self.makeAlert(title: message)
+            case .requestErr(let res):
+                if let message = res as? String {
+                    print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.activityIndicator.stopAnimating()
+                        self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    }
                 }
-                self.activityIndicator.stopAnimating()
             default:
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
@@ -276,12 +276,16 @@ extension InfoMainVC {
                     self.infoQuestionListTV.reloadData()
                     self.activityIndicator.stopAnimating()
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.setUpRequestData(sortType: .recent)
+                    }
                 }
-                self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "서버 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "서버 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -721,11 +721,15 @@ extension DefaultQuestionChatVC {
                     self.configueTextViewPlaceholder(userType: self.userType ?? -1, questionType: self.questionType ?? .personal)
                     self.activityIndicator.stopAnimating()
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
                     self.activityIndicator.stopAnimating()
-                    self.makeAlert(title: "내부 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.optionalBindingData()
+                    }
                 }
             default:
                 self.activityIndicator.stopAnimating()
@@ -747,11 +751,15 @@ extension DefaultQuestionChatVC {
                         self.activityIndicator.stopAnimating()
                     }
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
                     self.activityIndicator.stopAnimating()
-                    self.makeAlert(title: "내부 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.requestCreateComment(postID: self.postID ?? 0, comment: self.sendAreaTextView.text)
+                    }
                 }
             default:
                 self.activityIndicator.stopAnimating()
@@ -770,11 +778,15 @@ extension DefaultQuestionChatVC {
                     self.requestGetDetailQuestionData(postID: self.postID ?? 0)
                     self.activityIndicator.stopAnimating()
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
                     self.activityIndicator.stopAnimating()
-                    self.makeAlert(title: "내부 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.requestPostClassroomLikeData(postID: self.postID ?? 0, postTypeID: self.questionType ?? .personal)
+                    }
                 }
             default:
                 self.activityIndicator.stopAnimating()
@@ -792,12 +804,17 @@ extension DefaultQuestionChatVC {
                 self.isCommentEdited = true
                 self.requestGetDetailQuestionData(postID: self.postID ?? 0)
                 self.activityIndicator.stopAnimating()
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.activityIndicator.stopAnimating()
+                        self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    }
                 }
-                self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
@@ -813,12 +830,16 @@ extension DefaultQuestionChatVC {
             case .success(_):
                 self.navigationController?.popViewController(animated: true)
                 self.activityIndicator.stopAnimating()
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.requestDeletePostQuestion(postID: self.postID ?? 0)
+                    }
                 }
-                self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
@@ -836,12 +857,17 @@ extension DefaultQuestionChatVC {
                     self.requestGetDetailQuestionData(postID: self.postID ?? 0)
                 }
                 self.activityIndicator.stopAnimating()
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.activityIndicator.stopAnimating()
+                        self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    }
                 }
-                self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
@@ -857,11 +883,17 @@ extension DefaultQuestionChatVC {
             case .success(_):
                 self.makeAlert(title: "신고되었습니다.")
                 self.activityIndicator.stopAnimating()
-            case .requestErr(let msg):
-                if let message = msg as? String {
-                    self.makeAlert(title: message)
+            case .requestErr(let res):
+                if let message = res as? String {
+                    print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.activityIndicator.stopAnimating()
+                        self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    }
                 }
-                self.activityIndicator.stopAnimating()
             default:
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/EntireQuestionListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/EntireQuestionListVC.swift
@@ -224,11 +224,16 @@ extension EntireQuestionListVC {
                         }
                     }
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.setUpRequestData(sortType: .recent)
+                    }
                 }
-                self.makeAlert(title: "내부 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             case .pathErr:
                 print("pathErr")
                 self.makeAlert(title: "내부 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/EntireQuestionListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/EntireQuestionListVC.swift
@@ -211,9 +211,11 @@ extension EntireQuestionListVC {
     
     /// 전체 질문, 정보글 전체 목록 조회 및 정렬 API 요청 메서드
     func requestGetGroupOrInfoListData(majorID: Int, postTypeID: QuestionType, sort: ListSortType) {
+        self.activityIndicator.startAnimating()
         ClassroomAPI.shared.getGroupQuestionOrInfoListAPI(majorID: majorID, postTypeID: postTypeID.rawValue, sort: sort) { networkResult in
             switch networkResult {
             case .success(let res):
+                self.activityIndicator.stopAnimating()
                 if let data = res as? [ClassroomPostList] {
                     self.questionList = data
                     DispatchQueue.main.async {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/EntireQuestionListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/EntireQuestionListVC.swift
@@ -236,14 +236,8 @@ extension EntireQuestionListVC {
                         self.setUpRequestData(sortType: .recent)
                     }
                 }
-            case .pathErr:
-                print("pathErr")
-                self.makeAlert(title: "내부 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
-            case .serverErr:
-                print("serverErr")
-                self.makeAlert(title: "서버 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
-            case .networkFail:
-                print("networkFail")
+            default:
+                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionMainVC.swift
@@ -345,12 +345,17 @@ extension QuestionMainVC {
                     self.updateEntireQuestionTV()
                     self.activityIndicator.stopAnimating()
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.activityIndicator.stopAnimating()
+                        self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    }
                 }
-                self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "내부 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             case .pathErr:
                 print("pathErr")
                 self.activityIndicator.stopAnimating()

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionPersonListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionPersonListVC.swift
@@ -9,7 +9,7 @@ import UIKit
 import SnapKit
 import Then
 
-class QuestionPersonListVC: UIViewController {
+class QuestionPersonListVC: BaseVC {
     
     // MARK: Properties
     private let questionPersonNaviBar = NadoSunbaeNaviBar().then {
@@ -205,18 +205,27 @@ extension QuestionPersonListVC {
     
     /// 특정 학과 User List 조회를 요청하는 API
     private func getMajorUserList() {
+        self.activityIndicator.startAnimating()
         ClassroomAPI.shared.getMajorUserListAPI(majorID: majorID, completion: { networkResult in
             switch networkResult {
             case .success(let res):
+                self.activityIndicator.stopAnimating()
                 if let data = res as? MajorUserListDataModel {
                     self.majorUserList = data
                     self.questionPersonCV.reloadData()
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.getMajorUserList()
+                    }
                 }
             default:
+                self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         })

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
@@ -395,12 +395,16 @@ extension WriteQuestionVC {
             case .success(_):
                 self.activityIndicator.stopAnimating()
                 self.dismiss(animated: true, completion: nil)
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.createClassroomPost(majorID: self.majorID, answerID: self.answerID ?? nil, postTypeID: self.questionType.rawValue, title: self.questionTitleTextField.text ?? "", content: self.questionWriteTextView.text ?? "")
+                    }
                 }
-                self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
@@ -415,12 +419,18 @@ extension WriteQuestionVC {
             case .success(_):
                 self.activityIndicator.stopAnimating()
                 self.dismiss(animated: true, completion: nil)
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        if let postID = self.postID {
+                            self.editClassroomPost(postID: postID, title: self.questionTitleTextField.text ?? "", content: self.questionWriteTextView.text ?? "")
+                        }
+                    }
                 }
-                self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/MypageMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/MypageMainVC.swift
@@ -181,14 +181,19 @@ extension MypageMainVC {
                         self.activityIndicator.stopAnimating()
                     }
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
                     self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.getUserPersonalQuestionList()
+                    }
                 }
             default:
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
                 self.activityIndicator.stopAnimating()
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }) 
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyPostListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyPostListVC.swift
@@ -162,10 +162,14 @@ extension MypageMyPostListVC {
                         self.activityIndicator.stopAnimating()
                     }
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
                     self.activityIndicator.stopAnimating()
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.getMypageMyPostList()
+                    }
                 }
             default:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
@@ -194,10 +198,14 @@ extension MypageMyPostListVC {
                         self.activityIndicator.stopAnimating()
                     }
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
                     self.activityIndicator.stopAnimating()
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.getMypageMyAnswerList()
+                    }
                 }
             default:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyReviewVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyReviewVC.swift
@@ -127,11 +127,15 @@ extension MypageMyReviewVC {
                     self.setEmptyView()
                 }
                 self.activityIndicator.stopAnimating()
-            case .requestErr(let msg):
-                self.activityIndicator.stopAnimating()
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
                     self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    self.activityIndicator.stopAnimating()
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.getMypageMyReview()
+                    }
                 }
             default:
                 self.activityIndicator.stopAnimating()

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC.swift
@@ -236,12 +236,16 @@ extension MypageUserVC {
                         self.navigationController?.popViewController(animated: true)
                     }
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
-                    print("request err: ", message)
+            case .requestErr(let res):
+                if let message = res as? String {
+                    print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.requestBlockUser(blockUserID: self.userInfo.userID)
+                    }
                 }
-                self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
@@ -258,11 +262,16 @@ extension MypageUserVC {
                 if let _ = res as? ClassroomQuestionDetailData {
                     self.activityIndicator.stopAnimating()
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
                     self.activityIndicator.stopAnimating()
-                    self.makeAlert(title: "내부 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.activityIndicator.stopAnimating()
+                        self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    }
                 }
             default:
                 self.activityIndicator.stopAnimating()

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/ProfileSetting/VC/EditProfileVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/ProfileSetting/VC/EditProfileVC.swift
@@ -269,12 +269,16 @@ extension EditProfileVC {
             case .success:
                 self.activityIndicator.stopAnimating()
                 self.navigationController?.popViewController(animated: true)
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.requestEditProfile(data: self.profileData)
+                    }
                 }
-                self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/ResetPW/VC/ResetPWVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/ResetPW/VC/ResetPWVC.swift
@@ -157,6 +157,16 @@ extension ResetPWVC {
                 self.setRemoveUserdefaultValues()
                 self.goResetPWComplete()
                 self.activityIndicator.stopAnimating()
+            case .requestErr(let res):
+                if let message = res as? String {
+                    print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.requestSignOut()
+                    }
+                }
             default:
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/BlockListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/BlockListVC.swift
@@ -88,12 +88,16 @@ extension BlockListVC {
                     self.blockListTV.reloadData()
                     self.activityIndicator.stopAnimating()
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
-                    print("request err: ", message)
+            case .requestErr(let res):
+                if let message = res as? String {
+                    print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.getBlockList()
+                    }
                 }
-                self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
@@ -110,12 +114,17 @@ extension BlockListVC {
                     self.getBlockList()
                     self.activityIndicator.stopAnimating()
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
-                    print("request err: ", message)
+            case .requestErr(let res):
+                if let message = res as? String {
+                    print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.activityIndicator.stopAnimating()
+                        self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    }
                 }
-                self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingAppInfoVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingAppInfoVC.swift
@@ -122,12 +122,16 @@ extension SettingAppInfoVC {
                     self.latestVersion = response.iOS
                     self.appInfoTV.reloadRows(at: [IndexPath(row: 3, section: 0)], with: .none)
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
-                    print("request err: ", message)
+            case .requestErr(let res):
+                if let message = res as? String {
+                    print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.getLatestVersion()
+                    }
                 }
-                self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/Setting/VC/SettingVC.swift
@@ -169,6 +169,16 @@ extension SettingVC {
                 guard let signInVC = UIStoryboard.init(name: "SignInSB", bundle: nil).instantiateViewController(withIdentifier: SignInVC.className) as? SignInVC else { return }
                 signInVC.modalPresentationStyle = .fullScreen
                 self.present(signInVC, animated: true, completion: nil)
+            case .requestErr(let res):
+                if let message = res as? String {
+                    print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.requestSignOut()
+                    }
+                }
             default:
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Notification/VC/NotificationMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Notification/VC/NotificationMainVC.swift
@@ -82,12 +82,16 @@ extension NotificationMainVC {
                     }
                     self.activityIndicator.stopAnimating()
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
-                    print("request err: ", message)
+            case .requestErr(let res):
+                if let message = res as? String {
+                    print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.getNotiList()
+                    }
                 }
-                self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
@@ -103,11 +107,16 @@ extension NotificationMainVC {
                 if res is ReadNotificationDataModel {
                     self.getNotiList()
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
-                    print("request err: ", message)
+            case .requestErr(let res):
+                if let message = res as? String {
+                    print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.getNotiList()
+                    }
                 }
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
@@ -122,11 +131,16 @@ extension NotificationMainVC {
                 if res is DeleteNotificationDataModel {
                     self.getNotiList()
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
-                    print("request err: ", message)
+            case .requestErr(let res):
+                if let message = res as? String {
+                    print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.getNotiList()
+                    }
                 }
-                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             default:
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewMainLinkTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewMainLinkTVC.swift
@@ -50,12 +50,9 @@ extension ReviewMainLinkTVC {
                 if let message = msg as? String {
                     print(message)
                 }
-            case .pathErr:
-                print("pathErr")
-            case .serverErr:
-                print("serverErr")
-            case .networkFail:
-                print("networkFail")
+            default:
+                self.activityIndicator.stopAnimating()
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
@@ -260,10 +260,15 @@ extension ReviewDetailVC {
                     self.reviewPostTV.reloadData()
                     self.activityIndicator.stopAnimating()
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
                     self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.requestGetReviewPostDetail(postID: self.postId ?? -1)
+                    }
                 }
             default:
                 self.activityIndicator.stopAnimating()
@@ -283,11 +288,15 @@ extension ReviewDetailVC {
                     print(res)
                     self.activityIndicator.stopAnimating()
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
                     self.activityIndicator.stopAnimating()
                     self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.requestPostReviewDetailLikeData(postID: self.postId ?? 0, postTypeID: .review)
+                    }
                 }
             default:
                 self.activityIndicator.stopAnimating()
@@ -308,10 +317,15 @@ extension ReviewDetailVC {
                     self.activityIndicator.stopAnimating()
                     self.navigationController?.popViewController(animated: true)
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
                     self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.requestDeleteReviewPost(postID: self.postId ?? -1)
+                    }
                 }
             default:
                 self.activityIndicator.stopAnimating()
@@ -328,11 +342,17 @@ extension ReviewDetailVC {
             case .success(_):
                 self.makeAlert(title: "신고되었습니다.")
                 self.activityIndicator.stopAnimating()
-            case .requestErr(let msg):
-                if let message = msg as? String {
-                    self.makeAlert(title: message)
+            case .requestErr(let res):
+                if let message = res as? String {
+                    print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.activityIndicator.stopAnimating()
+                        self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    }
                 }
-                self.activityIndicator.stopAnimating()
             default:
                 self.activityIndicator.stopAnimating()
                 self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
@@ -427,11 +427,17 @@ extension ReviewMainVC {
                         self.reviewTV.reloadData()
                     }
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.activityIndicator.stopAnimating()
+                        self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    }
                 }
-                self.activityIndicator.stopAnimating()
             case .pathErr:
                 print("pathErr")
                 self.activityIndicator.stopAnimating()

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
@@ -478,12 +478,9 @@ extension ReviewWriteVC {
                         self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
                     }
                 }
-            case .pathErr:
-                print("pathErr")
-            case .serverErr:
-                print("serverErr")
-            case .networkFail:
-                print("networkFail")
+            default:
+                self.activityIndicator.stopAnimating()
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
@@ -437,9 +437,16 @@ extension ReviewWriteVC {
                     self.dismiss(animated: true)
                     print(data)
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.activityIndicator.stopAnimating()
+                        self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    }
                 }
             case .pathErr:
                 print("pathErr")
@@ -457,12 +464,19 @@ extension ReviewWriteVC {
             switch networkResult {
                 
             case .success(let res):
-                if let data = res as? ReviewEditData {
+                if res is ReviewEditData {
                     self.dismiss(animated: true)
                 }
-            case .requestErr(let msg):
-                if let message = msg as? String {
+            case .requestErr(let res):
+                if let message = res as? String {
                     print(message)
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                } else if res is Bool {
+                    self.updateAccessToken { _ in
+                        self.activityIndicator.stopAnimating()
+                        self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    }
                 }
             case .pathErr:
                 print("pathErr")

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/VC/AutoSignInVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/VC/AutoSignInVC.swift
@@ -21,22 +21,6 @@ class AutoSignInVC: BaseVC {
     }
 }
 
-// MARK: Custom Methods
-extension AutoSignInVC {
-    
-    /// Userdefaults에 값 지정하는 메서드
-    private func setUpUserdefaultValues(data: SignInDataModel) {
-        UserDefaults.standard.set(data.accesstoken, forKey: UserDefaults.Keys.AccessToken)
-        UserDefaults.standard.set(data.refreshtoken, forKey: UserDefaults.Keys.RefreshToken)
-        UserDefaults.standard.set(data.user.firstMajorID, forKey: UserDefaults.Keys.FirstMajorID)
-        UserDefaults.standard.set(data.user.firstMajorName, forKey: UserDefaults.Keys.FirstMajorName)
-        UserDefaults.standard.set(data.user.secondMajorID, forKey: UserDefaults.Keys.SecondMajorID)
-        UserDefaults.standard.set(data.user.secondMajorName, forKey: UserDefaults.Keys.SecondMajorName)
-        UserDefaults.standard.set(data.user.isReviewed, forKey: UserDefaults.Keys.IsReviewed)
-        UserDefaults.standard.set(data.user.userID, forKey: UserDefaults.Keys.UserID)
-    }
-}
-
 // MARK: Network
 extension AutoSignInVC {
     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/VC/SignInVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/VC/SignInVC.swift
@@ -116,7 +116,7 @@ extension SignInVC {
     }
     
     /// Userdefaults에 값 지정하는 메서드
-    private func setUpUserdefaultValues(data: SignInDataModel) {
+    private func setUpUserdefaultValuesForSignIn(data: SignInDataModel) {
         UserDefaults.standard.set(data.accesstoken, forKey: UserDefaults.Keys.AccessToken)
         UserDefaults.standard.set(data.refreshtoken, forKey: UserDefaults.Keys.RefreshToken)
         UserDefaults.standard.set(data.user.firstMajorID, forKey: UserDefaults.Keys.FirstMajorID)
@@ -130,7 +130,7 @@ extension SignInVC {
     }
     
     private func doForIsEmailVerified(data: SignInDataModel) {
-        self.setUpUserdefaultValues(data: data)
+        self.setUpUserdefaultValuesForSignIn(data: data)
         let nadoSunbaeTBC = NadoSunbaeTBC()
         nadoSunbaeTBC.modalPresentationStyle = .fullScreen
         self.present(nadoSunbaeTBC, animated: true, completion: nil)


### PR DESCRIPTION
## 🍎 관련 이슈
closed #288 

## 🍎 변경 사항 및 이유
*  access토큰 만료 status 분기처리
* refresh토큰으로 acces토큰 갱신(자동로그인api와 동일) 처리
* access토큰 갱신 실패 시, 로그아웃 처리 이후 로그인 페이지로 이동
* 모든 api 요청 코드에 이거 붙여
* 지은언니가 부탁한 인디케이터 넣음
* 네트워크 요청 실패 처리(pathErr, serverErr 등등) 통일할 수 있는 것 통일함. 보이는것만...
* 은주언니 decode 코드에서 warning 있던 부분 수정함

## 🍎 PR Point
* 최대한! accessToken 갱신하고 기존 요청 그대로 처리하도록 했는데, 내가 건들면 ~콩지아줏됏어~ 될 것 같은 부분은 그냥 토큰 갱신만 하고 네트워크 오류 alert 띄우게 처리했슴. 릴리즈 하고 나서는 토큰 시간 길어지니까 자주 있는 일은 아닌데, 각자 나중에 릴리즈 후 업데이트할 때 이 부분이 신경쓰인다면 처리해 주면 좋을 것 같아요!!

## 📸 ScreenShot
* 아래 영상은 과방탭에서 
> 내가 건들면 ~콩지아줏됏어~ 될 것 같은 부분은 그냥 토큰 갱신만 하고 네트워크 오류 alert 띄우게 처리했슴. 

이 부분처럼 처리한 거고, 토큰은 갱신되었기 때문에 다른 탭 갔다오거나 다시 시도하면 갱신 성공되어있는 부분!!

https://user-images.githubusercontent.com/43312096/157089651-97d7163e-33f8-4f87-920a-93a1062f1531.mov


* 액세스+리프레시 토큰 만료 시 로그아웃시키고 로그인 페이지로 이동하는 것도 적용했는데.....이것............만나는 경우가 하늘의 별따기라.... 아무튼구현했슴...