### PR TITLE
✨ [FEAT] 푸시알림 클릭시 알림탭으로 진입하는 기능 구현

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		33CF636627954D2400E92C04 /* QuestionEmptyTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CF636527954D2400E92C04 /* QuestionEmptyTVC.swift */; };
 		33CF636827955D9500E92C04 /* ClassroomNC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CF636727955D9500E92C04 /* ClassroomNC.swift */; };
 		33CF636C279567AF00E92C04 /* QuestionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CF636B279567AF00E92C04 /* QuestionType.swift */; };
+		33D9EA8F27D75335000AF8DB /* NotificationInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D9EA8E27D75335000AF8DB /* NotificationInfo.swift */; };
 		33DAB83A27914EAD00214CA8 /* WriteQuestionVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DAB83927914EAD00214CA8 /* WriteQuestionVC.swift */; };
 		33DAB83C279153A400214CA8 /* BaseCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DAB83B279153A400214CA8 /* BaseCVC.swift */; };
 		33E1E19627C7F51A0057C066 /* QnAType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E1E19527C7F51A0057C066 /* QnAType.swift */; };
@@ -356,6 +357,7 @@
 		33CF636527954D2400E92C04 /* QuestionEmptyTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionEmptyTVC.swift; sourceTree = "<group>"; };
 		33CF636727955D9500E92C04 /* ClassroomNC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassroomNC.swift; sourceTree = "<group>"; };
 		33CF636B279567AF00E92C04 /* QuestionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionType.swift; sourceTree = "<group>"; };
+		33D9EA8E27D75335000AF8DB /* NotificationInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationInfo.swift; sourceTree = "<group>"; };
 		33DAB83927914EAD00214CA8 /* WriteQuestionVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteQuestionVC.swift; sourceTree = "<group>"; };
 		33DAB83B279153A400214CA8 /* BaseCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCVC.swift; sourceTree = "<group>"; };
 		33E1E19527C7F51A0057C066 /* QnAType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QnAType.swift; sourceTree = "<group>"; };
@@ -1425,6 +1427,7 @@
 			children = (
 				77A7592E27981A0E00A8E48B /* MajorInfo.swift */,
 				77ED045427B19DBD00D077CA /* ReviewFilterInfo.swift */,
+				33D9EA8E27D75335000AF8DB /* NotificationInfo.swift */,
 			);
 			path = Singleton;
 			sourceTree = "<group>";
@@ -1783,6 +1786,7 @@
 				3313646C2785AEE000E0C118 /* String+.swift in Sources */,
 				331C5382279629620052B309 /* BaseQuestionTVC.swift in Sources */,
 				33C1B8A327974A4F004BABEC /* ClassroomQuestionDetailData.swift in Sources */,
