### PR TITLE
🔨 [FIX] 과방 최신순/좋아요 정렬 관련 버그 전면 수정

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		331C5384279629D30052B309 /* EntireQuestionListTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C5383279629D30052B309 /* EntireQuestionListTVC.swift */; };
 		33393ADF27D4E85E007F2585 /* NSLayoutConstraint+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33393ADE27D4E85E007F2585 /* NSLayoutConstraint+.swift */; };
 		334D2E0427914C8800A4CA23 /* WriteQuestionSB.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 334D2E0327914C8800A4CA23 /* WriteQuestionSB.storyboard */; };
+		3381083527D53E19005AF1F9 /* MypageLikeListVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3381083427D53E18005AF1F9 /* MypageLikeListVC.swift */; };
 		33856370278DC74D003C60A6 /* BaseTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3385636F278DC74D003C60A6 /* BaseTVC.swift */; };
 		3386010427988D0500C47D36 /* ActionSheetCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3386010327988D0500C47D36 /* ActionSheetCase.swift */; };
 		338601062798B1F800C47D36 /* NaviType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338601052798B1F800C47D36 /* NaviType.swift */; };
@@ -313,6 +314,7 @@
 		331C5383279629D30052B309 /* EntireQuestionListTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntireQuestionListTVC.swift; sourceTree = "<group>"; };
 		33393ADE27D4E85E007F2585 /* NSLayoutConstraint+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLayoutConstraint+.swift"; sourceTree = "<group>"; };
 		334D2E0327914C8800A4CA23 /* WriteQuestionSB.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = WriteQuestionSB.storyboard; sourceTree = "<group>"; };
+		3381083427D53E18005AF1F9 /* MypageLikeListVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageLikeListVC.swift; sourceTree = "<group>"; };
 		3385636F278DC74D003C60A6 /* BaseTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTVC.swift; sourceTree = "<group>"; };
 		3386010327988D0500C47D36 /* ActionSheetCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSheetCase.swift; sourceTree = "<group>"; };
 		338601052798B1F800C47D36 /* NaviType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaviType.swift; sourceTree = "<group>"; };
@@ -865,6 +867,7 @@
 			children = (
 				331364AB2785D96D00E0C118 /* MypageMainVC.swift */,
 				5C5AFCBC279400060045E47A /* MypageMainVC+TV.swift */,
+				3381083627D53E52005AF1F9 /* LikeList */,
 			);
 			path = VC;
 			sourceTree = "<group>";
@@ -894,6 +897,14 @@
 				331C537D2795F6260052B309 /* QuestionPeopleHeaderView.swift */,
 			);
 			path = CVC;
+			sourceTree = "<group>";
+		};
+		3381083627D53E52005AF1F9 /* LikeList */ = {
+			isa = PBXGroup;
+			children = (
+				3381083427D53E18005AF1F9 /* MypageLikeListVC.swift */,
+			);
+			path = LikeList;
 			sourceTree = "<group>";
 		};
 		3391E48A278B48EF0079EA31 /* Cell */ = {
@@ -1775,6 +1786,7 @@
 				33393ADF27D4E85E007F2585 /* NSLayoutConstraint+.swift in Sources */,
 				331364562785A90F00E0C118 /* TypeOfViewController.swift in Sources */,
 				77A7591E279762BF00A8E48B /* ReviewPostRegisterData.swift in Sources */,
+				3381083527D53E19005AF1F9 /* MypageLikeListVC.swift in Sources */,
 				33CF63602794A03300E92C04 /* QuestionHeaderTVC.swift in Sources */,
 				331364642785ADFE00E0C118 /* BaseVC.swift in Sources */,
 				5CA7E410278BC18D00D748E0 /* SelectMajorModalVC.swift in Sources */,

--- a/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
@@ -63,6 +63,12 @@
 		33393ADF27D4E85E007F2585 /* NSLayoutConstraint+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33393ADE27D4E85E007F2585 /* NSLayoutConstraint+.swift */; };
 		334D2E0427914C8800A4CA23 /* WriteQuestionSB.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 334D2E0327914C8800A4CA23 /* WriteQuestionSB.storyboard */; };
 		3381083527D53E19005AF1F9 /* MypageLikeListVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3381083427D53E18005AF1F9 /* MypageLikeListVC.swift */; };
+		3381083827D53F33005AF1F9 /* MypageReviewLikeVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3381083727D53F33005AF1F9 /* MypageReviewLikeVC.swift */; };
+		3381083A27D53F4A005AF1F9 /* MypageClassroomPostListVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3381083927D53F4A005AF1F9 /* MypageClassroomPostListVC.swift */; };
+		33834A1527D5F66E001C4947 /* MypageLikePostType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33834A1427D5F66E001C4947 /* MypageLikePostType.swift */; };
+		33834A1727D60530001C4947 /* MypageLikeListSB.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 33834A1627D60530001C4947 /* MypageLikeListSB.storyboard */; };
+		33834A1927D63245001C4947 /* MypageLikePostDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33834A1827D63245001C4947 /* MypageLikePostDataModel.swift */; };
+		33834A1D27D67FAB001C4947 /* MypageLikeReviewDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33834A1C27D67FAB001C4947 /* MypageLikeReviewDataModel.swift */; };
 		33856370278DC74D003C60A6 /* BaseTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3385636F278DC74D003C60A6 /* BaseTVC.swift */; };
 		3386010427988D0500C47D36 /* ActionSheetCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3386010327988D0500C47D36 /* ActionSheetCase.swift */; };
 		338601062798B1F800C47D36 /* NaviType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338601052798B1F800C47D36 /* NaviType.swift */; };
@@ -315,6 +321,12 @@
 		33393ADE27D4E85E007F2585 /* NSLayoutConstraint+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLayoutConstraint+.swift"; sourceTree = "<group>"; };
 		334D2E0327914C8800A4CA23 /* WriteQuestionSB.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = WriteQuestionSB.storyboard; sourceTree = "<group>"; };
 		3381083427D53E18005AF1F9 /* MypageLikeListVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageLikeListVC.swift; sourceTree = "<group>"; };
+		3381083727D53F33005AF1F9 /* MypageReviewLikeVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageReviewLikeVC.swift; sourceTree = "<group>"; };
+		3381083927D53F4A005AF1F9 /* MypageClassroomPostListVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageClassroomPostListVC.swift; sourceTree = "<group>"; };
+		33834A1427D5F66E001C4947 /* MypageLikePostType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageLikePostType.swift; sourceTree = "<group>"; };
+		33834A1627D60530001C4947 /* MypageLikeListSB.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MypageLikeListSB.storyboard; sourceTree = "<group>"; };
+		33834A1827D63245001C4947 /* MypageLikePostDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageLikePostDataModel.swift; sourceTree = "<group>"; };
+		33834A1C27D67FAB001C4947 /* MypageLikeReviewDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageLikeReviewDataModel.swift; sourceTree = "<group>"; };
 		3385636F278DC74D003C60A6 /* BaseTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTVC.swift; sourceTree = "<group>"; };
 		3386010327988D0500C47D36 /* ActionSheetCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSheetCase.swift; sourceTree = "<group>"; };
 		338601052798B1F800C47D36 /* NaviType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaviType.swift; sourceTree = "<group>"; };
@@ -640,6 +652,7 @@
 				3386010327988D0500C47D36 /* ActionSheetCase.swift */,
 				338601052798B1F800C47D36 /* NaviType.swift */,
 				33E1E19527C7F51A0057C066 /* QnAType.swift */,
