### PR TITLE
✅ [CHORE] 서버 세팅 파일 수정

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIEssentials/BaseAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIEssentials/BaseAPI.swift
@@ -1,0 +1,29 @@
+//
+//  BaseAPI.swift
+//  NadoSunbae
+//
+//  Created by EUNJU on 2022/09/07.
+//
+
+import Foundation
+import Moya
+
+class BaseAPI {
+    func judgeStatus<T: Codable>(by statusCode: Int, _ data: Data, _ type: T.Type) -> NetworkResult<Any> {
+        let decoder = JSONDecoder()
+        guard let decodedData = try? decoder.decode(GenericResponse<T>.self, from: data)
+                
+        else { return .pathErr }
+        print(decodedData)
+        switch statusCode {
+        case 200...202:
+            return .success(decodedData.data ?? "None-Data")
+        case 400..<500:
+            return .requestErr(decodedData.message)
+        case 500:
+            return .serverErr
+        default:
+            return .networkFail
+        }
+    }
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIEssentials/BaseAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIEssentials/BaseAPI.swift
@@ -14,7 +14,7 @@ class BaseAPI {
         guard let decodedData = try? decoder.decode(GenericResponse<T>.self, from: data)
                 
         else { return .pathErr }
-        print(decodedData)
+
         switch statusCode {
         case 200...202:
             return .success(decodedData.data ?? "None-Data")

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ReviewAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/ReviewAPI.swift
@@ -8,11 +8,11 @@
 import Foundation
 import Moya
 
-class ReviewAPI {
+class ReviewAPI: BaseAPI {
     static let shared = ReviewAPI()
     var userProvider = MoyaProvider<ReviewService>()
     
-    private init() {}
+    private override init() {}
     
     /// [POST] 후기글 등록 API
     func createReviewPostAPI(majorID: Int, bgImgID: Int, oneLineReview: String, prosCons: String, curriculum: String, career: String, recommendLecture: String, nonRecommendLecture: String, tip: String, completion: @escaping (NetworkResult<Any>) -> (Void)) {
@@ -22,8 +22,8 @@ class ReviewAPI {
             case .success(let response):
                 let statusCode = response.statusCode
                 let data = response.data
-                
-                completion(self.createReviewPostJudgeData(status: statusCode, data: data))
+                let networkResult = self.judgeStatus(by: statusCode, data, ReviewPostRegisterData.self)
+                completion(networkResult)
                 
             case .failure(let err):
                 print(err)
@@ -39,11 +39,11 @@ class ReviewAPI {
             case .success(let response):
                 let statusCode = response.statusCode
                 let data = response.data
-                
-                completion(self.getReviewPostListJudgeData(status: statusCode, data: data))
+                let networkResult = self.judgeStatus(by: statusCode, data, [ReviewMainPostListData].self)
+                completion(networkResult)
                 
             case .failure(let err):
-                print(err)
+                print(err.localizedDescription)
             }
         }
     }
@@ -56,8 +56,8 @@ class ReviewAPI {
             case .success(let response):
                 let statusCode = response.statusCode
                 let data = response.data
-                
-                completion(self.getReviewPostDetailJudgeData(status: statusCode, data: data))
+                let networkResult = self.judgeStatus(by: statusCode, data, ReviewPostDetailData.self)
+                completion(networkResult)
                 
             case .failure(let err):
                 print(err)
@@ -73,8 +73,8 @@ class ReviewAPI {
             case .success(let response):
                 let statusCode = response.statusCode
                 let data = response.data
-                
-                completion(self.getReviewHomepageJudgeData(status: statusCode, data: data))
+                let networkResult = self.judgeStatus(by: statusCode, data, ReviewHomePageData.self)
+                completion(networkResult)
                 
             case .failure(let err):
                 print(err)
@@ -90,8 +90,8 @@ class ReviewAPI {
             case .success(let response):
                 let statusCode = response.statusCode
                 let data = response.data
-                
-                completion(self.deleteReviewPostJudgeData(status: statusCode, data: data))
+                let networkResult = self.judgeStatus(by: statusCode, data, ReviewDeleteResModel.self)
+                completion(networkResult)
                 
             case .failure(let err):
                 print(err)
@@ -107,8 +107,8 @@ class ReviewAPI {
             case .success(let response):
                 let statusCode = response.statusCode
                 let data = response.data
-                
-                completion(self.editReviewPostJudgeData(status: statusCode, data: data))
+                let networkResult = self.judgeStatus(by: statusCode, data, ReviewEditData.self)
+                completion(networkResult)
                 
             case .failure(let err):
                 print(err)
@@ -116,119 +116,3 @@ class ReviewAPI {
         }
     }
 }
-
-// MARK: - JudgeData
-extension ReviewAPI {
-    
-    /// createReviewPostJudgeData
-    func createReviewPostJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
-        let decoder = JSONDecoder()
-        guard let decodedData = try? decoder.decode(GenericResponse<ReviewPostRegisterData>.self, from: data) else { return .pathErr }
-        
-        switch status {
-        case 200...204:
-            return .success(decodedData.data ?? "None-Data")
-        case 401:
-            return .requestErr(false)
-        case 400, 402...409:
-            return .requestErr(decodedData.message)
-        case 500:
-            return .serverErr
-        default:
-            return .networkFail
-        }
-    }
-    
-    /// getReviewPostListJudgeData
-    func getReviewPostListJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
-        let decoder = JSONDecoder()
-        guard let decodedData = try? decoder.decode(GenericResponse<[ReviewMainPostListData]>.self, from: data) else { return .pathErr }
-        
-        switch status {
-        case 200...204:
-            return .success(decodedData.data ?? "None-Data")
-        case 401:
-            return .requestErr(false)
-        case 400, 402...409:
-            return .requestErr(decodedData.message)
-        case 500:
-            return .serverErr
-        default:
-            return .networkFail
-        }
-    }
-    
-    /// getReviewPostDetailJudgeData
-    func getReviewPostDetailJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
-        let decoder = JSONDecoder()
-        guard let decodedData = try? decoder.decode(GenericResponse<ReviewPostDetailData>.self, from: data) else { return .pathErr }
-        
-        switch status {
-        case 200...204:
-            return .success(decodedData.data ?? "None-Data")
-        case 401:
-            return .requestErr(false)
-        case 400, 402...409:
-            return .requestErr(decodedData.message)
-        case 500:
-            return .serverErr
-        default:
-            return .networkFail
-        }
-    }
-    
-    /// getReviewHomepageJudgeData
-    func getReviewHomepageJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
-        let decoder = JSONDecoder()
-        guard let decodedData = try? decoder.decode(GenericResponse<ReviewHomePageData>.self, from: data) else { return .pathErr }
-        
-        switch status {
-        case 200...204:
-            return .success(decodedData.data ?? "None-Data")
-        case 400...409:
-            return .requestErr(decodedData.message)
-        case 500:
-            return .serverErr
-        default:
-            return .networkFail
-        }
-    }
-    
-    /// deleteReviewPostJudgeData
-    func deleteReviewPostJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
-        let decoder = JSONDecoder()
-        guard let decodedData = try? decoder.decode(GenericResponse<ReviewDeleteResModel>.self, from: data) else { return .pathErr }
-        
-        switch status {
-        case 200...204:
-            return .success(decodedData.data ?? "None-Data")
-        case 401:
-            return .requestErr(false)
-        case 400, 402...409:
-            return .requestErr(decodedData.message)
-        case 500:
-            return .serverErr
-        default:
-            return .networkFail
-        }
-    }
-    
-    /// editReviewPostJudgeData
-    func editReviewPostJudgeData(status: Int, data: Data) -> NetworkResult<Any> {
-        let decoder = JSONDecoder()
-        guard let decodedData = try? decoder.decode(GenericResponse<ReviewEditData>.self, from: data) else { return .pathErr }
-        
-        switch status {
-        case 200...204:
-            return .success(decodedData.data ?? "None-Data")
-        case 401:
-            return .requestErr(false)
-        case 400, 402...409:
-            return .requestErr(decodedData.message)
-        case 500:
-            return .serverErr
-        default:
-            return .networkFail
-        }
-    }
- }

--- a/NadoSunbae-iOS/NadoSunbae.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae.xcodeproj/project.pbxproj
@@ -265,6 +265,7 @@
 		77AEEB4D2789AF900016880B /* TVRegisterable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77AEEB4B2789AF900016880B /* TVRegisterable.swift */; };
 		77AEEB4E2789AF900016880B /* CVRegisterable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77AEEB4C2789AF900016880B /* CVRegisterable.swift */; };
 		77AEEB502789AFAF0016880B /* HalfModalPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77AEEB4F2789AFAF0016880B /* HalfModalPresentationController.swift */; };
