### PR TITLE
✨ [FEAT] 과방, 마이페이지 탭 후기 미작성자 권한 제한

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
@@ -137,13 +137,29 @@ extension InfoMainVC {
     /// 질문작성 floatingBtn tap 메서드
     private func setUpTapFloatingBtn() {
         infoFloatingBtn.press {
-            let writeQuestionSB: UIStoryboard = UIStoryboard(name: Identifiers.WriteQusetionSB, bundle: nil)
-            guard let writeQuestionVC = writeQuestionSB.instantiateViewController(identifier: WriteQuestionVC.className) as? WriteQuestionVC else { return }
             
-            writeQuestionVC.questionType = .info
-            writeQuestionVC.modalPresentationStyle = .fullScreen
-            
-            self.present(writeQuestionVC, animated: true, completion: nil)
+            /// 후기글 작성하지 않은 유저라면 후기글 열람 제한
+            if !(UserDefaults.standard.bool(forKey: UserDefaults.Keys.IsReviewed)) {
+                guard let restrictionAlert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+                
+                /// 후기 작성 버튼 클릭시 후기 작성 페이지로 이동
+                restrictionAlert.confirmBtn.press {
+                    let ReviewWriteSB = UIStoryboard.init(name: "ReviewWriteSB", bundle: nil)
+                    guard let nextVC = ReviewWriteSB.instantiateViewController(withIdentifier: ReviewWriteVC.className) as? ReviewWriteVC else { return }
+                    
+                    nextVC.modalPresentationStyle = .fullScreen
+                    self.present(nextVC, animated: true, completion: nil)
+                }
+                restrictionAlert.showNadoAlert(vc: self, message: "내 학과 후기를 작성해야\n이용할 수 있는 기능이에요.", confirmBtnTitle: "후기 작성", cancelBtnTitle: "다음에 작성")
+            } else {
+                let writeQuestionSB: UIStoryboard = UIStoryboard(name: Identifiers.WriteQusetionSB, bundle: nil)
+                guard let writeQuestionVC = writeQuestionSB.instantiateViewController(identifier: WriteQuestionVC.className) as? WriteQuestionVC else { return }
+                
+                writeQuestionVC.questionType = .info
+                writeQuestionVC.modalPresentationStyle = .fullScreen
+                
+                self.present(writeQuestionVC, animated: true, completion: nil)
+            }
         }
     }
     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoMainVC.swift
@@ -256,12 +256,28 @@ extension InfoMainVC: UITableViewDelegate {
     
     /// didSelectRowAt
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let infoDetailVC = self.storyboard?.instantiateViewController(withIdentifier: InfoDetailVC.className) as? InfoDetailVC else { return }
         
-        if infoList.count != 0 {
-            infoDetailVC.postID = infoList[indexPath.row].postID
-            infoDetailVC.hidesBottomBarWhenPushed = true
-            self.navigationController?.pushViewController(infoDetailVC, animated: true)
+        /// 후기글 작성하지 않은 유저라면 후기글 열람 제한
+        if !(UserDefaults.standard.bool(forKey: UserDefaults.Keys.IsReviewed)) {
+            guard let restrictionAlert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+            
+            /// 후기 작성 버튼 클릭시 후기 작성 페이지로 이동
+            restrictionAlert.confirmBtn.press {
+                let ReviewWriteSB = UIStoryboard.init(name: "ReviewWriteSB", bundle: nil)
+                guard let nextVC = ReviewWriteSB.instantiateViewController(withIdentifier: ReviewWriteVC.className) as? ReviewWriteVC else { return }
+                
+                nextVC.modalPresentationStyle = .fullScreen
+                self.present(nextVC, animated: true, completion: nil)
+            }
+            restrictionAlert.showNadoAlert(vc: self, message: "내 학과 후기를 작성해야\n이용할 수 있는 기능이에요.", confirmBtnTitle: "후기 작성", cancelBtnTitle: "다음에 작성")
+        } else {
+            guard let infoDetailVC = self.storyboard?.instantiateViewController(withIdentifier: InfoDetailVC.className) as? InfoDetailVC else { return }
+            
+            if infoList.count != 0 {
+                infoDetailVC.postID = infoList[indexPath.row].postID
+                infoDetailVC.hidesBottomBarWhenPushed = true
+                self.navigationController?.pushViewController(infoDetailVC, animated: true)
+            }
         }
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/EntireQuestionListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/EntireQuestionListVC.swift
@@ -197,15 +197,31 @@ extension EntireQuestionListVC: UITableViewDelegate {
     
     /// didSelectRowAt
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let groupChatSB: UIStoryboard = UIStoryboard(name: Identifiers.QuestionChatSB, bundle: nil)
-        guard let groupChatVC = groupChatSB.instantiateViewController(identifier: DefaultQuestionChatVC.className) as? DefaultQuestionChatVC else { return }
         
-        groupChatVC.questionType = .group
-        groupChatVC.naviStyle = .push
-        groupChatVC.postID = questionList[indexPath.row].postID
-        groupChatVC.hidesBottomBarWhenPushed = true
-        
-        self.navigationController?.pushViewController(groupChatVC, animated: true)
+        /// 후기글 작성하지 않은 유저라면 후기글 열람 제한
+        if !(UserDefaults.standard.bool(forKey: UserDefaults.Keys.IsReviewed)) {
+            guard let restrictionAlert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+            
+            /// 후기 작성 버튼 클릭시 후기 작성 페이지로 이동
+            restrictionAlert.confirmBtn.press {
+                let ReviewWriteSB = UIStoryboard.init(name: "ReviewWriteSB", bundle: nil)
+                guard let nextVC = ReviewWriteSB.instantiateViewController(withIdentifier: ReviewWriteVC.className) as? ReviewWriteVC else { return }
+                
+                nextVC.modalPresentationStyle = .fullScreen
+                self.present(nextVC, animated: true, completion: nil)
+            }
+            restrictionAlert.showNadoAlert(vc: self, message: "내 학과 후기를 작성해야\n이용할 수 있는 기능이에요.", confirmBtnTitle: "후기 작성", cancelBtnTitle: "다음에 작성")
+        } else {
+            let groupChatSB: UIStoryboard = UIStoryboard(name: Identifiers.QuestionChatSB, bundle: nil)
+            guard let groupChatVC = groupChatSB.instantiateViewController(identifier: DefaultQuestionChatVC.className) as? DefaultQuestionChatVC else { return }
+            
+            groupChatVC.questionType = .group
+            groupChatVC.naviStyle = .push
+            groupChatVC.postID = questionList[indexPath.row].postID
+            groupChatVC.hidesBottomBarWhenPushed = true
+            
+            self.navigationController?.pushViewController(groupChatVC, animated: true)
+        }
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionMainVC.swift
@@ -261,7 +261,23 @@ extension QuestionMainVC: UITableViewDataSource {
         case 0:
             guard let questionHeaderCell = tableView.dequeueReusableCell(withIdentifier: QuestionHeaderTVC.className, for: indexPath) as? QuestionHeaderTVC else { return UITableViewCell() }
             questionHeaderCell.tapWriteBtnAction = {
-                self.presentToWriteQuestionVC()
+                
+                /// 후기글 작성하지 않은 유저라면 후기글 열람 제한
+                if !(UserDefaults.standard.bool(forKey: UserDefaults.Keys.IsReviewed)) {
+                    guard let restrictionAlert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+                    
+                    /// 후기 작성 버튼 클릭시 후기 작성 페이지로 이동
+                    restrictionAlert.confirmBtn.press {
+                        let ReviewWriteSB = UIStoryboard.init(name: "ReviewWriteSB", bundle: nil)
+                        guard let nextVC = ReviewWriteSB.instantiateViewController(withIdentifier: ReviewWriteVC.className) as? ReviewWriteVC else { return }
+                        
+                        nextVC.modalPresentationStyle = .fullScreen
+                        self.present(nextVC, animated: true, completion: nil)
+                    }
+                    restrictionAlert.showNadoAlert(vc: self, message: "내 학과 후기를 작성해야\n이용할 수 있는 기능이에요.", confirmBtnTitle: "후기 작성", cancelBtnTitle: "다음에 작성")
+                } else {
+                    self.presentToWriteQuestionVC()
+                }
             }
             return questionHeaderCell
         case 1:

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionMainVC.swift
@@ -330,15 +330,31 @@ extension QuestionMainVC: UITableViewDelegate {
     /// didSelectRowAt
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if indexPath.section == 1 {
-            let groupChatSB: UIStoryboard = UIStoryboard(name: Identifiers.QuestionChatSB, bundle: nil)
-            guard let groupChatVC = groupChatSB.instantiateViewController(identifier: DefaultQuestionChatVC.className) as? DefaultQuestionChatVC else { return }
             
-            if questionList.count != 0 {
-                groupChatVC.questionType = .group
-                groupChatVC.naviStyle = .push
-                groupChatVC.postID = questionList[indexPath.row].postID
-                groupChatVC.hidesBottomBarWhenPushed = true
-                self.navigationController?.pushViewController(groupChatVC, animated: true)
+            /// 후기글 작성하지 않은 유저라면 후기글 열람 제한
+            if !(UserDefaults.standard.bool(forKey: UserDefaults.Keys.IsReviewed)) {
+                guard let restrictionAlert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+                
+                /// 후기 작성 버튼 클릭시 후기 작성 페이지로 이동
+                restrictionAlert.confirmBtn.press {
+                    let ReviewWriteSB = UIStoryboard.init(name: "ReviewWriteSB", bundle: nil)
+                    guard let nextVC = ReviewWriteSB.instantiateViewController(withIdentifier: ReviewWriteVC.className) as? ReviewWriteVC else { return }
+                    
+                    nextVC.modalPresentationStyle = .fullScreen
+                    self.present(nextVC, animated: true, completion: nil)
+                }
+                restrictionAlert.showNadoAlert(vc: self, message: "내 학과 후기를 작성해야\n이용할 수 있는 기능이에요.", confirmBtnTitle: "후기 작성", cancelBtnTitle: "다음에 작성")
+            } else {
+                let groupChatSB: UIStoryboard = UIStoryboard(name: Identifiers.QuestionChatSB, bundle: nil)
+                guard let groupChatVC = groupChatSB.instantiateViewController(identifier: DefaultQuestionChatVC.className) as? DefaultQuestionChatVC else { return }
+                
+                if questionList.count != 0 {
+                    groupChatVC.questionType = .group
+                    groupChatVC.naviStyle = .push
+                    groupChatVC.postID = questionList[indexPath.row].postID
+                    groupChatVC.hidesBottomBarWhenPushed = true
+                    self.navigationController?.pushViewController(groupChatVC, animated: true)
+                }
             }
         } else if indexPath.section == 2 {
             let entireQuestionVC = EntireQuestionListVC()

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageClassroomPostListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageClassroomPostListVC.swift
@@ -209,22 +209,54 @@ extension MypageClassroomPostListVC: UITableViewDelegate {
         case .review:
             break
         case .question:
-            guard let questionDetailVC = UIStoryboard.init(name: Identifiers.QuestionChatSB, bundle: nil).instantiateViewController(withIdentifier: DefaultQuestionChatVC.className) as? DefaultQuestionChatVC else { return }
             
-            if likePostList.count != 0 {
-                questionDetailVC.postID = likePostList[indexPath.row].postID
-                questionDetailVC.questionType = likePostList[indexPath.row].postTypeID == 3 ? .group : .personal
-                questionDetailVC.naviStyle = .push
-                questionDetailVC.hidesBottomBarWhenPushed = true
-                self.navigationController?.pushViewController(questionDetailVC, animated: true)
+            /// 후기글 작성하지 않은 유저라면 후기글 열람 제한
+            if !(UserDefaults.standard.bool(forKey: UserDefaults.Keys.IsReviewed)) {
+                guard let restrictionAlert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+                
+                /// 후기 작성 버튼 클릭시 후기 작성 페이지로 이동
+                restrictionAlert.confirmBtn.press {
+                    let ReviewWriteSB = UIStoryboard.init(name: "ReviewWriteSB", bundle: nil)
+                    guard let nextVC = ReviewWriteSB.instantiateViewController(withIdentifier: ReviewWriteVC.className) as? ReviewWriteVC else { return }
+                    
+                    nextVC.modalPresentationStyle = .fullScreen
+                    self.present(nextVC, animated: true, completion: nil)
+                }
+                restrictionAlert.showNadoAlert(vc: self, message: "내 학과 후기를 작성해야\n이용할 수 있는 기능이에요.", confirmBtnTitle: "후기 작성", cancelBtnTitle: "다음에 작성")
+            } else {
+                guard let questionDetailVC = UIStoryboard.init(name: Identifiers.QuestionChatSB, bundle: nil).instantiateViewController(withIdentifier: DefaultQuestionChatVC.className) as? DefaultQuestionChatVC else { return }
+                
+                if likePostList.count != 0 {
+                    questionDetailVC.postID = likePostList[indexPath.row].postID
+                    questionDetailVC.questionType = likePostList[indexPath.row].postTypeID == 3 ? .group : .personal
+                    questionDetailVC.naviStyle = .push
+                    questionDetailVC.hidesBottomBarWhenPushed = true
+                    self.navigationController?.pushViewController(questionDetailVC, animated: true)
+                }
             }
         case .information:
-            guard let infoDetailVC = UIStoryboard.init(name: Identifiers.InfoSB, bundle: nil).instantiateViewController(withIdentifier: InfoDetailVC.className) as? InfoDetailVC else { return }
             
-            if likePostList.count != 0 {
-                infoDetailVC.postID = likePostList[indexPath.row].postID
-                infoDetailVC.hidesBottomBarWhenPushed = true
-                self.navigationController?.pushViewController(infoDetailVC, animated: true)
+            /// 후기글 작성하지 않은 유저라면 후기글 열람 제한
+            if !(UserDefaults.standard.bool(forKey: UserDefaults.Keys.IsReviewed)) {
+                guard let restrictionAlert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+                
+                /// 후기 작성 버튼 클릭시 후기 작성 페이지로 이동
+                restrictionAlert.confirmBtn.press {
+                    let ReviewWriteSB = UIStoryboard.init(name: "ReviewWriteSB", bundle: nil)
+                    guard let nextVC = ReviewWriteSB.instantiateViewController(withIdentifier: ReviewWriteVC.className) as? ReviewWriteVC else { return }
+                    
+                    nextVC.modalPresentationStyle = .fullScreen
+                    self.present(nextVC, animated: true, completion: nil)
+                }
+                restrictionAlert.showNadoAlert(vc: self, message: "내 학과 후기를 작성해야\n이용할 수 있는 기능이에요.", confirmBtnTitle: "후기 작성", cancelBtnTitle: "다음에 작성")
+            } else {
+                guard let infoDetailVC = UIStoryboard.init(name: Identifiers.InfoSB, bundle: nil).instantiateViewController(withIdentifier: InfoDetailVC.className) as? InfoDetailVC else { return }
+                
+                if likePostList.count != 0 {
+                    infoDetailVC.postID = likePostList[indexPath.row].postID
+                    infoDetailVC.hidesBottomBarWhenPushed = true
+                    self.navigationController?.pushViewController(infoDetailVC, animated: true)
+                }
             }
         }
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageReviewLikeVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageReviewLikeVC.swift
@@ -164,7 +164,21 @@ extension MypageReviewLikeVC: UITableViewDelegate {
     
     /// didSelectRowAt
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if likeReviewList.count != 0 {
+        
+        /// 후기글 작성하지 않은 유저라면 후기글 열람 제한
+        if !(UserDefaults.standard.bool(forKey: UserDefaults.Keys.IsReviewed)) {
+            guard let restrictionAlert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+            
+            /// 후기 작성 버튼 클릭시 후기 작성 페이지로 이동
+            restrictionAlert.confirmBtn.press {
+                let ReviewWriteSB = UIStoryboard.init(name: "ReviewWriteSB", bundle: nil)
+                guard let nextVC = ReviewWriteSB.instantiateViewController(withIdentifier: ReviewWriteVC.className) as? ReviewWriteVC else { return }
+                
+                nextVC.modalPresentationStyle = .fullScreen
+                self.present(nextVC, animated: true, completion: nil)
+            }
+            restrictionAlert.showNadoAlert(vc: self, message: "내 학과 후기를 작성해야\n이용할 수 있는 기능이에요.", confirmBtnTitle: "후기 작성", cancelBtnTitle: "다음에 작성")
+        } else if likeReviewList.count != 0 {
             guard let reviewDetailVC = UIStoryboard.init(name: Identifiers.ReviewDetailSB, bundle: nil).instantiateViewController(withIdentifier: ReviewDetailVC.className) as? ReviewDetailVC else { return }
             reviewDetailVC.postId = likeReviewList[indexPath.row].postID
             self.navigationController?.pushViewController(reviewDetailVC, animated: true)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyPostListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyPostListVC.swift
@@ -123,19 +123,51 @@ extension MypageMyPostListVC: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         switch postType {
         case .question:
-            guard let chatVC = UIStoryboard(name: Identifiers.QuestionChatSB, bundle: nil).instantiateViewController(identifier: DefaultQuestionChatVC.className) as? DefaultQuestionChatVC else { return }
             
-            chatVC.questionType = .group
-            chatVC.naviStyle = .push
-            chatVC.postID = isPostOrAnswer ? self.postList[indexPath.row].postID : self.answerList[indexPath.row].postID
-            
-            self.navigationController?.pushViewController(chatVC, animated: true)
+            /// 후기글 작성하지 않은 유저라면 후기글 열람 제한
+            if !(UserDefaults.standard.bool(forKey: UserDefaults.Keys.IsReviewed)) {
+                guard let restrictionAlert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+                
+                /// 후기 작성 버튼 클릭시 후기 작성 페이지로 이동
+                restrictionAlert.confirmBtn.press {
+                    let ReviewWriteSB = UIStoryboard.init(name: "ReviewWriteSB", bundle: nil)
+                    guard let nextVC = ReviewWriteSB.instantiateViewController(withIdentifier: ReviewWriteVC.className) as? ReviewWriteVC else { return }
+                    
+                    nextVC.modalPresentationStyle = .fullScreen
+                    self.present(nextVC, animated: true, completion: nil)
+                }
+                restrictionAlert.showNadoAlert(vc: self, message: "내 학과 후기를 작성해야\n이용할 수 있는 기능이에요.", confirmBtnTitle: "후기 작성", cancelBtnTitle: "다음에 작성")
+            } else {
+                guard let chatVC = UIStoryboard(name: Identifiers.QuestionChatSB, bundle: nil).instantiateViewController(identifier: DefaultQuestionChatVC.className) as? DefaultQuestionChatVC else { return }
+                
+                chatVC.questionType = .group
+                chatVC.naviStyle = .push
+                chatVC.postID = isPostOrAnswer ? self.postList[indexPath.row].postID : self.answerList[indexPath.row].postID
+                
+                self.navigationController?.pushViewController(chatVC, animated: true)
+            }
         case .information:
-            guard let infoVC = UIStoryboard(name: Identifiers.InfoSB, bundle: nil).instantiateViewController(withIdentifier: InfoDetailVC.className) as? InfoDetailVC else { return }
             
-            infoVC.postID = isPostOrAnswer ? self.postList[indexPath.row].postID : self.answerList[indexPath.row].postID
-            
-            self.navigationController?.pushViewController(infoVC, animated: true)
+            /// 후기글 작성하지 않은 유저라면 후기글 열람 제한
+            if !(UserDefaults.standard.bool(forKey: UserDefaults.Keys.IsReviewed)) {
+                guard let restrictionAlert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+                
+                /// 후기 작성 버튼 클릭시 후기 작성 페이지로 이동
+                restrictionAlert.confirmBtn.press {
+                    let ReviewWriteSB = UIStoryboard.init(name: "ReviewWriteSB", bundle: nil)
+                    guard let nextVC = ReviewWriteSB.instantiateViewController(withIdentifier: ReviewWriteVC.className) as? ReviewWriteVC else { return }
+                    
+                    nextVC.modalPresentationStyle = .fullScreen
+                    self.present(nextVC, animated: true, completion: nil)
+                }
+                restrictionAlert.showNadoAlert(vc: self, message: "내 학과 후기를 작성해야\n이용할 수 있는 기능이에요.", confirmBtnTitle: "후기 작성", cancelBtnTitle: "다음에 작성")
+            } else {
+                guard let infoVC = UIStoryboard(name: Identifiers.InfoSB, bundle: nil).instantiateViewController(withIdentifier: InfoDetailVC.className) as? InfoDetailVC else { return }
+                
+                infoVC.postID = isPostOrAnswer ? self.postList[indexPath.row].postID : self.answerList[indexPath.row].postID
+                
+                self.navigationController?.pushViewController(infoVC, animated: true)
+            }
         }
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyReviewVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypageMyReviewVC.swift
@@ -95,10 +95,26 @@ extension MypageMyReviewVC: UITableViewDataSource {
 // MARK: - UITableViewDelegate
 extension MypageMyReviewVC: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let ReviewDetailSB = UIStoryboard.init(name: "ReviewDetailSB", bundle: nil)
-        guard let nextVC = ReviewDetailSB.instantiateViewController(withIdentifier: ReviewDetailVC.className) as? ReviewDetailVC else { return }
-        nextVC.postId = reviewList[indexPath.row].postID
-        self.navigationController?.pushViewController(nextVC, animated: true)
+        
+        /// 후기글 작성하지 않은 유저라면 후기글 열람 제한
+        if !(UserDefaults.standard.bool(forKey: UserDefaults.Keys.IsReviewed)) {
+            guard let restrictionAlert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+            
+            /// 후기 작성 버튼 클릭시 후기 작성 페이지로 이동
+            restrictionAlert.confirmBtn.press {
+                let ReviewWriteSB = UIStoryboard.init(name: "ReviewWriteSB", bundle: nil)
+                guard let nextVC = ReviewWriteSB.instantiateViewController(withIdentifier: ReviewWriteVC.className) as? ReviewWriteVC else { return }
+                
+                nextVC.modalPresentationStyle = .fullScreen
+                self.present(nextVC, animated: true, completion: nil)
+            }
+            restrictionAlert.showNadoAlert(vc: self, message: "내 학과 후기를 작성해야\n이용할 수 있는 기능이에요.", confirmBtnTitle: "후기 작성", cancelBtnTitle: "다음에 작성")
+        } else {
+            let ReviewDetailSB = UIStoryboard.init(name: "ReviewDetailSB", bundle: nil)
+            guard let nextVC = ReviewDetailSB.instantiateViewController(withIdentifier: ReviewDetailVC.className) as? ReviewDetailVC else { return }
+            nextVC.postId = reviewList[indexPath.row].postID
+            self.navigationController?.pushViewController(nextVC, animated: true)
+        }
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC+TV.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC+TV.swift
@@ -33,14 +33,30 @@ extension MypageUserVC: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let chatSB: UIStoryboard = UIStoryboard(name: Identifiers.QuestionChatSB, bundle: nil)
-        guard let personalChatVC = chatSB.instantiateViewController(identifier: DefaultQuestionChatVC.className) as? DefaultQuestionChatVC else { return }
-       
-        personalChatVC.questionType = .personal
-        personalChatVC.naviStyle = .push
-        personalChatVC.postID = self.questionList[indexPath.row].postID
-        personalChatVC.hidesBottomBarWhenPushed = true
         
-        self.navigationController?.pushViewController(personalChatVC, animated: true)
+        /// 후기글 작성하지 않은 유저라면 후기글 열람 제한
+        if !(UserDefaults.standard.bool(forKey: UserDefaults.Keys.IsReviewed)) {
+            guard let restrictionAlert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+            
+            /// 후기 작성 버튼 클릭시 후기 작성 페이지로 이동
+            restrictionAlert.confirmBtn.press {
+                let ReviewWriteSB = UIStoryboard.init(name: "ReviewWriteSB", bundle: nil)
+                guard let nextVC = ReviewWriteSB.instantiateViewController(withIdentifier: ReviewWriteVC.className) as? ReviewWriteVC else { return }
+                
+                nextVC.modalPresentationStyle = .fullScreen
+                self.present(nextVC, animated: true, completion: nil)
+            }
+            restrictionAlert.showNadoAlert(vc: self, message: "내 학과 후기를 작성해야\n이용할 수 있는 기능이에요.", confirmBtnTitle: "후기 작성", cancelBtnTitle: "다음에 작성")
+        } else {
+            let chatSB: UIStoryboard = UIStoryboard(name: Identifiers.QuestionChatSB, bundle: nil)
+            guard let personalChatVC = chatSB.instantiateViewController(identifier: DefaultQuestionChatVC.className) as? DefaultQuestionChatVC else { return }
+            
+            personalChatVC.questionType = .personal
+            personalChatVC.naviStyle = .push
+            personalChatVC.postID = self.questionList[indexPath.row].postID
+            personalChatVC.hidesBottomBarWhenPushed = true
+            
+            self.navigationController?.pushViewController(personalChatVC, animated: true)
+        }
     }
 }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #324

## 🍎 변경 사항 및 이유
- 후기를 작성하지 않은 유저에 대한 권한 제한을 모두 처리했습니다.

## 🍎 PR Point
- 처리 방법은 후기탭에서 했던거 그대로 가져와서 화면 전환 코드에 모두 넣어주었습니다!

## 📸 ScreenShot