+				33834A1427D5F66E001C4947 /* MypageLikePostType.swift */,
 			);
 			path = Struct;
 			sourceTree = "<group>";
@@ -902,7 +915,10 @@
 		3381083627D53E52005AF1F9 /* LikeList */ = {
 			isa = PBXGroup;
 			children = (
+				33834A1627D60530001C4947 /* MypageLikeListSB.storyboard */,
 				3381083427D53E18005AF1F9 /* MypageLikeListVC.swift */,
+				3381083727D53F33005AF1F9 /* MypageReviewLikeVC.swift */,
+				3381083927D53F4A005AF1F9 /* MypageClassroomPostListVC.swift */,
 			);
 			path = LikeList;
 			sourceTree = "<group>";
@@ -1117,6 +1133,8 @@
 				5CCCE06B27BEA4E300F0E5FD /* MypageMyPostListModel.swift */,
 				5C4B5A9B27BFF5200012A898 /* MypageMyAnswerListModel.swift */,
 				5C0606AC27C3F662000941DA /* MypageMyReviewModel.swift */,
+				33834A1827D63245001C4947 /* MypageLikePostDataModel.swift */,
+				33834A1C27D67FAB001C4947 /* MypageLikeReviewDataModel.swift */,
 			);
 			path = Mypage;
 			sourceTree = "<group>";
@@ -1707,6 +1725,7 @@
 				5CB6502D27944415007694B1 /* GoogleService-Info.plist in Resources */,
 				5C3280152796F2B700781EBE /* MypageSB.storyboard in Resources */,
 				33BAFD01278C004700BFF6BE /* ClassroomCommentTVC.xib in Resources */,
+				33834A1727D60530001C4947 /* MypageLikeListSB.storyboard in Resources */,
 				331364A82785D91800E0C118 /* NotificationSB.storyboard in Resources */,
 				3313647D2785BBAD00E0C118 /* Pretendard-Medium.otf in Resources */,
 				7754A32727954B770093C230 /* ReviewDetailPostTVC.xib in Resources */,
@@ -1787,6 +1806,7 @@
 				331364562785A90F00E0C118 /* TypeOfViewController.swift in Sources */,
 				77A7591E279762BF00A8E48B /* ReviewPostRegisterData.swift in Sources */,
 				3381083527D53E19005AF1F9 /* MypageLikeListVC.swift in Sources */,
+				33834A1D27D67FAB001C4947 /* MypageLikeReviewDataModel.swift in Sources */,
 				33CF63602794A03300E92C04 /* QuestionHeaderTVC.swift in Sources */,
 				331364642785ADFE00E0C118 /* BaseVC.swift in Sources */,
 				5CA7E410278BC18D00D748E0 /* SelectMajorModalVC.swift in Sources */,
@@ -1840,6 +1860,7 @@
 				5CAB3F2A278AE3C200025DA5 /* AgreeTermsVC.swift in Sources */,
 				C7F3F6D927D3858600E12888 /* AppLinkResponseModel.swift in Sources */,
 				33B9B0D727B8EB2A00066C1F /* InfoCommentTVC.swift in Sources */,
+				3381083827D53F33005AF1F9 /* MypageReviewLikeVC.swift in Sources */,
 				C71BF23427CCD4A20030DCB9 /* NotificationSettingBasicTVC.swift in Sources */,
 				33CF636627954D2400E92C04 /* QuestionEmptyTVC.swift in Sources */,
 				5C70A4FD27BA4C540096B20A /* MypagePostListVC.swift in Sources */,
@@ -1852,9 +1873,11 @@
 				C71BF22927CCB9550030DCB9 /* BlockListTVC.swift in Sources */,
 				5CC0BFE12798A3C300B96905 /* SignService.swift in Sources */,
 				77A759242797656B00A8E48B /* ReviewPostData.swift in Sources */,
+				33834A1927D63245001C4947 /* MypageLikePostDataModel.swift in Sources */,
 				330DA4332790BCCC00FE127F /* NadoTextView.swift in Sources */,
 				33E1E19627C7F51A0057C066 /* QnAType.swift in Sources */,
 				C71BF22B27CCC9880030DCB9 /* RequestBlockUnblockUserModel.swift in Sources */,
+				3381083A27D53F4A005AF1F9 /* MypageClassroomPostListVC.swift in Sources */,
 				3313646A2785AED600E0C118 /* UIFont+.swift in Sources */,
 				33C1B8A527974B72004BABEC /* ClassroomService.swift in Sources */,
 				77A049F627BD647900D09C69 /* ReviewDeleteResModel.swift in Sources */,
@@ -1882,6 +1905,7 @@
 				331364BD27861CD300E0C118 /* UITextView+.swift in Sources */,
 				5C0606AD27C3F662000941DA /* MypageMyReviewModel.swift in Sources */,
 				33A666A527BB958800779351 /* ReviewImgModel.swift in Sources */,
+				33834A1527D5F66E001C4947 /* MypageLikePostType.swift in Sources */,
 				C7C4145027C93C4700296C30 /* EditProfileResponseModel.swift in Sources */,
 				33BAFD05278C061C00BFF6BE /* DefaultQuestionChatVC.swift in Sources */,
 				338CDAFF278C939B00F8227A /* TVCContentUpdate.swift in Sources */,

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/Identifiers.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/Identifiers.swift
@@ -17,4 +17,5 @@ struct Identifiers {
     static let NotificationSB = "NotificationSB"
     static let MypageSB = "MypageSB"
     static let MypageLikeListSB = "MypageLikeListSB"
+    static let ReviewDetailSB = "ReviewDetailSB"
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/Identifiers.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/Identifiers.swift
@@ -16,4 +16,5 @@ struct Identifiers {
     static let InfoSB = "InfoSB"
     static let NotificationSB = "NotificationSB"
     static let MypageSB = "MypageSB"
+    static let MypageLikeListSB = "MypageLikeListSB"
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/MypageLikePostType.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/MypageLikePostType.swift
@@ -1,0 +1,14 @@
+//
+//  MypageLikeQuestionType.swift
+//  NadoSunbae-iOS
+//
+//  Created by hwangJi on 2022/03/07.
+//
+
+import Foundation
+
+enum MypageLikePostType: String {
+    case review = "review"
+    case question = "question"
+    case information = "information"
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/MypageAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/MypageAPI.swift
@@ -97,6 +97,38 @@ extension MypageAPI {
             }
         }
     }
+    
+    /// [GET] 학과후기 좋아요 목록 조회
+    func getMypageMyLikeReviewListAPI(completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        provider.request(.getMypageMyLikeList(postType: MypageLikePostType.review)) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                
+                completion(self.getMypageReviewLikeListJudgeData(status: statusCode, data: data))
+                
+            case .failure(let err):
+                print(err.localizedDescription)
+            }
+        }
+    }
+    
+    /// [GET] 질문글, 정보글 좋아요 목록 조회
+    func getMypageMyLikePostListAPI(postType: MypageLikePostType, completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        provider.request(.getMypageMyLikeList(postType: postType)) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                
+                completion(self.getMypagePostLikeListJudgeData(status: statusCode, data: data))
+                
+            case .failure(let err):
+                print(err.localizedDescription)
+            }
+        }
+    }
 }
 
 // MARK: - judgeData