+		77BAD54228C8775D006C2733 /* APIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77BAD54128C8775D006C2733 /* APIConstants.swift */; };
 		77ED045027AD75E700D077CA /* FilterVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77ED044E27AD75E700D077CA /* FilterVC.swift */; };
 		77ED045127AD75E700D077CA /* FilterVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 77ED044F27AD75E700D077CA /* FilterVC.xib */; };
 		77ED045327AEBDAF00D077CA /* SendUpdateStatusDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77ED045227AEBDAF00D077CA /* SendUpdateStatusDelegate.swift */; };
@@ -324,7 +325,6 @@
 		C7F3F6D927D3858600E12888 /* AppLinkResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F3F6D827D3858600E12888 /* AppLinkResponseModel.swift */; };
 		C7F3F6DB27D3E38000E12888 /* WithDrawResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F3F6DA27D3E38000E12888 /* WithDrawResponseModel.swift */; };
 		C7F3F6DD27D5192D00E12888 /* ResendSignUpMailResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F3F6DC27D5192D00E12888 /* ResendSignUpMailResponseModel.swift */; };
-		C7F93DA228C58A1200F2B129 /* APIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F93DA128C58A1200F2B129 /* APIConstants.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -584,6 +584,7 @@
 		77AEEB4B2789AF900016880B /* TVRegisterable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TVRegisterable.swift; sourceTree = "<group>"; };
 		77AEEB4C2789AF900016880B /* CVRegisterable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CVRegisterable.swift; sourceTree = "<group>"; };
 		77AEEB4F2789AFAF0016880B /* HalfModalPresentationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HalfModalPresentationController.swift; sourceTree = "<group>"; };
+		77BAD54128C8775D006C2733 /* APIConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConstants.swift; sourceTree = "<group>"; };
 		77ED044E27AD75E700D077CA /* FilterVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterVC.swift; sourceTree = "<group>"; };
 		77ED044F27AD75E700D077CA /* FilterVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FilterVC.xib; sourceTree = "<group>"; };
 		77ED045227AEBDAF00D077CA /* SendUpdateStatusDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendUpdateStatusDelegate.swift; sourceTree = "<group>"; };
@@ -640,7 +641,6 @@
 		C7F3F6D827D3858600E12888 /* AppLinkResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLinkResponseModel.swift; sourceTree = "<group>"; };
 		C7F3F6DA27D3E38000E12888 /* WithDrawResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithDrawResponseModel.swift; sourceTree = "<group>"; };
 		C7F3F6DC27D5192D00E12888 /* ResendSignUpMailResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResendSignUpMailResponseModel.swift; sourceTree = "<group>"; };
-		C7F93DA128C58A1200F2B129 /* APIConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConstants.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -852,7 +852,7 @@
 			isa = PBXGroup;
 			children = (
 				3313644E2785A84B00E0C118 /* NetworkResult.swift */,
