### PR TITLE
🔨 [FIX] 후기 부적절자 관련 알럿 메시지 수정

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/BaseVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/BaseVC.swift
@@ -122,6 +122,11 @@ extension BaseVC {
             }
         case .inappropriate:
             permissionMsg = "부적절한 후기 작성이 확인되어\n열람 권한이 제한되었습니다.\n권한을 얻고 싶다면\n다시 학과후기를 작성해주세요."
+            restrictionAlert.confirmBtn.press {
+                self.presentToReviewWriteVC { _ in }
+            }
+        case .report:
+            permissionMsg = UserPermissionInfo.shared.permissionMsg
             comfirmTitle = "문의하기"
             cancelTitle = "닫기"
             restrictionAlert.confirmBtn.press {
@@ -131,8 +136,8 @@ extension BaseVC {
                     }
                 }
             }
-        case .report:
-            permissionMsg = UserPermissionInfo.shared.permissionMsg
+        case .firstInappropriate:
+            permissionMsg = "부적절한 후기 작성이 확인되어\n열람 권한이 제한되었습니다.\n권한을 얻고 싶다면\n다시 학과후기를 작성해주세요."
             comfirmTitle = "문의하기"
             cancelTitle = "닫기"
             restrictionAlert.confirmBtn.press {
@@ -151,7 +156,9 @@ extension BaseVC {
     func divideUserPermission(defaultAction: () -> Void) {
         if UserPermissionInfo.shared.isUserReported {
             self.showRestrictionAlert(permissionStatus: .report)
-        } else if UserPermissionInfo.shared.isReviewInappropriate || !(UserPermissionInfo.shared.isReviewed) {
+        } else if UserPermissionInfo.shared.isReviewInappropriate {
+            self.showRestrictionAlert(permissionStatus: .inappropriate)
+        } else if !(UserPermissionInfo.shared.isReviewed) {
             self.showRestrictionAlert(permissionStatus: .review)
         } else {
             // 아무런 제한이 없을 때 실행되는 action

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/PermissionType.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/PermissionType.swift
@@ -11,4 +11,5 @@ enum PermissionType {
     case review
     case report
     case inappropriate
+    case firstInappropriate
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
@@ -160,7 +160,7 @@ extension ReviewMainVC {
     private func showInappropriateReviewerAlert() {
         var isShowed = false
         if !isShowed && UserPermissionInfo.shared.isReviewInappropriate {
-            showRestrictionAlert(permissionStatus: .inappropriate)
+            showRestrictionAlert(permissionStatus: .firstInappropriate)
             isShowed = true
         }
     }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #365 

## 🍎 변경 사항 및 이유
- 원래 후기 부적절 유저의 경우 첫 진입시에만 부적절 후기 관련 문구가 뜨고, 그 이후부터는 기능 접근시에 후기 미작성자와 동일한 알럿을 띄우는 거였는데,, 갑자기 바뀌었다고 합니다.

## 🍎 PR Point
- 그래서 firstInappropriate 케이스를 추가해서 처음과 그 이후를 구분해주었습니다!

## 📸 ScreenShot
카톡으루 첨부!