@@ -173,6 +205,40 @@ extension MypageAPI {
         let decoder = JSONDecoder()
         
         guard let decodedData = try? decoder.decode(GenericResponse<MypageMyReviewModel>.self, from: data) else { return .pathErr }
+
+        switch status {
+        case 200...204:
+            return .success(decodedData.data ?? "None-Data")
+        case 400...409:
+            return .requestErr(decodedData.message)
+        case 500:
+            return .serverErr
+        default:
+            return .networkFail
+        }
+    }
+    
+    private func getMypagePostLikeListJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
+        let decoder = JSONDecoder()
+        
+        guard let decodedData = try? decoder.decode(GenericResponse<MypageLikePostData>.self, from: data) else { return .pathErr }
+
+        switch status {
+        case 200...204:
+            return .success(decodedData.data ?? "None-Data")
+        case 400...409:
+            return .requestErr(decodedData.message)
+        case 500:
+            return .serverErr
+        default:
+            return .networkFail
+        }
+    }
+    
+    private func getMypageReviewLikeListJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
+        let decoder = JSONDecoder()
+        
+        guard let decodedData = try? decoder.decode(GenericResponse<MypageLikeReviewData>.self, from: data) else { return .pathErr }
 
         switch status {
         case 200...204:

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Mypage/MypageLikePostDataModel.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Mypage/MypageLikePostDataModel.swift
@@ -1,0 +1,39 @@
+//
+//  MypageLikePostDataModel.swift
+//  NadoSunbae-iOS
+//
+//  Created by hwangJi on 2022/03/07.
+//
+
+import Foundation
+
+// MARK: - MypageLikePostData
+struct MypageLikePostData: Codable {
+    let likePostList: [MypageLikePostDataModel]
+}
+
+// MARK: - MypageLikePostDataModel
+struct MypageLikePostDataModel: Codable {
+    let postID, postTypeID: Int
+    let title, content, createdAt: String
+    let writer: MypageLikeWriter
+    let commentCount: Int
+    let like: Like
+
+    enum CodingKeys: String, CodingKey {
+        case postID = "postId"
+        case postTypeID = "postTypeId"
+        case title, content, createdAt, writer, commentCount, like
+    }
+}
+
+// MARK: - MypageLikeWriter
+struct MypageLikeWriter: Codable {
+    let writerID: Int
+    let nickname: String
+
+    enum CodingKeys: String, CodingKey {
+        case writerID = "writerId"
+        case nickname
+    }
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Mypage/MypageLikeReviewDataModel.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Mypage/MypageLikeReviewDataModel.swift
@@ -1,0 +1,27 @@
+//
+//  MypageLikeReviewDataModel.swift
+//  NadoSunbae-iOS
+//
+//  Created by hwangJi on 2022/03/08.
+//
+
+import Foundation
+
+// MARK: - MypageLikeReviewData
+struct MypageLikeReviewData: Codable {
+    let likePostList: [MypageLikeReviewDataModel]
+}
+
+// MARK: - MypageLikeReviewDataModel
+struct MypageLikeReviewDataModel: Codable {
+    let postID: Int
+    let title, createdAt: String
+    let tagList: [ReviewTagList]
+    let writer: MypageLikeWriter
+    let like: Like
+
+    enum CodingKeys: String, CodingKey {
+        case postID = "postId"
+        case title, createdAt, tagList, writer, like
+    }
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/MypageService.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/MypageService.swift
@@ -14,6 +14,7 @@ enum MypageService {
     case getMypageMyPostList(postType: MypageMyPostType)
     case getMypageMyAnswerList(postType: MypageMyPostType)
     case getMypageMyReviewList(userID: Int)
+    case getMypageMyLikeList(postType: MypageLikePostType)
 }
 
 extension MypageService: TargetType {
@@ -38,12 +39,14 @@ extension MypageService: TargetType {
             }
         case .getMypageMyReviewList(let userID):
             return "/user/mypage/\(userID)/review-post/list"
+        case .getMypageMyLikeList:
+            return "/user/mypage/like/list/"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .getUserInfo, .getUserPersonalQuestionList, .getMypageMyPostList, .getMypageMyAnswerList, .getMypageMyReviewList:
+        case .getUserInfo, .getUserPersonalQuestionList, .getMypageMyPostList, .getMypageMyAnswerList, .getMypageMyReviewList, .getMypageMyLikeList:
             return .get
         }
     }
@@ -58,6 +61,8 @@ extension MypageService: TargetType {
             return .requestParameters(parameters: ["type": postType.rawValue], encoding: URLEncoding.queryString)
         case .getMypageMyAnswerList, .getMypageMyReviewList:
             return .requestPlain
+        case .getMypageMyLikeList(let postType):
+            return .requestParameters(parameters: ["type": postType.rawValue], encoding: URLEncoding.queryString)
         }
     }
     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/QuestionMain/BaseQuestionTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/QuestionMain/BaseQuestionTVC.swift
@@ -140,5 +140,15 @@ extension BaseQuestionTVC {
         likeCountLabel.text = "\(data.like.likeCount)"
         likeImgView.image = data.like.isLiked ? UIImage(named: "heart_filled") : UIImage(named: "btn_heart")
     }
+    
+    func setMypageLikeData(data: MypageLikePostDataModel) {
+        questionTitleLabel.text = data.title
+        questionContentLabel.text = data.content
+        nicknameLabel.text = data.writer.nickname
+        questionTimeLabel.text = data.createdAt.serverTimeToString(forUse: .forDefault)
+        commentCountLabel.text = "\(data.commentCount)"
+        likeCountLabel.text = "\(data.like.likeCount)"
+        likeImgView.image = data.like.isLiked ? UIImage(named: "heart_filled") : UIImage(named: "btn_heart")
+    }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
@@ -49,8 +49,8 @@ class InfoMainVC: BaseVC {
     
     private var selectActionSheetIndex = 0
     private var infoList: [ClassroomPostList] = []
+    private var lastSortType: ListSortType = .recent
     weak var sendSegmentStateDelegate: SendSegmentStateDelegate?
-    private let contentSizeObserverKeyPath = "contentSize"
     
     // MARK: Life Cycle
     override func viewDidLoad() {
@@ -66,7 +66,7 @@ class InfoMainVC: BaseVC {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        setUpRequestData(sortType: .recent)
+        setUpRequestData(sortType: lastSortType)
     }
 }
 
@@ -150,6 +150,7 @@ extension InfoMainVC {
     /// shared에 데이터가 있으면 shared정보로 데이터를 요청하고, 그렇지 않으면 Userdefaults의 전공ID로 요청을 보내는 메서드
     private func setUpRequestData(sortType: ListSortType) {
         requestGetGroupOrInfoListData(majorID: (MajorInfo.shared.selectedMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selectedMajorID ?? -1), postTypeID: .info, sort: sortType)
+        lastSortType = sortType
     }
     
     /// activityIndicator 설정 메서드
@@ -183,18 +184,6 @@ extension InfoMainVC {
         infoSegmentView.firstBtn.press {
             if let delegate = self.sendSegmentStateDelegate {
                 delegate.sendSegmentClicked(index: 0)
-            }
-        }
-    }
-    
-    /// infoQuestionListTV size값이 바뀌면 값을 비교하여 constraint를 업데이트하는 메서드
-    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
-        if (keyPath == contentSizeObserverKeyPath) {
-            if let newValue = change?[.newKey] {
-                let newSize  = newValue as! CGSize
-                self.infoQuestionListTV.snp.updateConstraints {
-                    $0.height.equalTo(newSize.height)
-                }
             }
         }
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
@@ -66,12 +66,7 @@ class InfoMainVC: BaseVC {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        self.infoQuestionListTV.addObserver(self, forKeyPath: contentSizeObserverKeyPath, options: .new, context: nil)
         setUpRequestData(sortType: .recent)
-    }
-    
-    override func viewDidDisappear(_ animated: Bool) {
-        self.infoQuestionListTV.removeObserver(self, forKeyPath: contentSizeObserverKeyPath)
     }
 }
 
@@ -238,7 +233,11 @@ extension InfoMainVC: UITableViewDelegate {
     
     /// estimatedHeightForRowAt
     func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 0
+        if infoList.count == 0 {
+            return 515
+        } else {
+            return 115
+        }
     }
     
     /// heightForRowAt
@@ -273,7 +272,14 @@ extension InfoMainVC {
             case .success(let res):
                 if let data = res as? [ClassroomPostList] {
                     self.infoList = data
-                    self.infoQuestionListTV.reloadData()
+                    DispatchQueue.main.async {
+                        self.infoQuestionListTV.reloadData()
+                        self.infoQuestionListTV.layoutIfNeeded()
+                        self.infoQuestionListTV.rowHeight = UITableView.automaticDimension
+                        self.infoQuestionListTV.snp.updateConstraints {
+                            $0.height.equalTo(self.infoQuestionListTV.contentSize.height)
+                        }
+                    }
                     self.activityIndicator.stopAnimating()
                 }
             case .requestErr(let msg):

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/EntireQuestionListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/EntireQuestionListVC.swift
@@ -32,6 +32,7 @@ class EntireQuestionListVC: BaseVC {
     
     private var selectActionSheetIndex = 0
     private var questionList: [ClassroomPostList] = []
+    private var lastSortType: ListSortType = .recent
      
     // MARK: Life Cycle
     override func viewDidLoad() {
@@ -45,7 +46,7 @@ class EntireQuestionListVC: BaseVC {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        setUpRequestData(sortType: .recent)
+        setUpRequestData(sortType: lastSortType)
         self.tabBarController?.tabBar.isHidden = false
     }
 }
@@ -123,6 +124,7 @@ extension EntireQuestionListVC {
     /// shared에 데이터가 있으면 shared정보로 데이터를 요청하고, 그렇지 않으면 Userdefaults의 전공ID로 요청을 보내는 메서드
     private func setUpRequestData(sortType: ListSortType) {
         requestGetGroupOrInfoListData(majorID: (MajorInfo.shared.selectedMajorID == nil ? UserDefaults.standard.integer(forKey: UserDefaults.Keys.FirstMajorID) : MajorInfo.shared.selectedMajorID ?? -1), postTypeID: .group, sort: sortType)
+        lastSortType = sortType
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/EntireQuestionListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/EntireQuestionListVC.swift
@@ -171,7 +171,6 @@ extension EntireQuestionListVC: UITableViewDelegate {
                                         okAction: { _ in
                 self.selectActionSheetIndex = 0
                 self.setUpRequestData(sortType: .recent)
-                self.requestGetGroupOrInfoListData(majorID: MajorInfo.shared.selectedMajorID ?? 0, postTypeID: .group, sort: .recent)
                 self.entireQuestionListTV.reloadSections([0], with: .fade)
             },
                                         secondOkAction: { _ in

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/SB/MypageSB.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/SB/MypageSB.storyboard
@@ -269,9 +269,6 @@
                                                         </constraints>
                                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                         <state key="normal" image="btn_arrow"/>
-                                                        <connections>
-                                                            <action selector="tapLikeListBtn:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="TPt-vj-GSd"/>
-                                                        </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="diamond_mint" translatesAutoresizingMaskIntoConstraints="NO" id="K7s-TV-xyE">
                                                         <rect key="frame" x="20" y="21.666666666666629" width="17.333333333333329" height="17.333333333333329"/>
@@ -285,16 +282,28 @@
                                                         <color key="textColor" name="mainDefault"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Wj6-Oh-wII">
+                                                        <rect key="frame" x="0.0" y="0.0" width="326" height="60.666666666666664"/>
+                                                        <state key="normal" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="plain" title=""/>
+                                                        <connections>
+                                                            <action selector="tapLikeListBtn:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="yHY-yC-OzH"/>
+                                                        </connections>
+                                                    </button>
                                                 </subviews>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
+                                                    <constraint firstAttribute="bottom" secondItem="Wj6-Oh-wII" secondAttribute="bottom" id="36S-rH-brq"/>
                                                     <constraint firstItem="kfP-4J-RuM" firstAttribute="top" secondItem="xRv-Yq-z9u" secondAttribute="top" constant="4" id="7Zm-eL-o5b"/>
                                                     <constraint firstItem="K7s-TV-xyE" firstAttribute="leading" secondItem="xRv-Yq-z9u" secondAttribute="leading" constant="20" id="Die-ST-Lvz"/>
+                                                    <constraint firstItem="Wj6-Oh-wII" firstAttribute="leading" secondItem="xRv-Yq-z9u" secondAttribute="leading" id="LCu-U3-MEk"/>
                                                     <constraint firstItem="hxj-K9-WHH" firstAttribute="centerY" secondItem="vcE-un-F0e" secondAttribute="centerY" id="LgJ-VP-3Kx"/>
                                                     <constraint firstItem="hxj-K9-WHH" firstAttribute="leading" secondItem="vcE-un-F0e" secondAttribute="trailing" constant="5" id="R4t-SX-CPN"/>
+                                                    <constraint firstItem="Wj6-Oh-wII" firstAttribute="top" secondItem="xRv-Yq-z9u" secondAttribute="top" id="VvG-0g-z3G"/>
                                                     <constraint firstItem="K7s-TV-xyE" firstAttribute="height" secondItem="xRv-Yq-z9u" secondAttribute="height" multiplier="0.2857" id="WbX-BE-B3G"/>
                                                     <constraint firstItem="vcE-un-F0e" firstAttribute="centerY" secondItem="xRv-Yq-z9u" secondAttribute="centerY" id="akF-Im-uL7"/>
                                                     <constraint firstItem="vcE-un-F0e" firstAttribute="leading" secondItem="K7s-TV-xyE" secondAttribute="trailing" constant="15" id="gld-as-amV"/>
+                                                    <constraint firstAttribute="trailing" secondItem="Wj6-Oh-wII" secondAttribute="trailing" id="nSg-ga-Aw6"/>
                                                     <constraint firstAttribute="trailing" secondItem="kfP-4J-RuM" secondAttribute="trailing" constant="1" id="ugo-6W-pDq"/>
                                                     <constraint firstAttribute="bottom" secondItem="kfP-4J-RuM" secondAttribute="bottom" constant="4" id="wTT-Qj-5GT"/>
                                                     <constraint firstItem="K7s-TV-xyE" firstAttribute="centerY" secondItem="xRv-Yq-z9u" secondAttribute="centerY" id="yQu-Og-MiW"/>
@@ -322,7 +331,7 @@
                                                 <sections/>
                                             </tableView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="나에게 온 1:1 질문" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eG2-qy-pTf">
-                                                <rect key="frame" x="24.000000000000007" y="300.33333333333331" width="118.66666666666669" height="19"/>
+                                                <rect key="frame" x="23.999999999999993" y="300.33333333333331" width="113.33333333333331" height="19"/>
                                                 <fontDescription key="fontDescription" name="Pretendard-Medium" family="Pretendard" pointSize="16"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -365,7 +374,7 @@
                                 <rect key="frame" x="24" y="429.66666666666669" width="326" height="545.33333333333326"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="등록된 1:1 질문이 없습니다." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dXN-aJ-nVo">
-                                        <rect key="frame" x="85.000000000000014" y="264.33333333333331" width="156.33333333333337" height="17"/>
+                                        <rect key="frame" x="87.666666666666686" y="264.33333333333331" width="151" height="17"/>
                                         <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="14"/>
                                         <color key="textColor" name="gray2"/>
                                         <nil key="highlightedColor"/>
@@ -626,7 +635,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="내용" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zcc-1G-jz2">
-                                                                <rect key="frame" x="16" y="32" width="287" height="16.333333333333329"/>
+                                                                <rect key="frame" x="16" y="32" width="287" height="17"/>
                                                                 <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="14"/>
                                                                 <color key="textColor" name="gray3"/>
                                                                 <nil key="highlightedColor"/>
@@ -691,7 +700,7 @@
                                             <sections/>
                                         </tableView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="님에게 온 1:1 질문" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5Ha-qF-Dwb">
-                                            <rect key="frame" x="94" y="266.66666666666669" width="118.66666666666669" height="19"/>
+                                            <rect key="frame" x="94" y="266.66666666666669" width="113.33333333333331" height="19"/>
                                             <fontDescription key="fontDescription" name="Pretendard-Medium" family="Pretendard" pointSize="16"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageClassroomPostListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageClassroomPostListVC.swift
@@ -1,0 +1,265 @@
+//
+//  MypageClassroomPostListVC.swift
+//  NadoSunbae-iOS
+//
+//  Created by hwangJi on 2022/03/07.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+class MypageClassroomPostListVC: BaseVC {
+    
+    // MARK: Properties
+    private var segmentView = NadoSegmentView().then {
+        $0.firstBtn.setTitleWithStyle(title: "후기", size: 14.0)
+        $0.secondBtn.setTitleWithStyle(title: "질문", size: 14.0)
+        $0.thirdBtn.setTitleWithStyle(title: "정보", size: 14.0)
+    }
+    
+    private let likePostListSV = UIScrollView().then {
+        $0.isScrollEnabled = true
+    }
+    private let contentView = UIView()
+    
+    private let likePostListTV = UITableView().then {
+        $0.separatorInset = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
+        $0.isScrollEnabled = false
+        $0.layer.cornerRadius = 8
+        $0.layer.borderWidth = 1
+        $0.layer.borderColor = UIColor.gray0.cgColor
+        $0.removeSeparatorsOfEmptyCellsAndLastCell()
+    }
+    
+    var likePostType = MypageLikePostType.question
+    private var likePostList: [MypageLikePostDataModel] = []
+    weak var sendSegmentStateDelegate: SendSegmentStateDelegate?
+    
+    // MARK: Life Cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+        setUpDelegate()
+        registerCell()
+        setSegmentStateByPostType()
+        setUpTapSegmentBtn()
+        addActivateIndicator()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        requestGetLikePostListData(postType: likePostType)
+    }
+}
+
+// MARK: - UI
+extension MypageClassroomPostListVC {
+    func configureUI() {
+        view.addSubview(likePostListSV)
+        likePostListSV.addSubview(contentView)
+        contentView.addSubviews([segmentView, likePostListTV])
+        
+        likePostListSV.snp.makeConstraints {
+            $0.top.leading.trailing.bottom.equalToSuperview()
+        }
+        
+        contentView.snp.makeConstraints {
+            $0.width.equalToSuperview()
+            $0.height.equalToSuperview().priority(.low)
+            $0.centerX.top.bottom.equalToSuperview()
+        }
+        
+        segmentView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(16)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(38.adjustedH)
+        }
+        
+        likePostListTV.snp.makeConstraints {
+            $0.top.equalTo(segmentView.snp.bottom).offset(16)
+            $0.leading.equalToSuperview().offset(24)
+            $0.trailing.equalToSuperview().offset(-24)
+            $0.height.equalTo(500)
+            $0.bottom.equalToSuperview().offset(-24)
+        }
+        
+        view.backgroundColor = .paleGray
+        likePostListTV.backgroundColor = .white
+        likePostListTV.separatorColor = .gray1
+    }
+}
+
+// MARK: - Custom Methods
+extension MypageClassroomPostListVC {
+    
+    /// 대리자 위임 메서드
+    private func setUpDelegate() {
+        likePostListTV.delegate = self
+        likePostListTV.dataSource = self
+    }
+    
+    /// 셀 등록 메서드
+    private func registerCell() {
+        likePostListTV.register(BaseQuestionTVC.self, forCellReuseIdentifier: BaseQuestionTVC.className)
+        likePostListTV.register(QuestionEmptyTVC.self, forCellReuseIdentifier: QuestionEmptyTVC.className)
+    }
+    
+    /// activityIndicator 설정 메서드
+    private func addActivateIndicator() {
+        activityIndicator.center = CGPoint(x: self.view.center.x, y: view.center.y - 106)
+        view.addSubview(self.activityIndicator)
+    }
+    
+    /// likePostType에 따라 Segment의 isActivated, isEnabled 상태를 지정하는 메서드
+    private func setSegmentStateByPostType() {
+        switch likePostType {
+        case .review:
+            break
+        case .question:
+            segmentView.secondBtn.isActivated = true
+            segmentView.secondBtn.isEnabled = false
+            [segmentView.firstBtn, segmentView.thirdBtn].forEach {
+                $0.isActivated = false
+                $0.isEnabled = true
+            }
+        case .information:
+            segmentView.thirdBtn.isActivated = true
+            segmentView.thirdBtn.isEnabled = false
+            [segmentView.firstBtn, segmentView.secondBtn].forEach {
+                $0.isActivated = false
+                $0.isEnabled = true
+            }
+        }
+    }
+    
+    /// segment를 눌렀을 때 실행되는 액션 메서드
+    func setUpTapSegmentBtn() {
+        segmentView.firstBtn.press {
+            if let delegate = self.sendSegmentStateDelegate {
+                delegate.sendSegmentClicked(index: 0)
+            }
+        }
+        segmentView.secondBtn.press {
+            if let delegate = self.sendSegmentStateDelegate {
+                delegate.sendSegmentClicked(index: 1)
+            }
+        }
+        segmentView.thirdBtn.press {
+            if let delegate = self.sendSegmentStateDelegate {
+                delegate.sendSegmentClicked(index: 2)
+            }
+        }
+    }
+}
+
+// MARK: - UITableViewDataSource
+extension MypageClassroomPostListVC: UITableViewDataSource {
+    
+    /// numberOfRowsInSection
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if likePostList.count == 0 {
+            return 1
+        } else {
+            return likePostList.count
+        }
+    }
+    
+    /// cellForRowAt
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        if likePostList.count == 0 {
+            let emptyCell = QuestionEmptyTVC()
+            emptyCell.setUpEmptyQuestionLabelText(text: likePostType == .question ? "좋아요한 질문글이 없습니다." : "좋아요한 정보글이 없습니다.")
+            return emptyCell
+        } else {
+            guard let postCell = tableView.dequeueReusableCell(withIdentifier: BaseQuestionTVC.className, for: indexPath) as? BaseQuestionTVC else { return UITableViewCell() }
+            postCell.setMypageLikeData(data: likePostList[indexPath.row])
+            postCell.backgroundColor = .white
+            postCell.layoutIfNeeded()
+            return postCell
+        }
+    }
+}
+
+// MARK: - UITableViewDelegate
+extension MypageClassroomPostListVC: UITableViewDelegate {
+    
+    /// estimatedHeightForRowAt
+    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        if likePostList.count == 0 {
+            return 515
+        } else {
+            return 126
+        }
+    }
+    
+    /// heightForRowAt
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        if likePostList.count == 0 {
+            return 515
+        } else {
+            return UITableView.automaticDimension
+        }
+    }
+    
+    /// didSelectRowAt
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        
+        switch likePostType {
+            
+        case .review:
+            break
+        case .question:
+            guard let questionDetailVC = UIStoryboard.init(name: Identifiers.QuestionChatSB, bundle: nil).instantiateViewController(withIdentifier: DefaultQuestionChatVC.className) as? DefaultQuestionChatVC else { return }
+            
+            if likePostList.count != 0 {
+                questionDetailVC.postID = likePostList[indexPath.row].postID
+                questionDetailVC.questionType = likePostList[indexPath.row].postTypeID == 3 ? .group : .personal
+                questionDetailVC.naviStyle = .push
+                questionDetailVC.hidesBottomBarWhenPushed = true
+                self.navigationController?.pushViewController(questionDetailVC, animated: true)
+            }
+        case .information:
+            guard let infoDetailVC = UIStoryboard.init(name: Identifiers.InfoSB, bundle: nil).instantiateViewController(withIdentifier: InfoDetailVC.className) as? InfoDetailVC else { return }
+            
+            if likePostList.count != 0 {
+                infoDetailVC.postID = likePostList[indexPath.row].postID
+                infoDetailVC.hidesBottomBarWhenPushed = true
+                self.navigationController?.pushViewController(infoDetailVC, animated: true)
+            }
+        }
+    }
+}
+
+// MARK: - Network
+extension MypageClassroomPostListVC {
+    
+    /// 질문, 정보글 좋아요 목록 조회 API 요청 메서드
+    func requestGetLikePostListData(postType: MypageLikePostType) {
+        self.activityIndicator.startAnimating()
+        MypageAPI.shared.getMypageMyLikePostListAPI(postType: postType) { networkResult in
+            switch networkResult {
+            case .success(let res):
+                if let data = res as? MypageLikePostData {
+                    self.likePostList = data.likePostList
+                    self.likePostListTV.reloadData()
+                    self.likePostListTV.layoutIfNeeded()
+                    self.likePostListTV.rowHeight = UITableView.automaticDimension
+                    self.likePostListTV.snp.updateConstraints {
+                        $0.height.equalTo(self.likePostListTV.contentSize.height)
+                    }
+                    self.activityIndicator.stopAnimating()
+                }
+            case .requestErr(let msg):
+                if let message = msg as? String {
+                    print(message)
+                }
+                self.activityIndicator.stopAnimating()
+                self.makeAlert(title: "서버 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+            default:
+                self.activityIndicator.stopAnimating()
+                self.makeAlert(title: "서버 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+            }
+        }
+    }
+}
+

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageLikeListSB.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageLikeListSB.storyboard
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Mypage Like ListVC-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="MypageLikeListVC" id="Y6W-OH-hqX" customClass="MypageLikeListVC" customModule="NadoSunbae_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="o4z-Hf-bBf" customClass="NadoSunbaeNaviBar" customModule="NadoSunbae_iOS" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="104"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="104" id="TQJ-dN-VaI"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="o4z-Hf-bBf" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" id="BeB-Tm-1kJ"/>
+                            <constraint firstItem="o4z-Hf-bBf" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="UKH-uL-6Wz"/>
+                            <constraint firstItem="o4z-Hf-bBf" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="a1H-jf-iSh"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="topNaviView" destination="o4z-Hf-bBf" id="28c-9F-Sg5"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="0.0" y="114.50892857142857"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageLikeListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageLikeListVC.swift
@@ -9,12 +9,108 @@ import UIKit
 import SnapKit
 import Then
 
-class MypageLikeListVC: UIViewController {
-
+class MypageLikeListVC: BaseVC {
+    
+    // MARK: Properties
+    private var likeContainerView = NadoHorizonContainerViews().then {
+        $0.setMultiplier(containerCount: 3)
+    }
+    
+    // MARK: IBOutlet
+    @IBOutlet var topNaviView: NadoSunbaeNaviBar! {
+        didSet {
+            topNaviView.configureTitleLabel(title: "좋아요 목록")
+            topNaviView.setUpNaviStyle(state: .backDefault)
+            topNaviView.backBtn.press {
+                    self.navigationController?.popViewController(animated: true)
+            }
+        }
+    }
+    
+    // MARK: Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        configureUI()
+        configureContainerView()
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        hideTabbar()
+    }
+}
 
+// MARK: - UI
+extension MypageLikeListVC {
+    private func configureUI() {
+        self.view.backgroundColor = .paleGray
+        self.view.addSubview(likeContainerView)
+        likeContainerView.snp.makeConstraints {
+            $0.top.equalTo(topNaviView.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+    }
+    
+    /// containerView 컨텐츠 VC를 설정하는 메서드
+    func configureContainerView() {
+        let likeReviewVC = MypageReviewLikeVC()
+        let likeQuestionVC = MypageClassroomPostListVC()
+        let likeInfoVC = MypageClassroomPostListVC()
+        likeInfoVC.likePostType = .information
+        
+        likeReviewVC.sendSegmentStateDelegate = self
+        likeQuestionVC.sendSegmentStateDelegate = self
+        likeInfoVC.sendSegmentStateDelegate = self
+        
+        [likeReviewVC, likeQuestionVC, likeInfoVC].forEach {
+            addChild($0)
+            $0.view.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        /// 세번째 containerView를 만들어 ContainerView의 containerStack의 서브뷰로 add
+        let thirdContainerView = UIView()
+        likeContainerView.containerStackView.addArrangedSubview(thirdContainerView)
+        
+        likeContainerView.firstContainerView.addSubview(likeReviewVC.view)
+        likeContainerView.secondContainerView.addSubview(likeQuestionVC.view)
+        thirdContainerView.addSubview(likeInfoVC.view)
+        
+        likeReviewVC.view.snp.makeConstraints {
+            $0.top.leading.trailing.bottom.equalTo(self.likeContainerView)
+        }
+        
+        likeQuestionVC.view.snp.makeConstraints {
+            $0.top.leading.trailing.bottom.equalTo(likeContainerView.secondContainerView)
+        }
+        
+        likeInfoVC.view.snp.makeConstraints {
+            $0.top.leading.trailing.bottom.equalTo(thirdContainerView)
+        }
+        
+        likeReviewVC.didMove(toParent: self)
+    }
+}
+
+// MARK: - SendSegmentStateDelegate
+extension MypageLikeListVC: SendSegmentStateDelegate {
+     
+    /// segment가 클릭되면 index에 따라 ContainerView의 ContentOffset.x 좌표를 바꿔주는 메서드
+    func sendSegmentClicked(index: Int) {
+        let contentOffsetX = likeContainerView.externalSV.contentOffset.x
+        
+        if index == 0 {
+            likeContainerView.externalSV.contentOffset.x = 0
+        } else if index == 1 {
+            if contentOffsetX > screenWidth {
+                likeContainerView.externalSV.contentOffset.x -= screenWidth
+            } else {
+                likeContainerView.externalSV.contentOffset.x += screenWidth
+            }
+        } else {
+            if contentOffsetX == screenWidth {
+                likeContainerView.externalSV.contentOffset.x += screenWidth
+            } else {
+                likeContainerView.externalSV.contentOffset.x += screenWidth * 2
+            }
+        }
+    }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageLikeListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageLikeListVC.swift
@@ -1,0 +1,20 @@
+//
+//  MypageLikeListVC.swift
+//  NadoSunbae-iOS
+//
+//  Created by hwangJi on 2022/03/07.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+class MypageLikeListVC: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageReviewLikeVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageReviewLikeVC.swift
@@ -1,0 +1,206 @@
+//
+//  MypageReviewLikeVC.swift
+//  NadoSunbae-iOS
+//
+//  Created by hwangJi on 2022/03/07.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+class MypageReviewLikeVC: BaseVC {
+    
+    // MARK: Properties
+    private var segmentView = NadoSegmentView().then {
+        $0.firstBtn.setTitleWithStyle(title: "후기", size: 14.0)
+        $0.secondBtn.setTitleWithStyle(title: "질문", size: 14.0)
+        $0.thirdBtn.setTitleWithStyle(title: "정보", size: 14.0)
+        $0.firstBtn.isActivated = true
+        $0.firstBtn.isEnabled = false
+        [$0.secondBtn, $0.thirdBtn].forEach {
+            $0.isActivated = false
+            $0.isEnabled = true
+        }
+    }
+    
+    private let likeReviewListSV = UIScrollView().then {
+        $0.isScrollEnabled = true
+    }
+    private let contentView = UIView()
+    
+    private let likeReviewListTV = UITableView().then {
+        $0.separatorStyle = .none
+        $0.isScrollEnabled = false
+        $0.removeSeparatorsOfEmptyCellsAndLastCell()
+    }
+    
+    // MARK: Properties
+    weak var sendSegmentStateDelegate: SendSegmentStateDelegate?
+    private var likeReviewList: [MypageLikeReviewDataModel] = []
+    
+    // MARK: Life Cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+        setUpTapSegmentBtn()
+        setUpDelegate()
+        registerCell()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        requestGetLikeReviewListData()
+    }
+}
+
+// MARK: - UI
+extension MypageReviewLikeVC {
+    func configureUI() {
+        view.addSubview(likeReviewListSV)
+        likeReviewListSV.addSubview(contentView)
+        contentView.addSubviews([segmentView, likeReviewListTV])
+        
+        likeReviewListSV.snp.makeConstraints {
+            $0.top.leading.trailing.bottom.equalToSuperview()
+        }
+        
+        contentView.snp.makeConstraints {
+            $0.width.equalToSuperview()
+            $0.height.equalToSuperview().priority(.low)
+            $0.centerX.top.bottom.equalToSuperview()
+        }
+        
+        segmentView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(16)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(38.adjustedH)
+        }
+        
+        likeReviewListTV.snp.makeConstraints {
+            $0.top.equalTo(segmentView.snp.bottom).offset(16)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(500)
+            $0.bottom.equalToSuperview().offset(-24)
+        }
+        
+        view.backgroundColor = .paleGray
+    }
+}
+
+// MARK: - Custom Methods
+extension MypageReviewLikeVC {
+    
+    /// 대리자 위임 메서드
+    private func setUpDelegate() {
+        likeReviewListTV.delegate = self
+        likeReviewListTV.dataSource = self
+    }
+    
+    /// 셀 등록 메서드
+    private func registerCell() {
+        likeReviewListTV.register(QuestionEmptyTVC.self, forCellReuseIdentifier: QuestionEmptyTVC.className)
+        ReviewMainPostTVC.register(target: likeReviewListTV)
+    }
+    
+    /// segment를 눌렀을 때 실행되는 액션 메서드
+    func setUpTapSegmentBtn() {
+        segmentView.firstBtn.press {
+            if let delegate = self.sendSegmentStateDelegate {
+                delegate.sendSegmentClicked(index: 0)
+            }
+        }
+        segmentView.secondBtn.press {
+            if let delegate = self.sendSegmentStateDelegate {
+                delegate.sendSegmentClicked(index: 1)
+            }
+        }
+        segmentView.thirdBtn.press {
+            if let delegate = self.sendSegmentStateDelegate {
+                delegate.sendSegmentClicked(index: 2)
+            }
+        }
+    }
+}
+
+// MARK: - UITableViewDataSource
+extension MypageReviewLikeVC: UITableViewDataSource {
+    
+    /// numberOfRowsInSection
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if likeReviewList.count == 0 {
+            return 1
+        } else {
+            return likeReviewList.count
+        }
+    }
+    
+    /// cellForRowAt
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        if likeReviewList.count == 0 {
+            let emptyCell = QuestionEmptyTVC()
+            emptyCell.setUpEmptyQuestionLabelText(text: "좋아요한 후기글이 없습니다.")
+            return emptyCell
+        } else {
+            guard let likeReviewCell = tableView.dequeueReusableCell(withIdentifier: ReviewMainPostTVC.className, for: indexPath) as? ReviewMainPostTVC else { return UITableViewCell() }
+            likeReviewCell.tagImgList = likeReviewList[indexPath.row].tagList
+            likeReviewCell.setMypageReviewLikeData(postData: likeReviewList[indexPath.row])
+            likeReviewCell.layoutIfNeeded()
+            return likeReviewCell
+        }
+    }
+}
+
+// MARK: - UITableViewDelegate
+extension MypageReviewLikeVC: UITableViewDelegate {
+    
+    /// heightForRowAt
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        if likeReviewList.count == 0 {
+            return 515
+        } else {
+            return 156.adjustedH
+        }
+    }
+    
+    /// didSelectRowAt
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        if likeReviewList.count != 0 {
+            guard let reviewDetailVC = UIStoryboard.init(name: Identifiers.ReviewDetailSB, bundle: nil).instantiateViewController(withIdentifier: ReviewDetailVC.className) as? ReviewDetailVC else { return }
+            reviewDetailVC.postId = likeReviewList[indexPath.row].postID
+            self.navigationController?.pushViewController(reviewDetailVC, animated: true)
+        }
+    }
+}
+
+// MARK: - Network
+extension MypageReviewLikeVC {
+    
+    /// 후기글 좋아요 목록 조회 API 요청 메서드
+    func requestGetLikeReviewListData() {
+        self.activityIndicator.startAnimating()
+        MypageAPI.shared.getMypageMyLikeReviewListAPI() { networkResult in
+            switch networkResult {
+            case .success(let res):
+                if let data = res as? MypageLikeReviewData {
+                    self.likeReviewList = data.likePostList
+                    self.likeReviewListTV.reloadData()
+                    self.likeReviewListTV.layoutIfNeeded()
+                    self.likeReviewListTV.snp.updateConstraints {
+                        $0.height.equalTo(self.likeReviewListTV.contentSize.height)
+                    }
+                }
+                self.activityIndicator.stopAnimating()
+            case .requestErr(let msg):
+                self.activityIndicator.stopAnimating()
+                if let message = msg as? String {
+                    print(message)
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                }
+            default:
+                self.activityIndicator.stopAnimating()
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+            }
+        }
+    }
+}
+

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/MypageMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/MypageMainVC.swift
@@ -60,7 +60,8 @@ class MypageMainVC: BaseVC {
     }
     
     @IBAction func tapLikeListBtn(_ sender: Any) {
-        /// 4순위
+        let likeListVC = MypageLikeListVC()
+        self.navigationController?.pushViewController(likeListVC, animated: true)
     }
     
     @IBAction func tapSortBtn(_ sender: Any) {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/MypageMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/MypageMainVC.swift
@@ -60,7 +60,7 @@ class MypageMainVC: BaseVC {
     }
     
     @IBAction func tapLikeListBtn(_ sender: Any) {
-        let likeListVC = MypageLikeListVC()
+        guard let likeListVC = UIStoryboard.init(name: Identifiers.MypageLikeListSB, bundle: nil).instantiateViewController(withIdentifier: MypageLikeListVC.className) as? MypageLikeListVC else { return }
         self.navigationController?.pushViewController(likeListVC, animated: true)
     }
     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewMainPostTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/Cell/TVC/ReviewMainPostTVC.swift
@@ -87,6 +87,18 @@ extension ReviewMainPostTVC {
         likeImgView.image = postData.like.isLiked ? UIImage(named: "heart_filled") : UIImage(named: "btn_heart")
     }
     
+    /// 마이페이지 후기 좋아요 리스트 데이터 세팅 함수
+    func setMypageReviewLikeData(postData: MypageLikeReviewDataModel) {
+        dateLabel.text = postData.createdAt.serverTimeToString(forUse: .forDefault)
+        titleLabel.text = postData.title
+        nickNameLabel.text = postData.writer.nickname
+        likeCountLabel.text = "\(postData.like.likeCount)"
+        [majorNameLabel, secondMajorNameLabel, firstMajorStartLabel, secondMajorStartLabel, majorSeparatorView].forEach { view in
+            view?.isHidden = true
+        }
+        likeImgView.image = postData.like.isLiked ? UIImage(named: "heart_filled") : UIImage(named: "btn_heart")
+    }
+    
     private func registerCVC() {
         ReviewPostTagCVC.register(target: tagCV)
     }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #292 

## 🍎 변경 사항 및 이유
### 지난 브랜치에서 따서 작업해서 커밋기록이 같이 딸려왔는데여, 마지막 3개 커밋만 봐주세여!!

## 🍎 PR Point
- 과방 최신순/좋아요 정렬 관련 버그 전면 수정하였습니다~
- 전체에게 질문 전체보기 리스트에서 최신순 > 좋아요 > 최신순 조회하면 조회가 되지 않는 오류 해결
- 전체에게 질문 전체보기 리스트, 과방 정보탭에서 뎁스가 깊어진 후 다시 정보리스트로 돌아왔을 때 정렬 정보를 기억하지 못하는 오류 해결

## 📸 ScreenShot
[전체에게 질문 전체보기 리스트]

https://user-images.githubusercontent.com/63224278/157109007-0c55c24e-816e-4c63-9de9-cd142ddd1ef3.mp4

https://user-images.githubusercontent.com/63224278/157109090-e8a473f4-a1ea-4df1-bd78-46b5502c2939.mp4

[과방 정보탭]

https://user-images.githubusercontent.com/63224278/157109144-4ddaa60b-0189-45e8-8d03-7e1e8f8036cf.mp4