-				C7F93DA128C58A1200F2B129 /* APIConstants.swift */,
+				77BAD54128C8775D006C2733 /* APIConstants.swift */,
 			);
 			path = APIEssentials;
 			sourceTree = "<group>";
@@ -2300,7 +2300,6 @@
 				5C9A93F727A64B550097310B /* SignUpBodyModel.swift in Sources */,
 				5C873A4B279978650050EE43 /* SignInDataModel.swift in Sources */,
 				33CF635427945C1200E92C04 /* SendSegmentStateDelegate.swift in Sources */,
-				C7F93DA228C58A1200F2B129 /* APIConstants.swift in Sources */,
 				331364892785D71100E0C118 /* NadoSunbaeTBC.swift in Sources */,
 				777C18D627D7B04C00A5ADEC /* ReviewDetailGrayTVC.swift in Sources */,
 				331364942785D78F00E0C118 /* Identifiers.swift in Sources */,
@@ -2326,6 +2325,7 @@
 				33D4456B287C28AE00D94495 /* CommunityMainVC.swift in Sources */,
 				77ED045027AD75E700D077CA /* FilterVC.swift in Sources */,
 				777ABF7C278C844E002D3214 /* ReviewMainLinkTVC.swift in Sources */,
+				77BAD54228C8775D006C2733 /* APIConstants.swift in Sources */,
 				3313642C2784D3BD00E0C118 /* SceneDelegate.swift in Sources */,
 				5C49669327BD469200983689 /* AutoSignInVC.swift in Sources */,
 				C7ACE63827CBD8450011B23F /* SettingVersionTVC.swift in Sources */,

