### PR TITLE
🔨 [FIX] 마이페이지 로드 전 프로필 영역 글씨 안 보이게 설정

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/SB/MypageSB.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/SB/MypageSB.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="PEE-ZU-uAc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="PEE-ZU-uAc">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -93,32 +93,32 @@
                                                             <constraint firstAttribute="width" secondItem="Whs-Ow-1T6" secondAttribute="height" multiplier="1:1" id="VMv-FL-clh"/>
                                                         </constraints>
                                                     </imageView>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DkH-uk-mr1">
-                                                        <rect key="frame" x="107.66666666666666" y="20" width="40" height="19.333333333333329"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DkH-uk-mr1">
+                                                        <rect key="frame" x="107.66666666666666" y="29.666666666666657" width="0.0" height="0.0"/>
                                                         <fontDescription key="fontDescription" name="Pretendard-Medium" family="Pretendard" pointSize="16"/>
                                                         <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="본" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fm0-p4-DGu">
-                                                        <rect key="frame" x="107.66666666666666" y="47.333333333333343" width="11" height="14"/>
+                                                        <rect key="frame" x="107.66666666666666" y="37.666666666666657" width="11" height="14"/>
                                                         <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="12"/>
                                                         <color key="textColor" name="gray2"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="제2" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9NL-ZH-n5I">
-                                                        <rect key="frame" x="107.66666666666666" y="61.33333333333335" width="18" height="17.333333333333336"/>
+                                                        <rect key="frame" x="107.66666666666666" y="51.666666666666657" width="18" height="14.666666666666671"/>
                                                         <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="12"/>
                                                         <color key="textColor" name="gray2"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9cd-WG-iJ5">
-                                                        <rect key="frame" x="131.66666666666666" y="47.333333333333343" width="30" height="14"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9cd-WG-iJ5">
+                                                        <rect key="frame" x="131.66666666666666" y="37.666666666666657" width="0.0" height="14"/>
                                                         <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="12"/>
                                                         <color key="textColor" name="gray2"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iAx-1x-GtA">
-                                                        <rect key="frame" x="124.66666666666666" y="48.666666666666657" width="1" height="11"/>
+                                                        <rect key="frame" x="124.66666666666666" y="39" width="1" height="11"/>
                                                         <color key="backgroundColor" name="gray1"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="1" id="Rjl-o7-iOY"/>
@@ -136,14 +136,14 @@
                                                         </connections>
                                                     </button>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P3N-QC-htV">
-                                                        <rect key="frame" x="131.66666666666666" y="63" width="1" height="14"/>
+                                                        <rect key="frame" x="131.66666666666666" y="53" width="1" height="11.666666666666671"/>
                                                         <color key="backgroundColor" name="gray1"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="1" id="3Li-LU-lVf"/>
                                                         </constraints>
                                                     </view>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kss-ZR-4kQ">
-                                                        <rect key="frame" x="138.66666666666666" y="63" width="30" height="14"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kss-ZR-4kQ">
+                                                        <rect key="frame" x="138.66666666666666" y="53" width="0.0" height="11.666666666666671"/>
                                                         <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="12"/>
                                                         <color key="textColor" name="gray2"/>
                                                         <nil key="highlightedColor"/>
@@ -407,6 +407,8 @@
                     <nil key="simulatedTopBarMetrics"/>
                     <size key="freeformSize" width="374" height="1033"/>
                     <connections>
+                        <outlet property="firstMajorFormLabel" destination="Fm0-p4-DGu" id="mbg-z6-YI8"/>
+                        <outlet property="firstMajorFormLineView" destination="iAx-1x-GtA" id="cUS-Ba-3nz"/>
                         <outlet property="firstMajorLabel" destination="9cd-WG-iJ5" id="LG3-gk-KJj"/>
                         <outlet property="likeCountLabel" destination="hxj-K9-WHH" id="Mzk-Ms-q5e"/>
                         <outlet property="likeListView" destination="xRv-Yq-z9u" id="YCz-Dy-OOG"/>
