### PR TITLE
🔨 [FIX] 회원가입, 프로필 수정 시 제1/제2전공 중복 선택 막기

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/ProfileSetting/VC/EditProfileVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/ProfileSetting/VC/EditProfileVC.swift
@@ -157,11 +157,16 @@ class EditProfileVC: BaseVC {
     }
     
     private func judgeSaveBtnState() {
-        if userInfo.secondMajorID != changedInfo.secondMajorID && changedInfo.secondMajorID != 1 && changedInfo.secondMajorStart == "미진입" {
+        if (userInfo.secondMajorID != changedInfo.secondMajorID && changedInfo.secondMajorID != 1 && changedInfo.secondMajorStart == "미진입") || !(checkMajorDuplicate(firstTextField: firstMajorTextField, secondTextField: secondMajorTextField)) {
             setNavViewNadoRightBtn(status: false)
         } else {
             setNavViewNadoRightBtn(status: userInfo == changedInfo ? false : true)
         }
+    }
+    
+    /// 제1, 제2전공 중복 선택 검사, 중복되지 않으면 true
+    private func checkMajorDuplicate(firstTextField: UITextField, secondTextField: UITextField) -> Bool {
+        return !(firstTextField.text == secondTextField.text)
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/SignUpMajorInfo/VC/SignUpMajorInfoVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/SignUpMajorInfo/VC/SignUpMajorInfoVC.swift
@@ -135,7 +135,7 @@ extension SignUpMajorInfoVC {
     /// textField에 값이 들어올 때마다 NextBtn 활성화할지를 체크하는 함수
     private func checkNextBtnIsEnabled() {
         secondMajorStartSelectBtn.isEnabled = !(secondMajorTextField.text == "미진입")
-        if !(univTextField.isEmpty) && !(firstMajorTextField.isEmpty) && !(firstMajorStartTextField.isEmpty) && !(secondMajorTextField.isEmpty) {
+        if !(univTextField.isEmpty) && !(firstMajorTextField.isEmpty) && !(firstMajorStartTextField.isEmpty) && !(secondMajorTextField.isEmpty) && checkMajorDuplicate(firstTextField: firstMajorTextField, secondTextField: secondMajorTextField) {
             if secondMajorTextField.text == "미진입" {
                 nextBtn.isActivated = true
                 nextBtn.isEnabled = true


### PR DESCRIPTION

## 🍎 관련 이슈
closed #385

## 🍎 변경 사항 및 이유
* 약 한 달 반만에 완성한 제1/제2 전공 중복 기입 막기...(사실 개발 20분걸림)ㅋㅋ

## 🍎 PR Point
* 없슴당

## 📸 ScreenShot
* 회원가입

https://user-images.githubusercontent.com/43312096/166257062-69a9b405-6a90-4524-b425-6e99e2a5fbf7.MP4

* 마이페이지 > 내정보 수정

https://user-images.githubusercontent.com/43312096/166257036-cce14fa5-9150-4b5b-ad2b-671226220e81.MP4


