### PR TITLE
✨ [FEAT] 과방탭 유저의 프로필 이미지, 닉네임을 클릭했을 때 유저의 마이페이지로 이동하는 기능 구현

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae-iOS.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		331C5382279629620052B309 /* BaseQuestionTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C5381279629620052B309 /* BaseQuestionTVC.swift */; };
 		331C5384279629D30052B309 /* EntireQuestionListTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C5383279629D30052B309 /* EntireQuestionListTVC.swift */; };
 		33393ADF27D4E85E007F2585 /* NSLayoutConstraint+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33393ADE27D4E85E007F2585 /* NSLayoutConstraint+.swift */; };
+		3341DB6C27D7D728007E65B6 /* SendBlockedInfoDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3341DB6B27D7D728007E65B6 /* SendBlockedInfoDelegate.swift */; };
 		334D2E0427914C8800A4CA23 /* WriteQuestionSB.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 334D2E0327914C8800A4CA23 /* WriteQuestionSB.storyboard */; };
 		3381083527D53E19005AF1F9 /* MypageLikeListVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3381083427D53E18005AF1F9 /* MypageLikeListVC.swift */; };
 		3381083827D53F33005AF1F9 /* MypageReviewLikeVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3381083727D53F33005AF1F9 /* MypageReviewLikeVC.swift */; };
@@ -332,6 +333,7 @@
 		331C5381279629620052B309 /* BaseQuestionTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseQuestionTVC.swift; sourceTree = "<group>"; };
 		331C5383279629D30052B309 /* EntireQuestionListTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntireQuestionListTVC.swift; sourceTree = "<group>"; };
 		33393ADE27D4E85E007F2585 /* NSLayoutConstraint+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLayoutConstraint+.swift"; sourceTree = "<group>"; };
+		3341DB6B27D7D728007E65B6 /* SendBlockedInfoDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendBlockedInfoDelegate.swift; sourceTree = "<group>"; };
 		334D2E0327914C8800A4CA23 /* WriteQuestionSB.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = WriteQuestionSB.storyboard; sourceTree = "<group>"; };
 		3381083427D53E18005AF1F9 /* MypageLikeListVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageLikeListVC.swift; sourceTree = "<group>"; };
 		3381083727D53F33005AF1F9 /* MypageReviewLikeVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageReviewLikeVC.swift; sourceTree = "<group>"; };
@@ -1570,6 +1572,7 @@
 				33BAFD02278C029F00BFF6BE /* TVCHeightDynamicUpdate.swift */,
 				338CDAFE278C939B00F8227A /* TVCContentUpdate.swift */,
 				5CC7E3EE278C7312000A8BD3 /* SendUpdateModalDelegate.swift */,
+				3341DB6B27D7D728007E65B6 /* SendBlockedInfoDelegate.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -2009,6 +2012,7 @@
 				77A7591A279712B700A8E48B /* ReviewPostTagCVC.swift in Sources */,
 				338601062798B1F800C47D36 /* NaviType.swift in Sources */,
 				3313642A2784D3BD00E0C118 /* AppDelegate.swift in Sources */,
+				3341DB6C27D7D728007E65B6 /* SendBlockedInfoDelegate.swift in Sources */,
 				C7F3F6DD27D5192D00E12888 /* ResendSignUpMailResponseModel.swift in Sources */,
 				3391E497278B7AC50079EA31 /* ClassroomQuestionTVC.swift in Sources */,
 				331364702785B18100E0C118 /* UserDefaults+.swift in Sources */,

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Protocol/SendBlockedInfoDelegate.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Protocol/SendBlockedInfoDelegate.swift
@@ -1,0 +1,12 @@
+//
+//  SendBlockedInfoDelegate.swift
+//  NadoSunbae-iOS
+//
+//  Created by hwangJi on 2022/03/09.
+//
+
+import Foundation
+
+protocol SendBlockedInfoDelegate {
+    func sendBlockedInfo(status: Bool, userID: Int)
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomCommentTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomCommentTVC.swift
@@ -42,6 +42,10 @@ class ClassroomCommentTVC: BaseTVC {
             changeCellDelegate.updateTV()
         }
     }
