### PR TITLE
♻️ [REFACTOR] NadoSegmentedContol 공용 컴포넌트 UI 구현부를 리펙토링합니다.

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/UIColor+.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/UIColor+.swift
@@ -97,14 +97,8 @@ extension UIColor {
         return UIColor(red: 239.0 / 255.0, green: 246.0 / 255.0, blue: 246.0 / 255.0, alpha: 1.0)
     }
     
-    // 💡 과방탭에서 사용되는 segment Bg Color
-    @nonobjc class var segmentDarkBgColor: UIColor {
+    @nonobjc class var segmentBgColor: UIColor {
         return UIColor(red: 242.0 / 255.0, green: 241.0 / 255.0, blue: 248.0 / 255.0, alpha: 1.0)
-    }
-    
-    // 💡 커뮤니티탭에서 사용되는 segment Bg Color
-    @nonobjc class var segmentLightBgColor: UIColor {
-        return UIColor(red: 245.0 / 255.0, green: 244.0 / 255.0, blue: 252.0 / 255.0, alpha: 1.0)
     }
     
     @nonobjc class var dropShadowColor: UIColor {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Class/NadoSegmentedControl.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Class/NadoSegmentedControl.swift
@@ -38,10 +38,7 @@ final class NadoSegmentedControl: UISegmentedControl {
     override func layoutSubviews() {
         super.layoutSubviews()
         configureSelectedSegmentStyle(index: numberOfSegments)
-        
-        for i in 0...(numberOfSegments - 1)  {
-            subviews[i].isHidden = true
-        }
+        hideWhiteImageSubviews()
     }
 }
 
@@ -121,5 +118,12 @@ extension NadoSegmentedControl {
             insertSegment(withTitle: items[i], at: i, animated: false)
         }
         selectedSegmentIndex = 0
+    }
+    
+    /// Segment의 배경색을 탁하게 만드는 원인인 subview들을 숨김
+    private func hideWhiteImageSubviews() {
+        for i in 0..<numberOfSegments {
+            subviews[i].isHidden = true
+        }
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Class/NadoSegmentedControl.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Class/NadoSegmentedControl.swift
@@ -17,17 +17,10 @@ import Then
  
  - Note:
  - setBackgroundColor: SegmentControl Background 색 변경
- - setUpNadoSegmentFrame: NadoSegmentedControl의 Frame을 통해 HighlightView Frame을 설정
  - setSegmentItems: Segment가 될 Item들 설정 [String]
  */
 
 final class NadoSegmentedControl: UISegmentedControl {
-    
-    // MARK: Properties
-    private lazy var highlightView = UIView().then {
-        $0.backgroundColor = .white
-        $0.makeRounded(cornerRadius: 6)
-    }
     
     // MARK: init
     init(items: [String]) {
@@ -39,20 +32,16 @@ final class NadoSegmentedControl: UISegmentedControl {
     required init(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)!
         configureDefaultStyle()
-        setUpNadoSegmentFrame()
     }
     
     // MARK: layoutSubViews
     override func layoutSubviews() {
         super.layoutSubviews()
+        configureSelectedSegmentStyle(index: numberOfSegments)
         
-        let finalXPosition = (self.bounds.width / CGFloat(self.numberOfSegments)) * CGFloat(self.selectedSegmentIndex) + 4.0
-        UIView.animate(
-            withDuration: 0.2,
-            animations: {
-                self.highlightView.frame.origin.x = finalXPosition
-            }
-        )
+        for i in 0...(numberOfSegments - 1)  {
+            subviews[i].isHidden = true
+        }
     }
 }
 
@@ -61,8 +50,8 @@ extension NadoSegmentedControl {
     
     /// NadoSegmentedControl의 기본 UI Style을 구성하는 메서드
     private func configureDefaultStyle() {
-        backgroundColor = .segmentLightBgColor
-        selectedSegmentTintColor = .clear
+        backgroundColor = .segmentBgColor
+        selectedSegmentTintColor = .white
         setDefaultTextStyle()
         setSelectedTextStyle()
         removeDivider()
@@ -104,15 +93,21 @@ extension NadoSegmentedControl {
         setTitleTextAttributes(selectedAttributes, for: .selected)
     }
     
-    /// NadoSegmentedControl의 Frame을 통해 HighlightView Frame을 설정하는 메서드
-    func setUpNadoSegmentFrame() {
-        let width = self.bounds.size.width / CGFloat(self.numberOfSegments) - 8.0
-        let height = self.bounds.size.height - 8.0
-        let xPosition = CGFloat(self.selectedSegmentIndex * Int(width)) + 4.0
-        let yPosition = 4.0
-        let frame = CGRect(x: xPosition, y: yPosition, width: width, height: height)
-        highlightView.frame = frame
-        addSubview(highlightView)
+    /// 세그먼트가 선택되었을 때 강조되는 뷰를 찾아 Style을 커스텀하는 메서드
+    private func configureSelectedSegmentStyle(index itemCount: Int) {
+        if let imageView = subviews[itemCount] as? UIImageView {
+            imageView.makeRounded(cornerRadius: 6)
+            
+            let originFrame = imageView.frame
+            imageView.layer.frame = CGRect(x: originFrame.minX + 2, y: originFrame.minY + 2, width: originFrame.width - 4, height: originFrame.height - 4)
+            imageView.layer.shadowColor = nil
+            imageView.layer.shadowPath = .none
+            imageView.layer.shadowOffset = .zero
+            
+            // Bounds를 업데이트할 때 발생하는 animation인 "SelectionBounds"을 제거
+            imageView.layer.removeAnimation(forKey: "SelectionBounds")
+            imageView.layer.masksToBounds = true
+        }
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Class/NadoSegmentedControl.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Class/NadoSegmentedControl.swift
@@ -92,18 +92,18 @@ extension NadoSegmentedControl {
     
     /// 세그먼트가 선택되었을 때 강조되는 뷰를 찾아 Style을 커스텀하는 메서드
     private func configureSelectedSegmentStyle(index itemCount: Int) {
-        if let imageView = subviews[itemCount] as? UIImageView {
-            imageView.makeRounded(cornerRadius: 6)
+        if let selectedSegmentView = subviews[itemCount] as? UIImageView {
+            selectedSegmentView.makeRounded(cornerRadius: 6)
             
-            let originFrame = imageView.frame
-            imageView.layer.frame = CGRect(x: originFrame.minX + 2, y: originFrame.minY + 2, width: originFrame.width - 4, height: originFrame.height - 4)
-            imageView.layer.shadowColor = nil
-            imageView.layer.shadowPath = .none
-            imageView.layer.shadowOffset = .zero
+            let originFrame = selectedSegmentView.frame
+            selectedSegmentView.layer.frame = CGRect(x: originFrame.minX + 2, y: originFrame.minY + 2, width: originFrame.width - 4, height: originFrame.height - 4)
+            selectedSegmentView.layer.shadowColor = nil
+            selectedSegmentView.layer.shadowPath = .none
+            selectedSegmentView.layer.shadowOffset = .zero
             
             // Bounds를 업데이트할 때 발생하는 animation인 "SelectionBounds"을 제거
-            imageView.layer.removeAnimation(forKey: "SelectionBounds")
-            imageView.layer.masksToBounds = true
+            selectedSegmentView.layer.removeAnimation(forKey: "SelectionBounds")
+            selectedSegmentView.layer.masksToBounds = true
         }
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Review/ClassroomMainHeaderView.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/Review/ClassroomMainHeaderView.swift
@@ -14,9 +14,7 @@ import ReactorKit
 
 class ClassroomMainHeaderView: UITableViewHeaderFooterView, View {
 
-    lazy var classroomSegmentedControl = NadoSegmentedControl(items: ["후기", "1:1질문"]).then {
-        $0.frame = CGRect(x: 16, y: 10, width: 160, height: 37)
-    }
+    var classroomSegmentedControl = NadoSegmentedControl(items: ["후기", "1:1질문"])
     
     lazy var filterBtn = UIButton().then {
         $0.setImgByName(name: "btnFilter", selectedName: "filterSelected")
@@ -31,7 +29,6 @@ class ClassroomMainHeaderView: UITableViewHeaderFooterView, View {
     // MARK: init
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
-        classroomSegmentedControl.setUpNadoSegmentFrame()
         configureUI()
     }
     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityMainVC.swift
@@ -62,11 +62,6 @@ final class CommunityMainVC: BaseVC, View {
         bindCommunityTV()
     }
     
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        communitySegmentedControl.setUpNadoSegmentFrame()
-    }
-    
     func bind(reactor: CommunityMainReactor) {
         bindAction(reactor)
         bindState(reactor)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageLikeListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageLikeListVC.swift
@@ -63,7 +63,6 @@ class MypageLikeListVC: BaseVC {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        likeListSegmentControl.setUpNadoSegmentFrame()
     }
     
     override func viewWillDisappear(_ animated: Bool) {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
@@ -58,7 +58,6 @@ class MypagePostListVC: BaseVC {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        postListSegmentControl.setUpNadoSegmentFrame()
     }
     
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
## 🍎 관련 이슈
closed #496

## 🍎 변경 사항 및 이유
- UIKit의 SegmentedControl을 사용할 때, SegmentedControl의 selected View에 직접 접근하는 프로퍼티나 메서드가 존재하지 않았습니다. 또한 해당 프로퍼티가 UIImage이기 때문에 쉽사리 커스텀을 할 수 없을것이라고 판단했었습니다.
- 이렇게 직접 접근 가능한 프로퍼티나 메서드로 해결할 수 없는 구현상의 아쉬움이 있었기에, 당시엔 위 문제를 해결하기 위해 기존 selectedSegment의 컬러를 Clear로 변경한 뒤 Custom View를 subview에 추가하고 직접 애니메이션을 구현해주는 방식으로 해결해주었습니다.
- 하지만, ViewController에서 UISegmentedControl의 프레임이 완전히 결정지어진 후에 UISegmentedControl의 내부 프레임이 결정될 수 있었기에 로드되자마자 매끈한 UI 경험을 제공하지 못한다는 세부 문제가 발생했습니다. (UIViewController의 ViewDidAppear에서 해당 프레임을 업데이트해주어야 하기 때문에 번쩍하는 약간의 로딩 버그가 발생 등)
- 따라서 기존에 시도해보던 SubView 접근을 통해 SegmentedControl의 selected View를 찾고, 해당 layer의 frame값을 변경해주는 방식으로 NadoSegmentedControl의 UI를 보수했습니다.
   - 구현을 해보니 segment가 선택될 때마다 frame값이 커스텀 값으로 바뀌는 animation으로 인해 segmentView가 커졌다가 작아지는 버그가 발생해서, 해당 layer에서 실행되는 animation의 key값을 print문으로 확인해보고, bound값을 업데이트할 때 발생되는 animation을 제거해주어서 해당 버그도 해결할 수 있었습니다 ! `imageView.layer.removeAnimation(forKey: "SelectionBounds")`

## 🍎 PR Point
- background color와 관련하여 설정 색보다 진하게 로드되는 문제가 있었는데, segmentedControl을 구성하는 subview들 중 이미지가 탁하게 만드는 것을 발견하여 해당 subview들을 숨김처리해주었습니다.
- UI와 관련한 추가 설정 작업 없이도 NadoSegmentedControl을 활용할 수 있게 성능을 개선했습니다.
   - 따라서 기존 setUpNodoSegmentFrame() 함수들을 모두 코드에서 제거해주었습니다.

## 📸 ScreenShot

https://user-images.githubusercontent.com/63224278/193809353-be24ac2c-7e6e-44dd-88b1-fafaeffaddc7.mp4


