### PR TITLE
🔨 [FIX] 알림탭에서 글로 이동 시 정확한 글로 이동하지 않는 문제 수정

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Notification/VC/NotificationMainVC+TV.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Notification/VC/NotificationMainVC+TV.swift
@@ -37,12 +37,11 @@ extension NotificationMainVC: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         
-        /// 뷰 이동 및 읽음 처리, 현재 질문글만 뷰 이동 가능
         switch notificationList[indexPath.section].notificationTypeID.getNotiType() {
         case .writtenInfo:
             guard let infoDetailVC = UIStoryboard(name: Identifiers.InfoSB, bundle: nil).instantiateViewController(identifier: InfoDetailVC.className) as? InfoDetailVC else { return }
             
-            infoDetailVC.postID = notificationList[indexPath.row].postID
+            infoDetailVC.postID = notificationList[indexPath.section].postID
             infoDetailVC.hidesBottomBarWhenPushed = true
             
             readNoti(notiID: notificationList[indexPath.section].notificationID)
@@ -62,7 +61,7 @@ extension NotificationMainVC: UITableViewDelegate {
         case .answerInfo:
             guard let infoDetailVC = UIStoryboard(name: Identifiers.InfoSB, bundle: nil).instantiateViewController(identifier: InfoDetailVC.className) as? InfoDetailVC else { return }
             
-            infoDetailVC.postID = notificationList[indexPath.row].postID
+            infoDetailVC.postID = notificationList[indexPath.section].postID
             infoDetailVC.hidesBottomBarWhenPushed = true
             
             readNoti(notiID: notificationList[indexPath.section].notificationID)


### PR DESCRIPTION
## 🍎 관련 이슈
closed #332

## 🍎 변경 사항 및 이유
* 알림 탭의 tableView를 1 section 1 row로 구현했는데... 알림 클릭 시 postID 접근할 때 indexPath.row로 접근하던 코드들이 있어서 "작성한 정보글", "답글을 작성한 정보글" 이 엉뚱한 뷰로 이동하는 경우가 있었음. 해결해쓰요

## 🍎 PR Point

## 📸 ScreenShot
정상적으로 동작