+    
+    @IBAction func tapNicknameBtn(_ sender: UIButton) {
+        print("tapNicknameBtn")
+    }
 }
 
 // MARK: - UI

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomCommentTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomCommentTVC.swift
@@ -23,6 +23,7 @@ class ClassroomCommentTVC: BaseTVC {
     weak var dynamicUpdateDelegate: TVCHeightDynamicUpdate?
     weak var changeCellDelegate: TVCContentUpdate?
     var tapMoreBtnAction : (() -> ())?
+    var tapNicknameBtnAction : (() -> ())?
     
     // MARK: LifeCycle
     override func awakeFromNib() {
@@ -44,7 +45,7 @@ class ClassroomCommentTVC: BaseTVC {
     }
     
     @IBAction func tapNicknameBtn(_ sender: UIButton) {
-        print("tapNicknameBtn")
+        tapNicknameBtnAction?()
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomCommentTVC.xib
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomCommentTVC.xib
@@ -75,11 +75,20 @@
                                 <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DA8-A9-yjt">
+                                <rect key="frame" x="16" y="16" width="42.5" height="21"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain"/>
+                                <connections>
+                                    <action selector="tapNicknameBtn:" destination="SVq-Rl-eLx" eventType="touchUpInside" id="FGi-T8-Ioj"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" name="chatFill"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="kYD-bX-I2J" secondAttribute="trailing" constant="8" id="3Bv-9l-2SU"/>
                             <constraint firstAttribute="bottom" secondItem="5pt-bF-h5S" secondAttribute="bottom" constant="12" id="8OR-AC-DMJ"/>
+                            <constraint firstItem="DA8-A9-yjt" firstAttribute="top" secondItem="OlX-jq-iUU" secondAttribute="top" id="9C8-7S-7re"/>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="272" id="DUs-YM-dxr"/>
                             <constraint firstItem="5pt-bF-h5S" firstAttribute="top" secondItem="LMH-SD-I1n" secondAttribute="bottom" constant="8" id="F5v-TD-YZN"/>
                             <constraint firstItem="kYD-bX-I2J" firstAttribute="centerY" secondItem="OlX-jq-iUU" secondAttribute="centerY" id="KU7-Fi-KNz"/>
@@ -91,6 +100,9 @@
                             <constraint firstAttribute="trailing" secondItem="LMH-SD-I1n" secondAttribute="trailing" constant="16" id="WcF-ac-ez0"/>
                             <constraint firstItem="LMH-SD-I1n" firstAttribute="leading" secondItem="OlX-jq-iUU" secondAttribute="leading" id="YCo-fW-BeS"/>
                             <constraint firstItem="5pt-bF-h5S" firstAttribute="leading" relation="lessThanOrEqual" secondItem="38o-sG-EsX" secondAttribute="leading" constant="180" id="a8O-1p-bd6"/>
+                            <constraint firstItem="DA8-A9-yjt" firstAttribute="trailing" secondItem="OlX-jq-iUU" secondAttribute="trailing" id="huH-bc-js3"/>
+                            <constraint firstItem="DA8-A9-yjt" firstAttribute="bottom" secondItem="OlX-jq-iUU" secondAttribute="bottom" id="oik-Zv-kSN"/>
+                            <constraint firstItem="DA8-A9-yjt" firstAttribute="leading" secondItem="OlX-jq-iUU" secondAttribute="leading" id="pwh-4n-ZcZ"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="12" id="u5x-eI-IfJ"/>
                             <constraint firstItem="OlX-jq-iUU" firstAttribute="leading" secondItem="38o-sG-EsX" secondAttribute="leading" constant="16" id="xmc-BG-enZ"/>
                             <constraint firstItem="XsY-Xa-ot0" firstAttribute="top" secondItem="OlX-jq-iUU" secondAttribute="bottom" id="yax-7h-ZWo"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomQuestionTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomQuestionTVC.swift
@@ -54,6 +54,10 @@ class ClassroomQuestionTVC: BaseTVC {
             changeCellDelegate.updateTV()
         }
     }
+    
+    @IBAction func tapNicknameBtn(_ sender: UIButton) {
+        print("tapNicknameBtn")
+    }
 }
 
 // MARK: - UI

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomQuestionTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomQuestionTVC.swift
@@ -31,6 +31,7 @@ class ClassroomQuestionTVC: BaseTVC {
     weak var changeCellDelegate: TVCContentUpdate?
     var tapLikeBtnAction : (() -> ())?
     var tapMoreBtnAction : (() -> ())?
+    var tapNicknameBtnAction : (() -> ())?
     
     // MARK: LifeCycle
     override func awakeFromNib() {
@@ -56,7 +57,7 @@ class ClassroomQuestionTVC: BaseTVC {
     }
     
     @IBAction func tapNicknameBtn(_ sender: UIButton) {
-        print("tapNicknameBtn")
+        tapNicknameBtnAction?()
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomQuestionTVC.xib
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Chat/ClassroomQuestionTVC.xib
@@ -100,16 +100,27 @@
                                 <color key="textColor" name="gray2"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1d4-Si-0qT">
+                                <rect key="frame" x="16" y="53" width="248" height="21"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title=""/>
+                                <connections>
+                                    <action selector="tapNicknameBtn:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="3GU-Jt-Kgh"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
+                            <constraint firstItem="1d4-Si-0qT" firstAttribute="bottom" secondItem="udq-eX-F8j" secondAttribute="bottom" id="9sz-sR-XdR"/>
                             <constraint firstItem="4Jn-Qv-vH7" firstAttribute="top" secondItem="YaZ-yA-JAB" secondAttribute="top" constant="16" id="A2q-Ul-nWi"/>
                             <constraint firstItem="XwU-wy-Tk1" firstAttribute="centerY" secondItem="hkZ-Xq-Tbg" secondAttribute="centerY" id="Aip-29-fcW"/>
                             <constraint firstItem="XwU-wy-Tk1" firstAttribute="leading" secondItem="hkZ-Xq-Tbg" secondAttribute="trailing" id="DMx-EJ-zEj"/>
+                            <constraint firstItem="1d4-Si-0qT" firstAttribute="trailing" secondItem="udq-eX-F8j" secondAttribute="trailing" id="H9l-fc-5Bz"/>
                             <constraint firstItem="aK2-Jo-OMJ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="4Jn-Qv-vH7" secondAttribute="trailing" constant="0.5" id="HtU-XE-oUE"/>
                             <constraint firstItem="OT9-0t-ckE" firstAttribute="leading" secondItem="udq-eX-F8j" secondAttribute="leading" id="Lqt-Ko-Ipf"/>
                             <constraint firstItem="1Ac-01-sRD" firstAttribute="leading" secondItem="XwU-wy-Tk1" secondAttribute="trailing" priority="250" constant="13.5" id="Mce-7W-KfJ"/>
                             <constraint firstAttribute="bottom" secondItem="hkZ-Xq-Tbg" secondAttribute="bottom" constant="8" id="NS0-hw-WPr"/>
+                            <constraint firstItem="1d4-Si-0qT" firstAttribute="top" secondItem="udq-eX-F8j" secondAttribute="top" id="ThY-vK-lIE"/>
                             <constraint firstAttribute="trailing" secondItem="CFZ-tM-j9m" secondAttribute="trailing" constant="16" id="WJP-tx-ted"/>
                             <constraint firstAttribute="width" relation="lessThanOrEqual" constant="311" id="WPb-Oa-v2T"/>
                             <constraint firstItem="CFZ-tM-j9m" firstAttribute="top" secondItem="OT9-0t-ckE" secondAttribute="bottom" constant="24" id="Wbm-tV-X35"/>
@@ -123,6 +134,7 @@
                             <constraint firstItem="hkZ-Xq-Tbg" firstAttribute="top" secondItem="CFZ-tM-j9m" secondAttribute="bottom" id="fno-3o-TVT"/>
                             <constraint firstItem="OT9-0t-ckE" firstAttribute="top" secondItem="udq-eX-F8j" secondAttribute="bottom" id="n14-nM-1FJ"/>
                             <constraint firstItem="udq-eX-F8j" firstAttribute="leading" secondItem="4Jn-Qv-vH7" secondAttribute="leading" id="rtw-NK-CcF"/>
+                            <constraint firstItem="1d4-Si-0qT" firstAttribute="leading" secondItem="udq-eX-F8j" secondAttribute="leading" id="sXQ-eS-qN6"/>
                             <constraint firstItem="aK2-Jo-OMJ" firstAttribute="top" secondItem="YaZ-yA-JAB" secondAttribute="top" constant="20" id="tCW-Jl-rdj"/>
                             <constraint firstItem="udq-eX-F8j" firstAttribute="top" secondItem="4Jn-Qv-vH7" secondAttribute="bottom" constant="8" id="tuW-gD-xQ2"/>
                             <constraint firstItem="CFZ-tM-j9m" firstAttribute="leading" secondItem="4Jn-Qv-vH7" secondAttribute="leading" id="ubm-BK-uee"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoCommentTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoCommentTVC.swift
@@ -46,6 +46,14 @@ class InfoCommentTVC: BaseTVC {
     @IBAction func tapMoreInfoBtn(_ sender: UIButton) {
         tapMoreInfoBtn?()
     }
+    
+    @IBAction func tapNicknameBtn(_ sender: UIButton) {
+        print("tapNicknameBtn")
+    }
+    
+    @IBAction func tapProfileImgBtn(_ sender: UIButton) {
+        print("tapProfileImgBtn")
+    }
 }
 
 // MARK: - Custom Methods

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoCommentTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoCommentTVC.swift
@@ -30,7 +30,9 @@ class InfoCommentTVC: BaseTVC {
     @IBOutlet var writerImgView: UIImageView!
     
     // MARK: Properties
-    var tapMoreInfoBtn: (() -> ())?
+    var tapMoreInfoBtnAction: (() -> ())?
+    var tapNicknameBtnAction: (() -> ())?
+    var tapProfileImgBtnAction: (() -> ())?
     var interactURL: ((_ data: URL) -> Void)?
     
     // MARK: Life Cycle
@@ -44,15 +46,15 @@ class InfoCommentTVC: BaseTVC {
     
     // MARK: IBAction
     @IBAction func tapMoreInfoBtn(_ sender: UIButton) {
-        tapMoreInfoBtn?()
+        tapMoreInfoBtnAction?()
     }
     
     @IBAction func tapNicknameBtn(_ sender: UIButton) {
-        print("tapNicknameBtn")
+        tapNicknameBtnAction?()
     }
     
     @IBAction func tapProfileImgBtn(_ sender: UIButton) {
-        print("tapProfileImgBtn")
+        tapProfileImgBtnAction?()
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoCommentTVC.xib
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoCommentTVC.xib
@@ -84,17 +84,40 @@
                             <constraint firstAttribute="width" constant="32" id="qGY-MV-yIL"/>
                         </constraints>
                     </imageView>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pid-x2-e1v">
+                        <rect key="frame" x="56" y="16" width="76" height="17"/>
+                        <state key="normal" title="Button"/>
+                        <buttonConfiguration key="configuration" style="plain" title=""/>
+                        <connections>
+                            <action selector="tapNicknameBtn:" destination="fh7-8u-a0h" eventType="touchUpInside" id="16O-ZD-IhO"/>
+                        </connections>
+                    </button>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Vkz-r6-rzK">
+                        <rect key="frame" x="16" y="16" width="32" height="32"/>
+                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                        <connections>
+                            <action selector="tapProfileImgBtn:" destination="fh7-8u-a0h" eventType="touchUpInside" id="2Lz-Re-Mxu"/>
+                        </connections>
+                    </button>
                 </subviews>
                 <color key="backgroundColor" name="paleGray"/>
                 <constraints>
                     <constraint firstItem="3ks-MP-Tdt" firstAttribute="leading" secondItem="rKz-xJ-yQq" secondAttribute="leading" id="0CX-vD-b4O"/>
                     <constraint firstItem="WQD-Tl-WV6" firstAttribute="leading" secondItem="rKz-xJ-yQq" secondAttribute="leading" id="5hP-49-jaD"/>
+                    <constraint firstItem="pid-x2-e1v" firstAttribute="top" secondItem="rKz-xJ-yQq" secondAttribute="top" id="C7F-oy-eza"/>
+                    <constraint firstItem="pid-x2-e1v" firstAttribute="trailing" secondItem="rKz-xJ-yQq" secondAttribute="trailing" id="CSw-2l-DrM"/>
+                    <constraint firstItem="Vkz-r6-rzK" firstAttribute="top" secondItem="E7S-Ue-Mte" secondAttribute="top" id="DDc-eG-swn"/>
                     <constraint firstItem="E7S-Ue-Mte" firstAttribute="top" secondItem="htk-89-fzd" secondAttribute="top" constant="16" id="DYk-jO-q9z"/>
                     <constraint firstItem="3ks-MP-Tdt" firstAttribute="top" secondItem="WQD-Tl-WV6" secondAttribute="bottom" constant="8" id="Jxz-GM-X5W"/>
                     <constraint firstAttribute="bottom" secondItem="oTA-58-wpP" secondAttribute="bottom" constant="7" id="KDC-SV-Q4n"/>
                     <constraint firstItem="oTA-58-wpP" firstAttribute="leading" secondItem="rKz-xJ-yQq" secondAttribute="leading" id="Ob0-1g-0LD"/>
+                    <constraint firstItem="Vkz-r6-rzK" firstAttribute="bottom" secondItem="E7S-Ue-Mte" secondAttribute="bottom" id="OnZ-zE-21C"/>
                     <constraint firstItem="anB-1a-uTg" firstAttribute="leading" secondItem="rKz-xJ-yQq" secondAttribute="trailing" constant="4" id="P39-6j-vyH"/>
+                    <constraint firstItem="pid-x2-e1v" firstAttribute="centerX" secondItem="rKz-xJ-yQq" secondAttribute="centerX" id="P8n-Nv-J3H"/>
+                    <constraint firstItem="Vkz-r6-rzK" firstAttribute="leading" secondItem="E7S-Ue-Mte" secondAttribute="leading" id="QUe-0p-GcP"/>
+                    <constraint firstItem="Vkz-r6-rzK" firstAttribute="trailing" secondItem="E7S-Ue-Mte" secondAttribute="trailing" id="TvH-u3-PzS"/>
                     <constraint firstItem="6S1-Ac-BEa" firstAttribute="top" secondItem="E7S-Ue-Mte" secondAttribute="top" id="Wkm-Ok-ezy"/>
+                    <constraint firstItem="pid-x2-e1v" firstAttribute="bottom" secondItem="rKz-xJ-yQq" secondAttribute="bottom" id="Zb1-4k-QCL"/>
                     <constraint firstItem="anB-1a-uTg" firstAttribute="centerY" secondItem="rKz-xJ-yQq" secondAttribute="centerY" id="cMR-MC-23c"/>
                     <constraint firstItem="E7S-Ue-Mte" firstAttribute="leading" secondItem="htk-89-fzd" secondAttribute="leading" constant="16" id="dI2-Zj-75T"/>
                     <constraint firstItem="rKz-xJ-yQq" firstAttribute="leading" secondItem="E7S-Ue-Mte" secondAttribute="trailing" constant="8" id="dkN-bo-gDu"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoQuestionTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoQuestionTVC.swift
@@ -53,6 +53,10 @@ class InfoQuestionTVC: BaseTVC {
     @IBAction func tapInfoLikeBtn(_ sender: UIButton) {
         tapLikeBtnAction?()
     }
+    
+    @IBAction func tapNicknameBtn(_ sender: UIButton) {
+        print("tapNicknameBtn")
+    }
 }
 
 // MARK: - Custom Methods

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoQuestionTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoQuestionTVC.swift
@@ -38,6 +38,7 @@ class InfoQuestionTVC: BaseTVC {
     
     // MARK: Properties
     var tapLikeBtnAction : (() -> ())?
+    var tapNicknameBtnAction : (() -> ())?
     var interactURL: ((_ data: URL) -> Void)?
     
     // MARK: Life Cycle
@@ -55,7 +56,7 @@ class InfoQuestionTVC: BaseTVC {
     }
     
     @IBAction func tapNicknameBtn(_ sender: UIButton) {
-        print("tapNicknameBtn")
+        tapNicknameBtnAction?()
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoQuestionTVC.xib
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoQuestionTVC.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -100,6 +100,14 @@
                             <action selector="tapInfoLikeBtn:" destination="Ruq-qR-max" eventType="touchUpInside" id="YGw-sG-enM"/>
                         </connections>
                     </button>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8XJ-kF-Jkk">
+                        <rect key="frame" x="24" y="90" width="145.5" height="17"/>
+                        <state key="normal" title="Button"/>
+                        <buttonConfiguration key="configuration" style="plain" title=""/>
+                        <connections>
+                            <action selector="tapNicknameBtn:" destination="Ruq-qR-max" eventType="touchUpInside" id="rjT-hf-oxc"/>
+                        </connections>
+                    </button>
                 </subviews>
                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
@@ -108,11 +116,14 @@
                     <constraint firstItem="bwe-DB-Ahe" firstAttribute="top" secondItem="bqR-DW-kR4" secondAttribute="bottom" constant="33" id="3zP-dJ-yJX"/>
                     <constraint firstItem="j6d-96-rol" firstAttribute="top" secondItem="Ldg-mB-RdQ" secondAttribute="bottom" constant="8" id="B8m-jY-qPg"/>
                     <constraint firstItem="H9E-DM-PWs" firstAttribute="leading" secondItem="j6d-96-rol" secondAttribute="trailing" constant="4" id="C12-jx-4bP"/>
+                    <constraint firstItem="8XJ-kF-Jkk" firstAttribute="leading" secondItem="j6d-96-rol" secondAttribute="leading" id="DJU-px-sPY"/>
                     <constraint firstItem="H9E-DM-PWs" firstAttribute="trailing" secondItem="Ldg-mB-RdQ" secondAttribute="trailing" id="Fsz-EG-0Ov"/>
                     <constraint firstItem="IpT-PK-08L" firstAttribute="bottom" secondItem="Uuv-04-IAF" secondAttribute="bottom" id="IkP-Mx-3VX"/>
                     <constraint firstItem="bwe-DB-Ahe" firstAttribute="leading" secondItem="Ldg-mB-RdQ" secondAttribute="leading" id="JZz-If-KXp"/>
+                    <constraint firstItem="8XJ-kF-Jkk" firstAttribute="top" secondItem="j6d-96-rol" secondAttribute="top" id="MnR-UD-9hB"/>
                     <constraint firstItem="Uuv-04-IAF" firstAttribute="leading" secondItem="nnp-hp-Mva" secondAttribute="leading" constant="-12" id="PCG-LH-g3y"/>
                     <constraint firstItem="Ldg-mB-RdQ" firstAttribute="leading" secondItem="X0y-co-BjG" secondAttribute="leading" constant="24" id="WzK-0E-fhj"/>
+                    <constraint firstItem="8XJ-kF-Jkk" firstAttribute="bottom" secondItem="j6d-96-rol" secondAttribute="bottom" id="dYW-pa-1p7"/>
                     <constraint firstAttribute="trailing" secondItem="Uuv-04-IAF" secondAttribute="trailing" constant="12" id="e52-gS-wDV"/>
                     <constraint firstItem="nnp-hp-Mva" firstAttribute="centerY" secondItem="bwe-DB-Ahe" secondAttribute="centerY" id="f0P-Kl-ePm"/>
                     <constraint firstItem="Uuv-04-IAF" firstAttribute="bottom" secondItem="nnp-hp-Mva" secondAttribute="bottom" constant="12" id="go1-Bk-dpi"/>
@@ -127,6 +138,7 @@
                     <constraint firstItem="H9E-DM-PWs" firstAttribute="centerY" secondItem="j6d-96-rol" secondAttribute="centerY" id="tSX-VL-kyy"/>
                     <constraint firstAttribute="bottom" secondItem="bwe-DB-Ahe" secondAttribute="bottom" constant="20" id="uT4-aa-lLb"/>
                     <constraint firstItem="Uuv-04-IAF" firstAttribute="top" secondItem="nnp-hp-Mva" secondAttribute="top" constant="-12" id="wuN-hF-8c1"/>
+                    <constraint firstItem="8XJ-kF-Jkk" firstAttribute="trailing" secondItem="j6d-96-rol" secondAttribute="trailing" id="xaO-YV-IUL"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="viJ-78-gos"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoQuestionTVC.xib
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoQuestionTVC.xib
@@ -84,7 +84,7 @@
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="114" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ruc-zw-Wox">
                                 <rect key="frame" x="25" y="0.0" width="21.5" height="12"/>
                                 <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="14"/>
-                                <color key="textColor" name="mainDefault"/>
+                                <color key="textColor" name="gray2"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/EntireQuestionListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/EntireQuestionListVC.swift
@@ -203,6 +203,8 @@ extension EntireQuestionListVC: UITableViewDelegate {
         groupChatVC.questionType = .group
         groupChatVC.naviStyle = .push
         groupChatVC.postID = questionList[indexPath.row].postID
+        groupChatVC.hidesBottomBarWhenPushed = true
+        
         self.navigationController?.pushViewController(groupChatVC, animated: true)
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionPersonListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionPersonListVC.swift
@@ -194,9 +194,9 @@ extension QuestionPersonListVC: UICollectionViewDelegateFlowLayout {
 }
 
 // MARK: - SendUpdateStatusDelegate
-extension QuestionPersonListVC: SendUpdateStatusDelegate {
-    func sendStatus(data: Bool) {
-        self.isBlocked = data
+extension QuestionPersonListVC: SendBlockedInfoDelegate {
+    func sendBlockedInfo(status: Bool, userID: Int) {
+        self.isBlocked = status
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC.swift
@@ -49,7 +49,7 @@ class MypageUserVC: BaseVC {
     var userInfo = MypageUserInfoModel()
     var questionList: [ClassroomPostList] = []
     var sortType: ListSortType = .recent
-    var judgeBlockStatusDelegate: SendUpdateStatusDelegate?
+    var judgeBlockStatusDelegate: SendBlockedInfoDelegate?
     
     // MARK: LifeCycle
     override func viewDidLoad() {
@@ -61,7 +61,7 @@ class MypageUserVC: BaseVC {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        showTabbar()
+        hideTabbar()
         getUserInfo()
         getUserPersonalQuestionList(sort: sortType)
     }
@@ -232,7 +232,7 @@ extension MypageUserVC {
                     guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
                     alert.showNadoAlert(vc: self, message: "해당 유저가 차단되었습니다.", confirmBtnTitle: "확인", cancelBtnTitle: "", type: .withSingleBtn)
                     alert.confirmBtn.press {
-                        self.judgeBlockStatusDelegate?.sendStatus(data: true)
+                        self.judgeBlockStatusDelegate?.sendBlockedInfo(status: true, userID: blockUserID)
                         self.navigationController?.popViewController(animated: true)
                     }
                 }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #305

## 🍎 변경 사항 및 이유
- 닉네임, 프로필이미지 위에 버튼을 얹어주었습니다.

## 🍎 PR Point
- 과방탭 유저의 프로필 이미지, 닉네임을 클릭했을 때 유저의 마이페이지로 이동하는 기능 구현했습니다.
- 원글유저가 차단되었을 시에는 pop 처리를 통해 글을 빠져나가도록 구현했습니다!
- 정보글 UI QA사항, EntireQuestionList > 질문스레드 이동시 하단탭바 오류 버그도 같이 수정했습니다!

## 📸 ScreenShot
[내 프로필로 이동]

https://user-images.githubusercontent.com/63224278/157325088-05add2c0-afef-43ff-a794-b9cb3a7cbd2c.mp4

[선배 마이페이지로 이동 후 원글 유저 차단]

https://user-images.githubusercontent.com/63224278/157325095-a30ce067-7e06-40a3-b779-7c3b3618189c.mp4

[선배 마이페이지로 이동 후 원글 유저가 아닌 타인 차단]

https://user-images.githubusercontent.com/63224278/157325371-030e8bbb-6f40-4447-801f-6067b4992360.mp4