--- a/NadoSunbae-iOS/NadoSunbae.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae.xcodeproj/project.pbxproj
@@ -266,6 +266,7 @@
 		77AEEB4E2789AF900016880B /* CVRegisterable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77AEEB4C2789AF900016880B /* CVRegisterable.swift */; };
 		77AEEB502789AFAF0016880B /* HalfModalPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77AEEB4F2789AFAF0016880B /* HalfModalPresentationController.swift */; };
 		77BAD54228C8775D006C2733 /* APIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77BAD54128C8775D006C2733 /* APIConstants.swift */; };
+		77BAD54628C87952006C2733 /* BaseAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77BAD54528C87952006C2733 /* BaseAPI.swift */; };
 		77ED045027AD75E700D077CA /* FilterVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77ED044E27AD75E700D077CA /* FilterVC.swift */; };
 		77ED045127AD75E700D077CA /* FilterVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 77ED044F27AD75E700D077CA /* FilterVC.xib */; };
 		77ED045327AEBDAF00D077CA /* SendUpdateStatusDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77ED045227AEBDAF00D077CA /* SendUpdateStatusDelegate.swift */; };
@@ -585,6 +586,7 @@
 		77AEEB4C2789AF900016880B /* CVRegisterable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CVRegisterable.swift; sourceTree = "<group>"; };
 		77AEEB4F2789AFAF0016880B /* HalfModalPresentationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HalfModalPresentationController.swift; sourceTree = "<group>"; };
 		77BAD54128C8775D006C2733 /* APIConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConstants.swift; sourceTree = "<group>"; };
+		77BAD54528C87952006C2733 /* BaseAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseAPI.swift; sourceTree = "<group>"; };
 		77ED044E27AD75E700D077CA /* FilterVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterVC.swift; sourceTree = "<group>"; };
 		77ED044F27AD75E700D077CA /* FilterVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FilterVC.xib; sourceTree = "<group>"; };
 		77ED045227AEBDAF00D077CA /* SendUpdateStatusDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendUpdateStatusDelegate.swift; sourceTree = "<group>"; };
@@ -853,6 +855,7 @@
 			children = (
 				3313644E2785A84B00E0C118 /* NetworkResult.swift */,
 				77BAD54128C8775D006C2733 /* APIConstants.swift */,
+				77BAD54528C87952006C2733 /* BaseAPI.swift */,
 			);
 			path = APIEssentials;
 			sourceTree = "<group>";
@@ -2120,6 +2123,7 @@
 				5CA73379278A8F4900806B17 /* NadoAlertVC.swift in Sources */,
 				33286B7B28A4F813006E6FF0 /* CommunitySearchVC.swift in Sources */,
 				5CC0BFD42798621600B96905 /* NotificationDataModel.swift in Sources */,
+				77BAD54628C87952006C2733 /* BaseAPI.swift in Sources */,
 				33A86798288B0227009BA6DE /* CommunityMainReactor.swift in Sources */,
 				77AEEB442789AF380016880B /* HalfModalVC.swift in Sources */,
 				331364512785A85E00E0C118 /* GenericResponse.swift in Sources */,


### PR DESCRIPTION
## 🍎 관련 이슈
closed #446

## 🍎 변경 사항 및 이유
기존 서버 세팅 파일을 수정했습니다.

## 🍎 PR Point
- ~judgeData() 함수가 API마다 존재하는 것이 비효율적이라고 생각되어 APIEssentials 폴더 아래에 `BaseAPI` 파일을 추가해서 `judgeStatus` 함수를 만들어두었습니다.

### 사용방법
~API 클래스에 `BaseAPI`를 상속받아주세요! 
API 함수에서 서버 통신 성공, 실패 여부로 `.success`, `.failure` 케이스가 나뉘게 되는데요! 
success 케이스로 들어갈 경우, 기존 completion을 통해  ~judgeData 함수로 넘겨서 해주었던 `StatusCode`별 판단 작업을 BaseAPI에 추가해둔 `judgeStatus()`함수를 이용해서 해주고 넘어온 결과를 completion으로 넘기는 형식으로 바꾸어서 중복되는 코드를 하나로 묶어두었습니다.
예시로 `ReviewAPI`파일을 변경해두었으니 참고해주시고 이해가 안가는 부분이 있다면 편하게 물어봐주어도 됩니다!!
**+** 참고로 StatusCode별 분기처리는 바뀐 명세서(스웨거) 및 주현이한테 확인을 받고 수정해두었습니다!

## 📸 ScreenShot
x
