### PR TITLE
🔨 [FIX] 후기글 수정 시 이전 작성 글 글자수 표시되지 않는 문제 해결

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
@@ -97,6 +97,9 @@ class ReviewWriteVC: BaseVC {
         [oneLineReviewTextView, prosAndConsTextView, learnInfoTextView, recommendClassTextView, badClassTextView, futureTextView, tipTextView].forEach {
             textView in setUpCompleteBtnStatus(textView: textView)
         }
+        [oneLineReviewTextView, prosAndConsTextView, learnInfoTextView, recommendClassTextView, badClassTextView, futureTextView, tipTextView].forEach {
+            textView in setUpCharCount(textView: textView)
+        }
         setUpDefaultBgImg()
     }
     
@@ -217,6 +220,30 @@ extension ReviewWriteVC {
         
         /// 완료 버튼 활성화 조건 (필수작성항목 모두 채워지고, 선택항목 조건 달성)
         reviewWriteNaviBar.rightActivateBtn.isActivated = essentialTextViewStatus && choiceTextViewStatus
+    }
+    
+    /// Label에 TextView 글자수 표시하는 함수
+    private func setUpCharCount(textView: UITextView) {
+        if textView == oneLineReviewTextView {
+            if textView.text != "학과를 한줄로 표현한다면?" {
+                oneLineReviewCountLabel.text = "\(oneLineReviewTextView.text.count)/최대 40자"
+            }
+        }
+        if textView.text != "내용을 입력해주세요" {
+            if textView == prosAndConsTextView {
+                prosAndConsCountLabel.text = "\(prosAndConsTextView.text.count)/최소 100자"
+            } else if textView == learnInfoTextView {
+                learnInfoCountLabel.text = "\(learnInfoTextView.text.count)/최소 100자"
+            } else if textView == recommendClassTextView {
+                recommendClassCountLabel.text = "\(recommendClassTextView.text.count)/최소 100자"
+            } else if textView == badClassTextView {
+                badClassCountLabel.text = "\(badClassTextView.text.count)/최소 100자"
+            } else if textView == futureTextView {
+                futureCountLabel.text = "\(futureTextView.text.count)/최소 100자"
+            } else if textView == tipTextView {
+                tipCountLabel.text = "\(tipTextView.text.count)/최소 100자"
+            }
+        }
     }
     
     /// ReviewDetailVC에서 상태값 받아오기 위한 함수
@@ -403,26 +430,7 @@ extension ReviewWriteVC: UITextViewDelegate {
         setUpCompleteBtnStatus(textView: textView)
         
         /// 글자수 표시
-        if textView == oneLineReviewTextView {
-            if textView.text != "학과를 한줄로 표현한다면?" {
-                oneLineReviewCountLabel.text = "\(oneLineReviewTextView.text.count)/최대 40자"
-            }
-        }
-        if textView.text != "내용을 입력해주세요" {
-            if textView == prosAndConsTextView {
-                prosAndConsCountLabel.text = "\(prosAndConsTextView.text.count)/최소 100자"
-            } else if textView == learnInfoTextView {
-                learnInfoCountLabel.text = "\(learnInfoTextView.text.count)/최소 100자"
-            } else if textView == recommendClassTextView {
-                recommendClassCountLabel.text = "\(recommendClassTextView.text.count)/최소 100자"
-            } else if textView == badClassTextView {
-                badClassCountLabel.text = "\(badClassTextView.text.count)/최소 100자"
-            } else if textView == futureTextView {
-                futureCountLabel.text = "\(futureTextView.text.count)/최소 100자"
-            } else if textView == tipTextView {
-                tipCountLabel.text = "\(tipTextView.text.count)/최소 100자"
-            }
-        }
+        setUpCharCount(textView: textView)
         
         /// 텍스트뷰 내 indicator 백그라운드 컬러 설정
         func scrollViewDidScroll(_ scrollView: UIScrollView) {


### PR DESCRIPTION
## 🍎 관련 이슈
closed #351

## 🍎 변경 사항 및 이유
- 후기글 수정 시에도 이전 작성 글의 글자수가 표시되도록 수정하였습니다.

## 🍎 PR Point
- 기존 글자수 카운트 코드를 함수화하여 `viewWillAppear()`에서 한번 더 호출해주었습니다.

## 📸 ScreenShot

https://user-images.githubusercontent.com/63277563/157709585-9863921f-bc9f-4bcb-8793-e62c325c84a8.mp4