@@ -417,6 +419,8 @@
                         <outlet property="questionEmptyView" destination="uF1-fq-33Y" id="OHN-bF-clq"/>
                         <outlet property="questionTV" destination="yck-ZF-BPb" id="ZN2-jP-vJ0"/>
                         <outlet property="questionTVHeight" destination="hG4-BW-Xr8" id="RAg-oM-4mg"/>
+                        <outlet property="secondMajorFormLabel" destination="9NL-ZH-n5I" id="wCT-NQ-orr"/>
+                        <outlet property="secondMajorFormLineView" destination="P3N-QC-htV" id="rMg-PU-Xhb"/>
                         <outlet property="secondMajorLabel" destination="Kss-ZR-4kQ" id="t8J-Aa-YRp"/>
                         <outlet property="userStateViewHeight" destination="Vaa-CA-BSH" id="ts6-aW-zdi"/>
                     </connections>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/SB/MypageSB.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/SB/MypageSB.storyboard
@@ -59,7 +59,7 @@
                                     <constraint firstAttribute="height" constant="104" id="txf-UB-xxH"/>
                                 </constraints>
                             </view>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" bouncesZoom="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lIU-LS-kTe">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lIU-LS-kTe">
                                 <rect key="frame" x="0.0" y="104" width="374" height="895"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vgh-ef-uvF" userLabel="Content View">

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/MypageMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/MypageMainVC.swift
@@ -26,6 +26,10 @@ class MypageMainVC: BaseVC {
     @IBOutlet weak var firstMajorLabel: UILabel!
     @IBOutlet weak var secondMajorLabel: UILabel!
     @IBOutlet weak var likeCountLabel: UILabel!
+    @IBOutlet weak var firstMajorFormLabel: UILabel!
+    @IBOutlet weak var secondMajorFormLabel: UILabel!
+    @IBOutlet weak var firstMajorFormLineView: UIView!
+    @IBOutlet weak var secondMajorFormLineView: UIView!
     
     // MARK: Properties
     var userInfo = MypageUserInfoModel()
@@ -42,6 +46,7 @@ class MypageMainVC: BaseVC {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setProfileUI(isVisable: false)
         configureUI()
         setUpTV()
         registerCell()
@@ -125,6 +130,15 @@ extension MypageMainVC {
             }
         }
     }
+    
+    /// 프로필 뷰의 기본 틀 UI 세팅
+    private func setProfileUI(isVisable: Bool) {
+        DispatchQueue.main.async {
+            [self.firstMajorFormLabel, self.secondMajorFormLabel, self.firstMajorFormLineView, self.secondMajorFormLineView].forEach {
+                $0?.isHidden = !(isVisable)
+            }
+        }
+    }
 }
 
 // MARK: - Custom Methods
