### PR TITLE
🔨 [FIX] 온보딩 전에 스플래시 뜨지 않는 문제 해결

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/VC/AutoSignInVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignIn/VC/AutoSignInVC.swift
@@ -21,7 +21,7 @@ class AutoSignInVC: BaseVC {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
-        requestAutoSignInAfterSplash()
+        presentNextViewAfterSplash()
     }
 }
 
@@ -37,9 +37,17 @@ extension AutoSignInVC {
 
 // MARK: Custom Methods
 extension AutoSignInVC {
-    private func requestAutoSignInAfterSplash() {
-        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.5) {
-            self.requestAutoSignIn()
+    private func presentNextViewAfterSplash() {
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.2) {
+            guard let nextVC = UIStoryboard.init(name: "OnboardingSB", bundle: nil).instantiateViewController(withIdentifier: OnboardingVC.className) as? OnboardingVC else { return }
+            if !UserDefaults.standard.bool(forKey: UserDefaults.Keys.IsOnboarding) {
+                nextVC.modalPresentationStyle = .fullScreen
+                nextVC.modalTransitionStyle = .crossDissolve
+                nextVC.view.layer.speed = 1
+                self.present(nextVC, animated: true, completion: nil)
+            } else {
+                self.requestAutoSignIn()
+            }
         }
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Support/SceneDelegate.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Support/SceneDelegate.swift
@@ -20,13 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         if let windowScene = scene as? UIWindowScene {
             let window = UIWindow(windowScene: windowScene)
             
-            // rootVC를 tabBar로 지정
-            // window.rootViewController = NadoSunbaeTBC()
-            if !UserDefaults.standard.bool(forKey: UserDefaults.Keys.IsOnboarding) {
-                window.rootViewController = UIStoryboard.init(name: "OnboardingSB", bundle: nil).instantiateViewController(withIdentifier: OnboardingVC.className) as? OnboardingVC
-            } else {
-                window.rootViewController = UIStoryboard.init(name: "SignInSB", bundle: nil).instantiateViewController(withIdentifier: AutoSignInVC.className) as? AutoSignInVC
-            }
+            window.rootViewController = UIStoryboard.init(name: "SignInSB", bundle: nil).instantiateViewController(withIdentifier: AutoSignInVC.className) as? AutoSignInVC
             self.window = window
             window.makeKeyAndVisible()
         }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #339

## 🍎 변경 사항 및 이유
- 온보딩 전에 스플래시 뜨지 않는 문제를 해결했습니다.

## 🍎 PR Point
- 무조건 root뷰컨을 AutoSignInVC(스플래시)로 해주었습니다. 스플래시 이후에 온보딩 판단을해서 어떤 화면으로 전환해줄지 분기처리하여 문제를 해결했습니다.

## 📸 ScreenShot

