### PR TITLE
✨ [FEAT] 커뮤니티 탭의 게시글 리스트에서 게시글 상세보기로 화면전환 기능을 구현합니다.

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/WritePost/BaseWritePostVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/WritePost/BaseWritePostVC.swift
@@ -1,0 +1,228 @@
+//
+//  BaseWritePostVC.swift
+//  NadoSunbae
+//
+//  Created by hwangJi on 2022/09/30.
+//
+
+import UIKit
+import RxCocoa
+import RxSwift
+
+class BaseWritePostVC: BaseVC {
+
+    // MARK: Properties
+    private let questionSV = UIScrollView()
+    private let disposeBag = DisposeBag()
+    private var questionTextViewLineCount: Int = 1
+    private var majorID: Int = MajorInfo.shared.selectedMajorID ?? UserDefaults.standard.value(forKey: UserDefaults.Keys.FirstMajorID) as! Int
+    
+    let questionWriteNaviBar = NadoSunbaeNaviBar().then {
+        $0.addShadow(location: .nadoBotttom, color: .shadowDefault, opacity: 0.3, radius: 16)
+    }
+    
+    let questionTitleTextField = UITextField().then {
+        $0.borderStyle = .none
+        $0.backgroundColor = .white
+        $0.placeholder = "질문 제목을 입력하세요."
+        $0.textColor = .mainDefault
+        $0.font = .PretendardSB(size: 24.0)
+        $0.autocorrectionType = .no
+    }
+    
+    let textHighlightView = UIView().then {
+        $0.backgroundColor = .gray0
+    }
+    
+    let contentHeaderLabel = UILabel().then {
+        $0.text = "내용"
+        $0.textColor = .black
+        $0.font = .PretendardM(size: 16.0)
+    }
+    
+    let questionWriteTextView = NadoTextView()
+    let contentView = UIView()
+    var confirmAlertMsg: String = ""
+    var dismissAlertMsg: String = ""
+    var isTextViewEmpty: Bool = true
+    
+    // MARK: Life Cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUpInitStyle()
+        configureUI()
+        hideKeyboardWhenTappedAround()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        addKeyboardObserver()
+        hideTabbar()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        removeKeyboardObserver()
+    }
+}
+
+// MARK: - UI
+extension BaseWritePostVC {
+    
+    /// UI 구성하는 메서드
+    private func configureUI() {
+        view.addSubviews([questionWriteNaviBar, questionSV])
+        questionSV.addSubview(contentView)
+        contentView.addSubviews([questionTitleTextField, textHighlightView, contentHeaderLabel, questionWriteTextView])
+        
+        questionWriteNaviBar.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+            $0.height.equalTo(104)
+        }
+        
+        questionSV.snp.makeConstraints {
+            $0.top.equalTo(questionWriteNaviBar.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+        
+        contentView.snp.makeConstraints {
+            $0.width.equalToSuperview()
+            $0.height.equalToSuperview()
+            $0.centerX.top.bottom.equalToSuperview()
+        }
+        
+        questionTitleTextField.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(24)
+            $0.leading.equalToSuperview().offset(24)
+            $0.trailing.equalToSuperview().offset(-24)
+        }
+        
+        textHighlightView.snp.makeConstraints {
+            $0.top.equalTo(questionTitleTextField.snp.bottom).offset(4)
+            $0.leading.trailing.equalTo(questionTitleTextField)
+            $0.height.equalTo(1)
+        }
+        
+        contentHeaderLabel.snp.makeConstraints {
+            $0.top.equalTo(textHighlightView.snp.bottom).offset(72)
+            $0.leading.equalTo(textHighlightView)
+        }
+        
+        questionWriteTextView.snp.makeConstraints {
+            $0.top.equalTo(contentHeaderLabel.snp.bottom).offset(8)
+            $0.leading.trailing.equalTo(questionTitleTextField)
+            $0.bottom.equalTo(contentView.snp.bottom).offset(-102)
+        }
+        
+        setHighlightViewState(textField: questionTitleTextField, highlightView: textHighlightView)
+        setActivateBtnState(textField: questionTitleTextField, textView: questionWriteTextView)
+    }
+}
+
+// MARK: - Custom Method
+extension BaseWritePostVC {
+    
+    /// 컴포넌트의 초기 스타일을 구성하는 메서드
+    private func setUpInitStyle() {
+        questionWriteNaviBar.setUpNaviStyle(state: .dismissWithNadoBtn)
+    }
+    
+    /// textField가 채워져 있는지에 따라 highlightView 상태 변경하는 메서드
+    private func setHighlightViewState(textField: UITextField, highlightView: UIView) {
+        textField.rx.text
+            .orEmpty
+            .distinctUntilChanged()
+            .subscribe(onNext: { [weak self] changedText in
+                if self?.questionTitleTextField.text?.isEmpty == true {
+                    self?.textHighlightView.backgroundColor = .gray0
+                } else {
+                    self?.textHighlightView.backgroundColor = .black
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    /// 제목, 내용이 모두 채워져 있는지에 따라 상단 네비바 버튼 활성화/비활성화 하는 메서드
+    private func setActivateBtnState(textField: UITextField, textView: NadoTextView) {
+        let a = BehaviorSubject<Bool>(value: false)
+        let b = BehaviorSubject<Bool>(value: false)
+        
+        textField.rx.text
+            .orEmpty
+            .distinctUntilChanged()
+            .subscribe(onNext: { changedText in
+                if changedText.isEmpty {
+                    a.onNext(false)
+                } else {
+                    a.onNext(true)
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        textView.rx.text
+            .orEmpty
+            .distinctUntilChanged()
+            .subscribe(onNext: { [weak self] changedText in
+                if changedText.isEmpty || self?.isTextViewEmpty == true {
+                    b.onNext(false)
+                } else {
+                    b.onNext(true)
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        Observable.combineLatest(a, b) {$0 && $1}
+            .bind(to: questionWriteNaviBar.rightActivateBtn.rx.isActivated)
+            .disposed(by: disposeBag)
+    }
+    
+    /// textView의 상태에 따라 스크롤뷰를 Up, Down 하는 메서드
+    func scollByTextViewState(textView: UITextView) {
+        var contentOffsetY = questionSV.contentOffset.y
+        var isLineAdded = true
+        
+        if questionTextViewLineCount != textView.numberOfLines() {
+            
+            if questionTextViewLineCount > textView.numberOfLines() {
+                isLineAdded = false
+            } else {
+                isLineAdded = true
+            }
+            
+            if  isLineAdded && textView.numberOfLines() > 8 && questionSV.contentOffset.y < 243 {
+                contentOffsetY += 38
+                questionSV.setContentOffset(CGPoint(x: 0, y: contentOffsetY), animated: true)
+                
+            } else if !isLineAdded && questionTextViewLineCount < 14 && questionSV.contentOffset.y > 0 {
+                
+                if contentOffsetY - 38 > 0 {
+                    contentOffsetY -= 38
+                    questionSV.setContentOffset(CGPoint(x: 0, y: contentOffsetY), animated: true)
+                } else {
+                    contentOffsetY = 0
+                    questionSV.setContentOffset(CGPoint(x: 0, y: 0), animated: true)
+                }
+            }
+        }
+        questionTextViewLineCount = textView.numberOfLines()
+    }
+}
+
+// MARK: - Keyboard
+extension BaseWritePostVC {
+    
+    /// Keyboard Observer add 메서드
+    private func addKeyboardObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(self.keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    /// Keyboard Observer remove 메서드
+    private func removeKeyboardObserver() {
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    /// keyboardWillHide
+    @objc
+    func keyboardWillHide(notification: Notification) {
+        questionSV.setContentOffset(CGPoint(x: 0, y: 0), animated: true)
+    }
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/PublicAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/PublicAPI.swift
@@ -121,4 +121,22 @@ class PublicAPI: BaseAPI {
             }
         }
     }
+    
+    /// [POST] 게시글 작성
+    func requestWritePost(type: PostFilterType, majorID: Int, answererID: Int, title: String, content: String, completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        publicProvider.request(.requestWritePost(type: type, majorID: majorID, answererID: answererID, title: title, content: content)) { result in
+            switch result {
+                
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                let networkResult = self.judgeStatus(by: statusCode, data, WritePostResModel.self)
+                
+                completion(networkResult)
+                
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Public/PostDetailResModel.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Public/PostDetailResModel.swift
@@ -25,7 +25,7 @@ struct PostDetailResModel: Codable {
     
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
-        post = (try? values.decode(DetailPost.self, forKey: .post)) ?? DetailPost(postDetailID: 0, title: "", content: "", createdAt: "", majorName: "")
+        post = (try? values.decode(DetailPost.self, forKey: .post)) ?? DetailPost(postDetailID: 0, title: "", type: "", content: "", createdAt: "", majorName: "")
         writer = (try? values.decode(PostDetailWriter.self, forKey: .writer)) ?? PostDetailWriter(writerID: 0, isPostWriter: false, profileImageID: 0, nickname: "", firstMajorName: "", firstMajorStart: "", secondMajorName: "", secondMajorStart: "")
         isAuthorized = (try? values.decode(Bool.self, forKey: .isAuthorized)) ?? false
         answererID = (try? values.decode(Int.self, forKey: .answererID)) ?? 0
@@ -67,10 +67,10 @@ struct PostDetailWriter: Codable {
 // MARK: - DetailPost
 struct DetailPost: Codable {
     let postDetailID: Int
-    let title, content, createdAt, majorName: String
+    let title, type, content, createdAt, majorName: String
     
     enum CodingKeys: String, CodingKey {
         case postDetailID = "id"
-        case title, content, createdAt, majorName
+        case title, type, content, createdAt, majorName
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Public/WritePostReqModel.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Public/WritePostReqModel.swift
@@ -1,0 +1,16 @@
+//
+//  WritePostReqModel.swift
+//  NadoSunbae
+//
+//  Created by hwangJi on 2022/09/28.
+//
+
+import Foundation
+
+struct WritePostReqModel {
+    var type: PostFilterType
+    var majorID: Int
+    var answererID: Int
+    var title: String
+    var content: String
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Public/WritePostResModel.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Public/WritePostResModel.swift
@@ -1,0 +1,28 @@
+//
+//  WritePostResModel.swift
+//  NadoSunbae
+//
+//  Created by hwangJi on 2022/09/28.
+//
+
+import Foundation
+
+struct WritePostResModel: Codable {
+    let post: WritePost
+    let writer: RankingListModel
+}
+
+struct WritePost: Codable {
+    let id: Int
+    let type, title, content: String
+    let majorID: Int
+    let createdAt: String
+    let answererID: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case id, type, title, content
+        case majorID = "majorId"
+        case createdAt
+        case answererID = "answererId"
+    }
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Public/WritePostResModel.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Public/WritePostResModel.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct WritePostResModel: Codable {
     let post: WritePost
-    let writer: RankingListModel
+    let writer: HomeRankingResponseModel.UserList
 }
 
 struct WritePost: Codable {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/PublicService.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/PublicService.swift
@@ -92,8 +92,7 @@ extension PublicService: TargetType {
     
     var headers: [String: String]? {
         switch self {
-        case .requestBlockUnBlockUser, .requestReport, .getPostList, .requestWritePost:
-        case .requestBlockUnBlockUser, .requestReport, .getPostList, .getPostDetail:
+        case .requestBlockUnBlockUser, .requestReport, .getPostList, .requestWritePost, .getPostDetail:
             let accessToken = UserToken.shared.accessToken ?? ""
             return ["accessToken": accessToken]
         default:

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/PublicService.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/PublicService.swift
@@ -15,6 +15,7 @@ enum PublicService {
     case getAppLink
     case getPostList(univID: Int, majorID: Int, filter: PostFilterType, sort: String, search: String)
     case getPostDetail(postID: Int)
+    case requestWritePost(type: PostFilterType, majorID: Int, answererID: Int, title: String, content: String)
 }
 
 extension PublicService: TargetType {
@@ -37,6 +38,8 @@ extension PublicService: TargetType {
             return "/post/university/\(univID)"
         case .getPostDetail(let postID):
             return "/post/\(postID)"
+        case .requestWritePost:
+            return "/post"
         }
     }
     
@@ -44,7 +47,7 @@ extension PublicService: TargetType {
         switch self {
         case .getMajorList, .getAppLink, .getPostList, .getPostDetail:
             return .get
-        case .requestBlockUnBlockUser, .requestReport:
+        case .requestBlockUnBlockUser, .requestReport, .requestWritePost:
             return .post
         }
     }
@@ -75,11 +78,21 @@ extension PublicService: TargetType {
             return .requestParameters(parameters: query, encoding:  URLEncoding.queryString)
         case .getPostDetail:
             return .requestPlain
+        case .requestWritePost(let type, let majorID, let answererID, let title, let content):
+            let body: [String: Any] = [
+                "type": "\(type)",
+                "majorId": majorID,
+                "answererId": answererID,
+                "title": title,
+                "content": content
+            ]
+            return .requestParameters(parameters: body, encoding: JSONEncoding.prettyPrinted)
         }
     }
     
     var headers: [String: String]? {
         switch self {
+        case .requestBlockUnBlockUser, .requestReport, .getPostList, .requestWritePost:
         case .requestBlockUnBlockUser, .requestReport, .getPostList, .getPostDetail:
             let accessToken = UserToken.shared.accessToken ?? ""
             return ["accessToken": accessToken]

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -321,7 +321,6 @@ extension DefaultQuestionChatVC {
                 goToQuestionfloatingBtn.press { [weak self] in
                     guard let self = self else { return }
                     self.navigator?.instantiateVC(destinationViewControllerType: WriteQuestionVC.self, useStoryboard: true, storyboardName: Identifiers.WriteQusetionSB, naviType: .present, modalPresentationStyle: .fullScreen) { writeQuestionVC in
-                        writeQuestionVC.questionType = .questionToPerson
                     }
                 }
             } else {
@@ -381,7 +380,6 @@ extension DefaultQuestionChatVC {
                     /// 수정
                     /// 질문 원글일 경우
                     self.navigator?.instantiateVC(destinationViewControllerType: WriteQuestionVC.self, useStoryboard: true, storyboardName: Identifiers.WriteQusetionSB, naviType: .present, modalPresentationStyle: .fullScreen) { [weak self] writeQuestionVC in
-                        writeQuestionVC.questionType = .questionToPerson
                         writeQuestionVC.isEditState = true
                         writeQuestionVC.postID = self?.postID
                         writeQuestionVC.originTitle = self?.questionData?.title
@@ -423,7 +421,6 @@ extension DefaultQuestionChatVC {
                             /// 수정
                             /// 질문 원글일 경우
                             self.navigator?.instantiateVC(destinationViewControllerType: WriteQuestionVC.self, useStoryboard: true, storyboardName: Identifiers.WriteQusetionSB, naviType: .present, modalPresentationStyle: .fullScreen) { [weak self] writeQuestionVC in
-                                writeQuestionVC.questionType = .questionToPerson
                                 writeQuestionVC.isEditState = true
                                 writeQuestionVC.postID = self?.postID
                                 writeQuestionVC.originTitle = self?.questionData?.title

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -321,10 +321,9 @@ extension DefaultQuestionChatVC {
                 goToQuestionfloatingBtn.press { [weak self] in
                     guard let self = self else { return }
                     self.navigator?.instantiateVC(destinationViewControllerType: WriteQuestionVC.self, useStoryboard: true, storyboardName: Identifiers.WriteQusetionSB, naviType: .present, modalPresentationStyle: .fullScreen) { writeQuestionVC in
+                        writeQuestionVC.answererID = self.answererID
                     }
                 }
-            } else {
-                
             }
         }
     }
@@ -802,6 +801,7 @@ extension DefaultQuestionChatVC {
                     self.questionData = data.post
                     self.commentData = data.commentList
                     self.questionLikeData = data.like
+                    self.answererID = data.answererID
                     self.questionerData = data.writer
                     self.userType = self.identifyUserType(questionerID: data.writer.writerID, isAuthorized: data.isAuthorized)
                     self.setUpSendBtnEnabledState(textView: self.sendAreaTextView ?? UITextView())

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -694,7 +694,7 @@ extension DefaultQuestionChatVC: UITableViewDataSource {
             if let questionData = questionData {
                 questionCell.bindQuestionData(questionData)
             } else {
-                questionCell.bindQuestionData(DetailPost(postDetailID: 0, title: "", content: "", createdAt: "", majorName: ""))
+                questionCell.bindQuestionData(DetailPost(postDetailID: 0, title: "", type: "", content: "", createdAt: "", majorName: ""))
             }
             configureDeletedQuestionCell(indexPath, questionCell)
             configureQuestionCell(indexPath: indexPath, questionCell: questionCell)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
@@ -57,60 +57,6 @@ extension WriteQuestionVC {
         questionWriteTextView.delegate = self
     }
     
-    /// textField가 채워져 있는지에 따라 highlightView 상태 변경하는 메서드
-    private func setHighlightViewState(textField: UITextField, highlightView: UIView) {
-        textField.rx.text
-            .orEmpty
-            .distinctUntilChanged()
-            .subscribe(onNext: { [weak self] changedText in
-                if self?.questionTitleTextField.text?.isEmpty == true {
-                    self?.textHighlightView.backgroundColor = .gray0
-                } else {
-                    self?.textHighlightView.backgroundColor = .black
-                }
-            })
-            .disposed(by: disposeBag)
-    }
-    
-    /// 제목, 내용이 모두 채워져 있는지에 따라 상단 네비바 버튼 활성화/비활성화 하는 메서드
-    private func setActivateBtnState(textField: UITextField, textView: NadoTextView) {
-        let a = BehaviorSubject<Bool>(value: false)
-        let b = BehaviorSubject<Bool>(value: false)
-        
-        textField.rx.text
-            .orEmpty
-            .distinctUntilChanged()
-            .subscribe(onNext: { changedText in
-                if changedText.isEmpty {
-                    a.onNext(false)
-                } else {
-                    a.onNext(true)
-                }
-            })
-            .disposed(by: disposeBag)
-        
-        textView.rx.text
-            .orEmpty
-            .distinctUntilChanged()
-            .subscribe(onNext: { [weak self] changedText in
-                if changedText.isEmpty || self?.isTextViewEmpty == true {
-                    b.onNext(false)
-                } else {
-                    b.onNext(true)
-                }
-            })
-            .disposed(by: disposeBag)
-        
-        Observable.combineLatest(a, b) {$0 && $1}
-            .bind(to: questionWriteNaviBar.rightActivateBtn.rx.isActivated)
-            .disposed(by: disposeBag)
-        
-        /// 수정상태일 때 (title, content가 있는 상황이므로) 첫 진입상태를 isActivate로 하기 위한 분기처리
-        if isEditState {
-            questionWriteNaviBar.rightActivateBtn.isActivated = true
-        }
-    }
-    
     /// btn Action set 메서드
     private func setTapBtnAction() {
         

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/Cell/TVC/PostDetail/InfoCommentTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/Cell/TVC/PostDetail/InfoCommentTVC.swift
@@ -62,7 +62,7 @@ class InfoCommentTVC: BaseTVC {
 extension InfoCommentTVC {
     
     /// 데이터 바인딩하는 메서드
-    func bindData(model: InfoDetailCommentList) {
+    func bindData(model: CommentList) {
         profileImgView.image = UIImage(named: "profileImage\(model.writer.profileImageID)")
         nicknameLabel.text = model.writer.nickname
         writerImgView.isHidden = !(model.writer.isPostWriter ?? false)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/Cell/TVC/PostDetail/InfoQuestionTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/Cell/TVC/PostDetail/InfoQuestionTVC.swift
@@ -73,7 +73,7 @@ class InfoQuestionTVC: BaseTVC {
 extension InfoQuestionTVC {
     
     /// 데이터 바인딩하는 메서드
-    func bindData(_ model: InfoDetailDataModel) {
+    func bindData(_ model: PostDetailResModel) {
         infoTitleLabel.text = model.post.title
         nicknameLabel.text = model.writer.nickname
         majorInfoLabel.text = convertToMajorInfoString(model.writer.firstMajorName, model.writer.firstMajorStart, model.writer.secondMajorName, model.writer.secondMajorStart)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityMainVC.swift
@@ -59,6 +59,7 @@ final class CommunityMainVC: BaseVC, View {
         registerCell()
         setUpDelegate()
         setUpInitAction()
+        bindCommunityTV()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -176,6 +177,18 @@ extension CommunityMainVC {
     
     private func setUpInitAction() {
         reactor?.action.onNext(.reloadCommunityTV(majorID: 0, type: .community, sort: "recent", search: ""))
+    }
+    
+    /// CommunityTV를 bind하는 메서드
+    private func bindCommunityTV() {
+        communityTV.rx.modelSelected(PostListResModel.self)
+            .subscribe(onNext: { item in
+                self.navigator?.instantiateVC(destinationViewControllerType: CommunityPostDetailVC.self, useStoryboard: true, storyboardName: "CommunityPostDetailSB", naviType: .push) { postDetailVC in
+                    postDetailVC.postID = item.postID
+                    postDetailVC.hidesBottomBarWhenPushed = true
+                }
+            })
+            .disposed(by: disposeBag)
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityMainVC.swift
@@ -106,10 +106,11 @@ extension CommunityMainVC {
             .disposed(by: disposeBag)
         
         writeFloatingBtn.rx.tap
-            .map {
-                print("플로팅 버튼 클릭")
-                return CommunityMainReactor.Action.witeFloatingBtnDidTap }
-            .bind(to: reactor.action)
+            .subscribe(onNext: {
+                self.navigator?.instantiateVC(destinationViewControllerType: CommunityWriteVC.self, useStoryboard: false, storyboardName: "", naviType: .present, modalPresentationStyle: .fullScreen) { communityWriteVC in
+                    communityWriteVC.reactor = CommunityWriteReactor()
+                }
+            })
             .disposed(by: disposeBag)
         
         filterBtn.rx.tap

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityPostDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityPostDetailVC.swift
@@ -49,9 +49,8 @@ class CommunityPostDetailVC: BaseVC {
     // MARK: Properties
     var postID: Int?
     var userID: Int?
-    var questionerID: Int?
-    private var infoDetailData: InfoDetailDataModel?
-    private var infoDetailCommentData: [InfoDetailCommentList] = []
+    private var infoDetailData: PostDetailResModel?
+    private var infoDetailCommentData: [CommentList] = []
     private var infoDetailLikeData: Like?
     private var qnaType: QnAType?
     private var isCommentSend: Bool = false
@@ -71,7 +70,6 @@ class CommunityPostDetailVC: BaseVC {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        hideTabbar()
         addKeyboardObserver()
         optionalBindingData()
         makeScreenAnalyticsEvent(screenName: "ClassRoom_Info Tab", screenClass: CommunityPostDetailVC.className)
@@ -146,7 +144,7 @@ extension CommunityPostDetailVC {
             } else {
                 self.makeAlertWithCancel(okTitle: "신고", okAction: { _ in
                     self.reportActionSheet(completion: { reason in
-                        self.requestReport(reportedTargetID: self.infoDetailData?.post.postID ?? 0, reportedTargetTypeID: 2, reason: reason)
+                        self.requestReport(reportedTargetID: self.infoDetailData?.post.postDetailID ?? 0, reportedTargetTypeID: 2, reason: reason)
                     })
                 })
             }
@@ -272,10 +270,11 @@ extension CommunityPostDetailVC: UITableViewDataSource {
         /// 정보글 원글 Cell
         if indexPath.row == 0 {
             infoQuestionCell.separatorInset = UIEdgeInsets(top: 0, left: CGFloat.greatestFiniteMagnitude, bottom: 0, right: 0)
-            infoQuestionCell.bindData(infoDetailData ?? InfoDetailDataModel(post: InfoDetailPost(postID: 0, title: "", content: "", createdAt: ""), writer: InfoDetailWriter(writerID: 0, profileImageID: 0, nickname: "", firstMajorName: "", firstMajorStart: "", secondMajorName: "", secondMajorStart: "", isPostWriter: false), like: Like(isLiked: false, likeCount: 0), commentCount: 0, commentList: []))
+            if let infoDetailData = infoDetailData {
+                infoQuestionCell.bindData(infoDetailData)
+            }
             
-            // TODO: 서버 명세서 나오면 상황에 맞춰 변경하기
-            infoQuestionCell.setInfoTypeTitle("정보")
+            infoQuestionCell.setInfoTypeTitle(infoDetailData?.post.type ?? "")
             
             infoQuestionCell.tapLikeBtnAction = { [weak self] in
                 self?.requestPostLikeData(postID: self?.postID ?? 0, postTypeID: .info)
@@ -424,17 +423,16 @@ extension CommunityPostDetailVC {
     private func requestGetDetailInfoData(postID: Int, addLoadBackView: Bool) {
         addLoadBackView ? self.configureWhiteBackView() : nil
         self.activityIndicator.startAnimating()
-        ClassroomAPI.shared.getInfoDetailAPI(postID: postID) { networkResult in
+        PublicAPI.shared.getPostDetail(postID: postID) { [weak self] networkResult in
+            guard let self = self else { return }
             switch networkResult {
             case .success(let res):
-                if let data = res as? InfoDetailDataModel {
+                if let data = res as? PostDetailResModel {
                     self.infoDetailData = data
                     self.infoDetailCommentData = data.commentList
                     self.userID = UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID)
                     self.isWriter = (self.userID == self.infoDetailData?.writer.writerID) ? true : false
-                    
-                    // TODO: 서버 명세서 나오면 상황에 맞춰 변경하기
-                    self.setUpNaviSubTitle(major: "국어국문학과")
+                    self.setUpNaviSubTitle(major: data.post.majorName)
                     
                     DispatchQueue.main.async {
                         self.infoDetailTV.reloadData()

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunitySearchVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunitySearchVC.swift
@@ -62,6 +62,7 @@ final class CommunitySearchVC: BaseVC, View {
         setUpDelegate()
         configureUI()
         registerCell()
+        bindSearchTV()
     }
     
     func bind(reactor: CommunitySearchReactor) {
@@ -133,6 +134,17 @@ extension CommunitySearchVC {
                 } else {
                     self.activityIndicator.stopAnimating()
                     self.setUpHiddenState(searchTV: false, representStackView: false)
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    /// searchTV를 bind하는 메서드
+    private func bindSearchTV() {
+        searchTV.rx.modelSelected(PostListResModel.self)
+            .subscribe(onNext: { item in
+                self.navigator?.instantiateVC(destinationViewControllerType: CommunityPostDetailVC.self, useStoryboard: true, storyboardName: "CommunityPostDetailSB", naviType: .push) { postDetailVC in
+                    postDetailVC.postID = item.postID
                 }
             })
             .disposed(by: disposeBag)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityWriteVC.swift
@@ -7,8 +7,9 @@
 
 import UIKit
 import ReactorKit
+import RxCocoa
 
-final class CommunityWriteVC: WriteQuestionVC, View {
+final class CommunityWriteVC: BaseWritePostVC, View {
     
     // MARK: Components
     private let selectMajorLabel = UILabel().then {
@@ -39,7 +40,15 @@ final class CommunityWriteVC: WriteQuestionVC, View {
         $0.backgroundColor = .gray0
     }
     
+    private var selectedCategory: PostFilterType = .general
+    
+    private let nadoAlert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: CommunityWriteVC.self, options: nil)?.first as? NadoAlertVC
+    
     var disposeBag = DisposeBag()
+    var isEditState: Bool = false
+    var postID: Int?
+    var originTitle: String?
+    var originContent: String?
     
     // MARK: Life Cycle
     override func viewDidLoad() {
@@ -49,6 +58,8 @@ final class CommunityWriteVC: WriteQuestionVC, View {
         configureLabel()
         setUpInitAction()
         registerCell()
+        setUpInitStyle()
+        setUpAlertMsgByEditState()
     }
     
     func bind(reactor: CommunityWriteReactor) {
@@ -128,8 +139,30 @@ extension CommunityWriteVC {
     // MARK: Action
     private func bindAction(_ reactor: CommunityWriteReactor) {
         majorSelectBtn.rx.tap
-            .map { CommunityWriteReactor.Action.majorSelectBtnDidTap }
+            .map { CommunityWriteReactor.Action.tapMajorSelectBtn }
             .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        questionWriteNaviBar.rightActivateBtn.rx.tap
+            .subscribe(onNext: {
+                self.nadoAlert?.showNadoAlert(vc: self, message: self.confirmAlertMsg, confirmBtnTitle: "네", cancelBtnTitle: "아니요")
+            })
+            .disposed(by: disposeBag)
+        
+        nadoAlert?.confirmBtn.rx.tap.map{ CommunityWriteReactor.Action.tapQuestionWriteBtn(type: self.selectedCategory, majorID: 1, answererID: 0, title: self.questionTitleTextField.text ?? "", content: self.questionWriteTextView.text) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        questionWriteNaviBar.dismissBtn.rx.tap
+            .subscribe(onNext: {
+                self.nadoAlert?.showNadoAlert(vc: self, message: self.dismissAlertMsg, confirmBtnTitle: "계속 작성", cancelBtnTitle: "나갈래요")
+            })
+            .disposed(by: disposeBag)
+        
+        nadoAlert?.cancelBtn.rx.tap
+            .subscribe(onNext: {
+                self.dismiss(animated: true, completion: nil)
+            })
             .disposed(by: disposeBag)
     }
     
@@ -156,6 +189,15 @@ extension CommunityWriteVC {
                 return categoryCell
             }
             .disposed(by: disposeBag)
+        
+        reactor.state
+            .map{ $0.writePostSuccess }
+            .subscribe(onNext: { success in
+                if success {
+                    self.dismiss(animated: true, completion: nil)
+                }
+            })
+            .disposed(by: disposeBag)
     }
 }
 
@@ -171,12 +213,48 @@ extension CommunityWriteVC {
     private func setUpDelegate() {
         categoryCV.rx.setDelegate(self)
             .disposed(by: disposeBag)
+        questionWriteTextView.delegate = self
     }
     
     /// 초기 Action 설정 메서드
     private func setUpInitAction() {
         reactor?.action.onNext(.loadCategoryData)
         categoryCV.selectItem(at: [0, 0], animated: false, scrollPosition: .top)
+    }
+    
+    /// 컴포넌트의 초기 스타일을 구성하는 메서드
+    private func setUpInitStyle() {
+        if isEditState {
+            self.makeScreenAnalyticsEvent(screenName: "Community Tab", screenClass: "CommunityWriteVC+Edit")
+            isTextViewEmpty = false
+            questionWriteTextView.setDefaultStyle(isUsePlaceholder: false, placeholderText: "")
+            questionTitleTextField.text = originTitle
+            questionWriteTextView.text = originContent
+            questionWriteNaviBar.rightActivateBtn.isActivated = true
+        } else {
+            questionTitleTextField.placeholder = "제목을 입력하세요."
+            questionWriteTextView.setDefaultStyle(isUsePlaceholder: true, placeholderText: "내용을 입력하세요.")
+        }
+        
+        questionWriteNaviBar.configureTitleLabel(title: "게시글 작성")
+    }
+    
+    /// 수정상태인지 아닌지에 따라 Alert Message를 지정하는 메서드
+    private func setUpAlertMsgByEditState() {
+        confirmAlertMsg =
+        """
+        글을 올리시겠습니까?
+        """
+        dismissAlertMsg = isEditState ?
+        """
+        페이지를 나가면
+        수정한 내용이 저장되지 않아요.
+        """
+        :
+        """
+        페이지를 나가면
+        작성중인 글이 삭제돼요.
+        """
     }
 }
 
@@ -186,5 +264,50 @@ extension CommunityWriteVC: UICollectionViewDelegateFlowLayout {
     /// sizeForItemAt
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return CGSize(width: 61.adjusted, height: 32.adjustedH)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        switch indexPath.row {
+        case 0:
+            selectedCategory = .general
+        case 1:
+            selectedCategory = .questionToEveryone
+        default:
+            selectedCategory = .information
+        }
+    }
+}
+
+// MARK: - UITextFieldDelegate
+extension CommunityWriteVC: UITextViewDelegate {
+    
+    /// scrollViewDidScroll
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        DispatchQueue.main.async() {
+            scrollView.scrollIndicators.vertical?.backgroundColor = .scrollMint
+        }
+    }
+    
+    /// textViewDidBeginEditing
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.textColor == .gray2 {
+            textView.text = nil
+            textView.textColor = .mainText
+        }
+    }
+    
+    /// textViewDidChange
+    func textViewDidChange(_ textView: UITextView) {
+        isTextViewEmpty = false
+        scollByTextViewState(textView: textView)
+    }
+    
+    /// textViewDidEndEditing
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.isEmpty {
+            textView.text = "내용을 입력하세요."
+            textView.textColor = .gray2
+            isTextViewEmpty = true
+        }
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC.swift
@@ -79,8 +79,7 @@ class MypageUserVC: BaseVC {
             guard let self = self else { return }
             if self.userInfo.isOnQuestion == true {
                 self.navigator?.instantiateVC(destinationViewControllerType: WriteQuestionVC.self, useStoryboard: true, storyboardName: Identifiers.WriteQusetionSB, naviType: .present, modalPresentationStyle: .fullScreen) { writeQuestionVC in
-                    writeQuestionVC.questionType = .questionToPerson
-                    writeQuestionVC.answerID = self.userInfo.userID
+                    writeQuestionVC.answererID = self.userInfo.userID
                 }
             }
         }

--- a/NadoSunbae-iOS/NadoSunbae.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		330ADB0828E353F80099E8D7 /* WritePostReqModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 330ADB0728E353F80099E8D7 /* WritePostReqModel.swift */; };
+		330ADB0A28E358190099E8D7 /* WritePostResModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 330ADB0928E358190099E8D7 /* WritePostResModel.swift */; };
 		330DA4332790BCCC00FE127F /* NadoTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 330DA4322790BCCC00FE127F /* NadoTextView.swift */; };
 		330DA4352790C3E300FE127F /* UIScrollView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 330DA4342790C3E300FE127F /* UIScrollView+.swift */; };
 		3313642A2784D3BD00E0C118 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331364292784D3BD00E0C118 /* AppDelegate.swift */; };
@@ -340,6 +342,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		330ADB0728E353F80099E8D7 /* WritePostReqModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WritePostReqModel.swift; sourceTree = "<group>"; };
+		330ADB0928E358190099E8D7 /* WritePostResModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WritePostResModel.swift; sourceTree = "<group>"; };
 		330DA4322790BCCC00FE127F /* NadoTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NadoTextView.swift; sourceTree = "<group>"; };
 		330DA4342790C3E300FE127F /* UIScrollView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+.swift"; sourceTree = "<group>"; };
 		331364262784D3BD00E0C118 /* NadoSunbae.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NadoSunbae.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1780,6 +1784,8 @@
 				C7F3F6D827D3858600E12888 /* AppLinkResponseModel.swift */,
 				33BD384228C9AC73005528DD /* PostListResModel.swift */,
 				33EDB53F28CFD3660086BE3F /* PostDetailResModel.swift */,
+				330ADB0728E353F80099E8D7 /* WritePostReqModel.swift */,
+				330ADB0928E358190099E8D7 /* WritePostResModel.swift */,
 			);
 			path = Public;
 			sourceTree = "<group>";
@@ -2277,6 +2283,7 @@
 				77A049F627BD647900D09C69 /* ReviewDeleteResModel.swift in Sources */,
 				331364AE2785DC1900E0C118 /* ViewControllerFactory.swift in Sources */,
 				33CF636827955D9500E92C04 /* ClassroomNC.swift in Sources */,
+				330ADB0828E353F80099E8D7 /* WritePostReqModel.swift in Sources */,
 				33F3ED8827C54E9F00731E24 /* EditPostQuestionModel.swift in Sources */,
 				33BE2D4727897DD1000FB6C8 /* NadoSunbaeNaviBar.swift in Sources */,
 				C790A273289D6B5D00A67135 /* HomeBannerTVC.swift in Sources */,
@@ -2343,6 +2350,7 @@
 				775728A127D652A700148C9A /* FirstOnboardingCVC.swift in Sources */,
 				C71BF22727CCB68B0030DCB9 /* GetBlockListResponseModel.swift in Sources */,
 				777ABF74278C7947002D3214 /* ReviewMainImgTVC.swift in Sources */,
+				330ADB0A28E358190099E8D7 /* WritePostResModel.swift in Sources */,
 				77AEEB4D2789AF900016880B /* TVRegisterable.swift in Sources */,
 				C7ACE63D27CBEAB70011B23F /* GetLatestVersionResponseModel.swift in Sources */,
 				779DC5A128DB7A51009B9A43 /* RankingReactor.swift in Sources */,

--- a/NadoSunbae-iOS/NadoSunbae.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae.xcodeproj/project.pbxproj
@@ -144,6 +144,9 @@
 		33EAD1F127C68D09000AD673 /* EditPostCommentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EAD1F027C68D09000AD673 /* EditPostCommentModel.swift */; };
 		33EDB54028CFD3660086BE3F /* PostDetailResModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EDB53F28CFD3660086BE3F /* PostDetailResModel.swift */; };
 		33F3ED8827C54E9F00731E24 /* EditPostQuestionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F3ED8727C54E9F00731E24 /* EditPostQuestionModel.swift */; };
+		33F507FF28E723E60037D632 /* WritePostResModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F507FD28E723E60037D632 /* WritePostResModel.swift */; };
+		33F5080028E723E60037D632 /* WritePostReqModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F507FE28E723E60037D632 /* WritePostReqModel.swift */; };
+		33F5080328E737E10037D632 /* BaseWritePostVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F5080228E737E10037D632 /* BaseWritePostVC.swift */; };
 		33FA593E288D6B6700BC7C32 /* CommunityWriteVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33FA593D288D6B6700BC7C32 /* CommunityWriteVC.swift */; };
 		33FA5940288D72F800BC7C32 /* CommunityWriteReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33FA593F288D72F800BC7C32 /* CommunityWriteReactor.swift */; };
 		33FA5943288DCA7600BC7C32 /* CommunityWriteCategoryCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33FA5942288DCA7600BC7C32 /* CommunityWriteCategoryCVC.swift */; };
@@ -471,6 +474,9 @@
 		33EDB53F28CFD3660086BE3F /* PostDetailResModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailResModel.swift; sourceTree = "<group>"; };
 		33F02A8A278889650078F9B7 /* NadoSunbaeBtn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NadoSunbaeBtn.swift; sourceTree = "<group>"; };
 		33F3ED8727C54E9F00731E24 /* EditPostQuestionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPostQuestionModel.swift; sourceTree = "<group>"; };
+		33F507FD28E723E60037D632 /* WritePostResModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WritePostResModel.swift; sourceTree = "<group>"; };
+		33F507FE28E723E60037D632 /* WritePostReqModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WritePostReqModel.swift; sourceTree = "<group>"; };
+		33F5080228E737E10037D632 /* BaseWritePostVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseWritePostVC.swift; sourceTree = "<group>"; };
 		33FA593D288D6B6700BC7C32 /* CommunityWriteVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityWriteVC.swift; sourceTree = "<group>"; };
 		33FA593F288D72F800BC7C32 /* CommunityWriteReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityWriteReactor.swift; sourceTree = "<group>"; };
 		33FA5942288DCA7600BC7C32 /* CommunityWriteCategoryCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityWriteCategoryCVC.swift; sourceTree = "<group>"; };
@@ -773,6 +779,7 @@
 		331364412785A4B400E0C118 /* Class */ = {
 			isa = PBXGroup;
 			children = (
+				33F5080128E737C60037D632 /* WritePost */,
 				331364632785ADFE00E0C118 /* BaseVC.swift */,
 				33BE2D48278982E0000FB6C8 /* BaseNC.swift */,
 				3385636F278DC74D003C60A6 /* BaseTVC.swift */,
@@ -1349,6 +1356,14 @@
 			path = Class;
 			sourceTree = "<group>";
 		};
+		33F5080128E737C60037D632 /* WritePost */ = {
+			isa = PBXGroup;
+			children = (
+				33F5080228E737E10037D632 /* BaseWritePostVC.swift */,
+			);
+			path = WritePost;
+			sourceTree = "<group>";
+		};
 		33FA5941288DCA5100BC7C32 /* CVC */ = {
 			isa = PBXGroup;
 			children = (
@@ -1375,7 +1390,6 @@
 			children = (
 				5C3280132796E5A800781EBE /* MypageUserInfoModel.swift */,
 				775BAFD627D9353700DB37EB /* UserAuthInfo.swift */,
-				33B2010128B8CA1500F9AE3B /* APIConstants.swift */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -1755,6 +1769,8 @@
 		77A7593427987E9E00A8E48B /* Public */ = {
 			isa = PBXGroup;
 			children = (
+				33F507FE28E723E60037D632 /* WritePostReqModel.swift */,
+				33F507FD28E723E60037D632 /* WritePostResModel.swift */,
 				5C328020279741C200781EBE /* QuestionOrInfoListModel.swift */,
 				77A7591F2797645E00A8E48B /* WriterData.swift */,
 				77A759252797FDEA00A8E48B /* MajorListData.swift */,
@@ -2200,6 +2216,7 @@
 				5C32801C2797292B00781EBE /* MypageAPI.swift in Sources */,
 				775728A927D6593700148C9A /* ThirdOnboardingCVC.swift in Sources */,
 				5CF0EC2C279317FA00AF63E4 /* MypageUserVC+TV.swift in Sources */,
+				33F5080028E723E60037D632 /* WritePostReqModel.swift in Sources */,
 				336216B328D2014C00FEA3E9 /* RecentQuestionTVC.swift in Sources */,
 				77ED045327AEBDAF00D077CA /* SendUpdateStatusDelegate.swift in Sources */,
 				5C54CECF278DF6190054136D /* SignUpCompleteVC.swift in Sources */,
@@ -2226,6 +2243,7 @@
 				C75926AD27D7CB72006ECD9E /* AppVersion.swift in Sources */,
 				77A759222797649A00A8E48B /* LikeData.swift in Sources */,
 				77AA830B28A8AB1F00985B80 /* ClassroomMainSection.swift in Sources */,
+				33F5080328E737E10037D632 /* BaseWritePostVC.swift in Sources */,
 				331364C12786217400E0C118 /* ReviewService.swift in Sources */,
 				C7362E9328D9D46800C90DC6 /* HomeAPI.swift in Sources */,
 				5CAB3F2A278AE3C200025DA5 /* AgreeTermsVC.swift in Sources */,
@@ -2286,6 +2304,7 @@
 				331364BD27861CD300E0C118 /* UITextView+.swift in Sources */,
 				5C0606AD27C3F662000941DA /* MypageMyReviewModel.swift in Sources */,
 				33C79DCF2881B28900B6C32C /* CommunityTVC.swift in Sources */,
+				33F507FF28E723E60037D632 /* WritePostResModel.swift in Sources */,
 				33A666A527BB958800779351 /* ReviewImgModel.swift in Sources */,
 				33834A1527D5F66E001C4947 /* MypageLikePostType.swift in Sources */,
 				779DC59828D84DA0009B9A43 /* RankingTVC.swift in Sources */,


### PR DESCRIPTION
## 🍎 관련 이슈
closed #481

## 🍎 변경 사항 및 이유
- PostDetailResModel에 빠진 변수가 있어 추가했습니다(type).

## 🍎 PR Point
- 커뮤니티 메인, 검색뷰와 게시글 상세보기뷰를 연결하였습니다.
- 과방쪽 화면전환 기능은 과방 메인 리펙토링 작업 이후 진행할 예정입니다.
- 이전 브랜치가 머지되지 않아서 이전 브랜치에서 브랜치를 따서 작업을 했더니 커밋이 같이 반영되었습니다. 따라서 8ee76d8b920c746cd1048a1ac65d8952ca2f1445 부터 bcd7bc37800a553f3ea933d94ff33e9be5f673a4 까지 봐주시면 됩니당!

## 📸 ScreenShot
https://user-images.githubusercontent.com/63224278/193342151-0a05e89e-ffb1-426e-a550-28f501cbdb8e.mp4

https://user-images.githubusercontent.com/63224278/193342244-523bf186-2091-4423-a927-ff8712b13813.mp4

