### PR TITLE
🔨 [FIX] 회원가입 요청 시 "미진입" 데이터 잘못 들어가는 버그 수정 

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/SignUpMajorInfo/VC/SignUpMajorInfoVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/SignUpMajorInfo/VC/SignUpMajorInfoVC.swift
@@ -88,6 +88,9 @@ class SignUpMajorInfoVC: BaseVC {
     
     @IBAction func tapNextBtn(_ sender: UIButton) {
         guard let vc = UIStoryboard.init(name: SignUpUserInfoVC.className, bundle: nil).instantiateViewController(withIdentifier: SignUpUserInfoVC.className) as? SignUpUserInfoVC else { return }
+        if signUpData.secondMajorStart == "선택하기" {
+            signUpData.secondMajorStart = "미진입"
+        }
         vc.signUpData = signUpData
         self.navigationController?.pushViewController(vc, animated: true)
     }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #372 

## 🍎 변경 사항 및 이유
* 제2전공 진입시기가 placeholder 값으로 들어가는 경우를 찾을 수가 없어서...(애초에 placeholder값을 가져오는 코드 자체가 없었음..) 원인 찾는 거는 실패했고 일단 임시방편으로 데이터 넘기기 전에 "선택하기"라고 되어 있으면 그거 "미진입"으로 수정하는 코드 추가했습니다~~ 정확한 원인을 찾게 되면 그때 바꾸든가 할게요 우선 기존같은 현상은 안 일어날 듯~

## 🍎 PR Point
없ㅅ

## 📸 ScreenShot