@@ -150,6 +164,7 @@ extension MypageMainVC {
             case .success(let res):
                 self.activityIndicator.stopAnimating()
                 if let data = res as? MypageUserInfoModel {
+                    self.setProfileUI(isVisable: true)
                     self.userInfo = data
                     print("user info: ", self.userInfo)
                     self.configureUI()

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/SB/MypageUserVC.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/SB/MypageUserVC.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -332,6 +332,8 @@
                     </view>
                     <size key="freeformSize" width="375" height="948"/>
                     <connections>
+                        <outlet property="firstMajorFormLabel" destination="yPh-Ud-xRn" id="DwK-DM-EnF"/>
+                        <outlet property="firstMajorFormLineView" destination="wz5-np-T0h" id="7Fd-0i-YZX"/>
                         <outlet property="firstMajorLabel" destination="k4h-rD-4bX" id="bcy-3M-F37"/>
                         <outlet property="floatingBtn" destination="Yax-Dk-hiT" id="diD-0g-tev"/>
                         <outlet property="majorReviewCountLabel" destination="SWl-yB-pDv" id="kC7-rK-IHA"/>
@@ -345,6 +347,8 @@
                         <outlet property="questionTV" destination="kXs-pO-uLu" id="c9i-Dw-cxu"/>
                         <outlet property="questionTVHeight" destination="9Eh-OO-Be7" id="cHm-PC-Cy0"/>
                         <outlet property="responseRateLabel" destination="E7l-XF-nO7" id="wzk-e0-3jA"/>
+                        <outlet property="secondMajorFormLabel" destination="cvT-p9-Xxn" id="bUY-87-La2"/>
+                        <outlet property="secondMajorFormLineView" destination="WBF-5b-Y9V" id="HoQ-uU-Vph"/>
                         <outlet property="secondMajorLabel" destination="QdH-XR-kIi" id="PY0-W5-go8"/>
                         <outlet property="sortBtn" destination="YlK-2x-mgE" id="ijw-06-d5o"/>
                         <outlet property="userStateView" destination="1KN-MV-zEV" id="nlC-vs-Xrm"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC.swift
@@ -43,6 +43,10 @@ class MypageUserVC: BaseVC {
             responseRateLabel.isHidden = true
         }
     }
+    @IBOutlet weak var firstMajorFormLabel: UILabel!
+    @IBOutlet weak var secondMajorFormLabel: UILabel!
+    @IBOutlet weak var firstMajorFormLineView: UIView!
+    @IBOutlet weak var secondMajorFormLineView: UIView!
     
     // MARK: Properties
     var targetUserID = 1
@@ -54,6 +58,7 @@ class MypageUserVC: BaseVC {
     // MARK: LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        setProfileUI(isVisable: false)
         configureUI()
         setUpTV()
         registerCell()
@@ -154,6 +159,15 @@ extension MypageUserVC {
             self.questionTV.isHidden = self.questionList.isEmpty ? true : false
         }
     }
+    
+    /// 프로필 뷰의 기본 틀 UI 세팅
+    private func setProfileUI(isVisable: Bool) {
+        DispatchQueue.main.async {
+            [self.firstMajorFormLabel, self.secondMajorFormLabel, self.firstMajorFormLineView, self.secondMajorFormLineView].forEach {
+                $0?.isHidden = !(isVisable)
+            }
+        }
+    }
 }
 
 // MARK: - Custom Methods
@@ -177,6 +191,7 @@ extension MypageUserVC {
             switch networkResult {
             case .success(let res):
                 if let data = res as? MypageUserInfoModel {
+                    self.setProfileUI(isVisable: true)
                     self.userInfo = data
                     self.configureUI()
                 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/ProfileSetting/SB/EditProfileVC.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/ProfileSetting/SB/EditProfileVC.storyboard
@@ -32,7 +32,7 @@
                                     <constraint firstAttribute="height" constant="104" id="aVZ-Q2-ewv"/>
                                 </constraints>
                             </view>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dJ4-qk-4Mf">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dJ4-qk-4Mf">
                                 <rect key="frame" x="0.0" y="104" width="375" height="853"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Erw-kK-1XW" userLabel="Content View">

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/SignUpUserInfo/VC/SignUpUserInfoVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/SignUpUserInfo/VC/SignUpUserInfoVC.swift
@@ -100,7 +100,7 @@ extension SignUpUserInfoVC {
         [(nickNameTextField, nickNameClearBtn), (emailTextField, emailClearBtn), (PWTextField, PWClearBtn), (checkPWTextFIeld, checkPWClearBtn)].forEach { (textField, btn) in
             setTextFieldClearBtn(textField: textField, clearBtn: btn)
         }
-        emailTextField.text = "@korea.ac.kr"
+        emailTextField.placeholder = "@korea.ac.kr"
         changePWInfoLabelState()
         checkEmailIsValid()
         checkNickNameIsValid()


### PR DESCRIPTION
## 🍎 관련 이슈
closed #338 

## 🍎 변경 사항 및 이유
* 지은언니가 말한, 마이페이지에서 로딩 전 프로필 영역 기본 글씨가 안 보이도록 설정
* 마이페이지 말고도 선배페이지에서도 설정
* 마이페이지 메인, 프로필 수정뷰 스크롤뷰 indicator 제거
* 회원가입 > 기본정보 이메일 placeholder로 힌트값 넣기

## 🍎 PR Point


## 📸 ScreenShot

https://user-images.githubusercontent.com/43312096/157481369-e23d2306-0f62-461a-a181-ff089733da22.mov

![스크린샷 2022-03-10 오전 1 20 25](https://user-images.githubusercontent.com/43312096/157484025-96afbd82-8072-41ee-9d77-111a17d34149.png)

