### PR TITLE
🔨 [FIX] 과방 메인 전체에게 질문 TableView Height 버그 해결

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionMainVC.swift
@@ -246,6 +246,8 @@ extension QuestionMainVC {
                 self.entireQuestionTV.snp.updateConstraints {
                     $0.height.equalTo(newSize.height)
                 }
+                
+                questionSV.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: questionList.count == 3 ? 70.adjustedH : 0, right: 0)
             }
         }
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionMainVC.swift
@@ -62,6 +62,7 @@ class QuestionMainVC: BaseVC {
     }
     
     private var questionList: [ClassroomPostList] = []
+    private let contentSizeObserverKeyPath = "contentSize"
     weak var sendSegmentStateDelegate: SendSegmentStateDelegate?
     let halfVC = HalfModalVC()
     
@@ -74,12 +75,16 @@ class QuestionMainVC: BaseVC {
         registerCell()
         setUpTapFindSunbaeBtn()
         addActivateIndicator()
-        setUpRequestData()
-        NotificationCenter.default.addObserver(self, selector: #selector(updateDataBySelectedMajor), name: Notification.Name.dismissHalfModal, object: nil)
     }
     
-    override func viewDidAppear(_ animated: Bool) {
+    override func viewWillAppear(_ animated: Bool) {
         setUpRequestData()
+        NotificationCenter.default.addObserver(self, selector: #selector(updateDataBySelectedMajor), name: Notification.Name.dismissHalfModal, object: nil)
+        self.entireQuestionTV.addObserver(self, forKeyPath: contentSizeObserverKeyPath, options: .new, context: nil)
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        self.entireQuestionTV.removeObserver(self, forKeyPath: contentSizeObserverKeyPath)
     }
 }
 
@@ -231,6 +236,19 @@ extension QuestionMainVC {
             }
         }
     }
+    
+    /// entireQuestionTV size값이 바뀌면 값을 비교하여 constraint를 업데이트하는 메서드
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
+        if (keyPath == contentSizeObserverKeyPath) {
+            if let newValue = change?[.newKey] {
+                let newSize  = newValue as! CGSize
+                
+                self.entireQuestionTV.snp.updateConstraints {
+                    $0.height.equalTo(newSize.height)
+                }
+            }
+        }
+    }
 }
 
 // MARK: - UITableViewDataSource
@@ -289,7 +307,7 @@ extension QuestionMainVC: UITableViewDelegate {
         case 0:
             return 44
         case 1:
-            return (questionList.count == 0 ? 189 : 120)
+            return (questionList.count == 0 ? 189 : 0)
         case 2:
             return (questionList.count > 5 ? 40 : 0)
         default:
@@ -342,7 +360,7 @@ extension QuestionMainVC {
             case .success(let res):
                 if let data = res as? [ClassroomPostList] {
                     self.questionList = data
-                    self.updateEntireQuestionTV()
+                    self.entireQuestionTV.reloadData()
                     self.activityIndicator.stopAnimating()
                 }
             case .requestErr(let res):


### PR DESCRIPTION
## 🍎 관련 이슈
closed #322

## 🍎 변경 사항 및 이유
- 옵저버를 다시 도입해 사이즈가 변경될 때마다 테이블뷰 사이즈를 변경해주었습니다!

## 🍎 PR Point
- 글이 3개일 때 탭바에 파뭍혀.. 스크롤뷰가 컨텐츠뷰 영역을 못잡아서 스크롤도 안되구 정적인 뷰로 그려지는 문제가 있어서 게시글 카운트 3일 경우에 스크롤뷰 인셋을 조정해주었습니다.

## 📸 ScreenShot
카톡으루 첨부!