+				33D9EA8F27D75335000AF8DB /* NotificationInfo.swift in Sources */,
 				331364BF27861D0600E0C118 /* Adjusted+.swift in Sources */,
 				777ABF89278CB793002D3214 /* ReviewStickyHeaderView.swift in Sources */,
 				5C4B5A9C27BFF5200012A898 /* MypageMyAnswerListModel.swift in Sources */,

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/Notification.Name.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/Notification.Name.swift
@@ -9,4 +9,5 @@ import Foundation
 
 extension Notification.Name {
     static let dismissHalfModal = Notification.Name("dismissHalfModal")
+    static let pushNotificationClicked = Notification.Name("pushNotificationClicked")
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/PublicData/Singleton/NotificationInfo.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/PublicData/Singleton/NotificationInfo.swift
@@ -1,0 +1,17 @@
+//
+//  NotificationInfo.swift
+//  NadoSunbae-iOS
+//
+//  Created by hwangJi on 2022/03/08.
+//
+
+import Foundation
+
+class NotificationInfo {
+    
+    /// 푸시알림을 클릭해서 앱에 진입했는지에 대한 정보를 저장해두기 위한 싱글톤 객체 선언
+    static let shared = NotificationInfo()
+    
+    var isPushComes: Bool = false
+    private init() { }
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/VC/AutoSignInVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/VC/AutoSignInVC.swift
@@ -33,7 +33,10 @@ extension AutoSignInVC {
                     self.setUpUserdefaultValues(data: data)
                     let nadoSunbaeTBC = NadoSunbaeTBC()
                     nadoSunbaeTBC.modalPresentationStyle = .fullScreen
-                    self.present(nadoSunbaeTBC, animated: true, completion: nil)
+                    self.present(nadoSunbaeTBC, animated: true, completion: {
+                        nadoSunbaeTBC.selectedIndex = NotificationInfo.shared.isPushComes ? 2 : 0
+                        NotificationInfo.shared.isPushComes = false
+                    })
                 }
             default:
                 print("Failed Auto SignIn")

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/TabBar/VC/NadoSunbaeTBC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/TabBar/VC/NadoSunbaeTBC.swift
@@ -15,6 +15,11 @@ class NadoSunbaeTBC: UITabBarController {
         configureTabBarItemStyle()
         configureTabBar()
         applyShadowTabBar()
+        NotificationCenter.default.addObserver(self, selector: #selector(goToNotificationVC), name: Notification.Name.pushNotificationClicked, object: nil)
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        NotificationCenter.default.removeObserver(self, name: Notification.Name.pushNotificationClicked, object: nil)
     }
 }
 
@@ -59,5 +64,17 @@ extension NadoSunbaeTBC {
         
         UITabBar.clearShadow()
         tabBar.layer.applyShadow(color: UIColor.shadowDefault, alpha: 0.16, x: 0, y: -9, blur: 18)
+    }
+}
+
+// MARK: - Custom Methods
+extension NadoSunbaeTBC {
+    
+    /// foreground로 알림을 클릭했을 때 실행되는 메서드
+    @objc
+    private func goToNotificationVC() {
+        /// 탭바에서 NotificationCenter Observer를 활용하여 푸시를 클릭했을 때 탭바의 selectedIndex를 2로, 싱글톤 객체의 값을 false로 변경
+        NotificationInfo.shared.isPushComes = false
+        self.selectedIndex = 2
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Support/AppDelegate.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Support/AppDelegate.swift
@@ -96,6 +96,8 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     
     /// 푸시알림을 클릭했을 때 실행되는 메서드
     func userNotificationCenter(_ center: UNUserNotificationCenter,didReceive response: UNNotificationResponse,withCompletionHandler completionHandler: @escaping () -> Void) {
+        NotificationCenter.default.post(name: Notification.Name.pushNotificationClicked, object: nil)
+        NotificationInfo.shared.isPushComes = true
         completionHandler()
     }
 }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #295 

## 🍎 변경 사항 및 이유
- Notification.Name -> `pushNotificationClicked` 생성
- `NotificationInfo` 싱글톤 생성
- 싱글톤을 만든 이유는,, push관련 정보가 앱 런칭시 앱딜리게이트로부터 생기는 데이터이므로 불필요하게 userdefaults를 사용할 필요가 없다고 판단했기 때문입니다!

## 🍎 PR Point
- 푸시 클릭 상태에 따라 AutoSignInVC에서 진입하는 탭바의 selectedIndex를 다르게 지정해주었습니다.
- foreground알림이 왔을 경우에는 탭바에 Observer를 두어 클릭 시 탭바 자체에서 selectedIndex를 변경하는 @objc 함수를 selector로 지정하여 구현했습니다!

## 📸 ScreenShot
📌 앱 첫 진입이 푸시알림 클릭일 경우 : (background 알림 클릭 후 앱으로 진입)

https://user-images.githubusercontent.com/63224278/157209024-c510c5c0-153a-4c3c-aac5-f35314f20625.mp4


📌 앱에서 foreground알림을 클릭했을 경우

https://user-images.githubusercontent.com/63224278/157209096-d766bd63-adc8-4b88-85bf-06ffd5c9a280.mp4


