### PR TITLE
🔨 [FIX] 알림탭에서 삭제된 게시글의 알림을 누를 경우 오류 해결

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/BaseVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/BaseVC.swift
@@ -103,6 +103,14 @@ extension BaseVC {
             }
         }
     }
+    
+    /// 특정 탭의 루트 뷰컨으로 이동시키는 메서드
+    func goToRootOfTab(index: Int) {
+        tabBarController?.selectedIndex = index
+        if let nav = tabBarController?.viewControllers?[index] as? UINavigationController {
+            nav.popToRootViewController(animated: true)
+        }
+    }
 }
 
 // MARK: - UIGestureRecognizerDelegate

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/NadoAlertVC.xib
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/NadoAlertVC.xib
@@ -33,8 +33,7 @@
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ELo-xG-zpK" customClass="NadoSunbaeBtn" customModule="NadoSunbae_iOS" customModuleProvider="target">
                                 <rect key="frame" x="14.000000000000007" y="102" width="111.66666666666669" height="52"/>
                                 <color key="tintColor" name="gray2"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <connections>
                                     <action selector="tapCancelBtn:" destination="gxf-cd-wcu" eventType="touchUpInside" id="dQw-P8-lDI"/>
                                 </connections>
@@ -42,8 +41,7 @@
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CCK-SR-a1R" customClass="NadoSunbaeBtn" customModule="NadoSunbae_iOS" customModuleProvider="target">
                                 <rect key="frame" x="138" y="102" width="112" height="52"/>
                                 <color key="tintColor" name="mainDefault"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <connections>
                                     <action selector="tapConfirmBtn:" destination="gxf-cd-wcu" eventType="touchUpInside" id="nKu-N0-vHw"/>
                                 </connections>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ClassroomAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ClassroomAPI.swift
@@ -214,10 +214,12 @@ extension ClassroomAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
+        case 400:
+            return .requestErr(decodedData.message)
         case 401:
             return .requestErr(false)
-        case 400, 402...409:
-            return .requestErr(decodedData.message)
+        case 404:
+            return .requestErr(404)
         case 500:
             return .serverErr
         default:
@@ -234,10 +236,12 @@ extension ClassroomAPI {
         switch status {
         case 200...204:
             return .success(decodedData.data ?? "None-Data")
+        case 400:
+            return .requestErr(decodedData.message)
         case 401:
             return .requestErr(false)
-        case 400, 402...409:
-            return .requestErr(decodedData.message)
+        case 404:
+            return .requestErr(404)
         case 500:
             return .serverErr
         default:

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoQuestionTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/InfoDetail/InfoQuestionTVC.swift
@@ -73,6 +73,7 @@ extension InfoQuestionTVC {
         infoLikeBackView.backgroundColor =  model.like.isLiked ? UIColor.nadoBlack : UIColor.gray0
         infoLikeImgView.image = model.like.isLiked ? UIImage(named: "heart_mint") : UIImage(named: "heart")
         infoLikeCountLabel.text = "\(model.like.likeCount)"
+        infoLikeCountLabel.textColor = model.like.isLiked ? .mainDefault : .gray2
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
@@ -437,10 +437,15 @@ extension InfoDetailVC {
                 if let message = res as? String {
                     print(message)
                     self.activityIndicator.stopAnimating()
-                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.") 
                 } else if res is Bool {
                     self.updateAccessToken { _ in
                         self.optionalBindingData()
+                    }
+                } else if res is Int {
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "존재하지 않는 포스트입니다.") { _ in
+                        self.navigationController?.popViewController(animated: true)
                     }
                 }
             default:

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
@@ -247,14 +247,6 @@ extension InfoDetailVC {
             self.navigationController?.pushViewController(myPageUserVC, animated: true)
         }
     }
-    
-    /// 특정 탭의 루트 뷰컨으로 이동시키는 메서드
-    private func goToRootOfTab(index: Int) {
-        tabBarController?.selectedIndex = index
-        if let nav = tabBarController?.viewControllers?[index] as? UINavigationController {
-            nav.popToRootViewController(animated: true)
-        }
-    }
 }
 
 // MARK: - UITableViewDataSource

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Info/InfoDetailVC.swift
@@ -437,7 +437,7 @@ extension InfoDetailVC {
                 if let message = res as? String {
                     print(message)
                     self.activityIndicator.stopAnimating()
-                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.") 
+                    self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
                 } else if res is Bool {
                     self.updateAccessToken { _ in
                         self.optionalBindingData()

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -362,14 +362,6 @@ extension DefaultQuestionChatVC {
             self.navigationController?.pushViewController(myPageUserVC, animated: true)
         }
     }
-    
-    /// 특정 탭의 루트 뷰컨으로 이동시키는 메서드
-    private func goToRootOfTab(index: Int) {
-        tabBarController?.selectedIndex = index
-        if let nav = tabBarController?.viewControllers?[index] as? UINavigationController {
-            nav.popToRootViewController(animated: true)
-        }
-    }
 }
 
 // MARK: - UITextViewDelegate

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -765,10 +765,15 @@ extension DefaultQuestionChatVC {
                     self.updateAccessToken { _ in
                         self.optionalBindingData()
                     }
+                } else if res is Int {
+                    self.activityIndicator.stopAnimating()
+                    self.makeAlert(title: "존재하지 않는 포스트입니다.") { _ in
+                        self.navigationController?.popViewController(animated: true)
+                    }
                 }
             default:
                 self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "내부 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }
@@ -798,7 +803,7 @@ extension DefaultQuestionChatVC {
                 }
             default:
                 self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "내부 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }
@@ -825,7 +830,7 @@ extension DefaultQuestionChatVC {
                 }
             default:
                 self.activityIndicator.stopAnimating()
-                self.makeAlert(title: "내부 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
+                self.makeAlert(title: "네트워크 오류로 인해\n데이터를 불러올 수 없습니다.\n다시 시도해 주세요.")
             }
         }
     }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #317 

## 🍎 변경 사항 및 이유
- 나도알럿 내 나도선배버튼 폰트 오류 해결 -> button의 상태를 default로 지정!
- 과방 정보글 좋아요 UI 라벨 컬러 수정
- requestErr떴을 때 message라벨에 띄우고 pop코드 심으려다가.. 찐 네트워크 오류일 때가 있을 수 있어서 404(삭제된 포스트를 조회했을 경우)에만 해당 기능을 추가해주었습니다! --> 따라서 네트워크 코드도 좀 바뀜!

## 🍎 PR Point
- 알림탭에서 삭제된 게시글의 알림을 누를 경우 오류 해결

## 📸 ScreenShot

https://user-images.githubusercontent.com/63224278/157438579-e5cf4530-8619-48df-8016-9bbf948fb478.mp4


