### PR TITLE
🔨 [FIX] 마이페이지 QA 수정

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Class/NadoEmptyView.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Class/NadoEmptyView.swift
@@ -1,0 +1,56 @@
+//
+//  NadoEmptyView.swift
+//  NadoSunbae
+//
+//  Created by madilyn on 2022/10/06.
+//
+
+import UIKit
+import Then
+import SnapKit
+
+/**
+ - 나도선배에서 자주 사용되는 Empty View
+ - radius는 해당 인스턴스에서 따로 설정 필요
+ ---
+ - Note:
+ - setTitleLabel: titleLabel의 텍스트 변경
+ */
+class NadoEmptyView: UIView {
+    
+    // MARK: Components
+    private let titleLabel = UILabel().then {
+        $0.font = .PretendardR(size: 14)
+        $0.textColor = .gray2
+        $0.textAlignment = .center
+    }
+    
+    // MARK: Initialization
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        configureUI()
+    }
+    
+    required init(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)!
+        configureUI()
+    }
+}
+
+// MARK: - UI
+extension NadoEmptyView {
+    private func configureUI() {
+        self.backgroundColor = .white
+        
+        self.addSubview(titleLabel)
+        
+        titleLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(16)
+        }
+    }
+    
+    func setTitleLabel(titleText: String) {
+        titleLabel.text = titleText
+    }
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageLikeListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageLikeListVC.swift
@@ -181,8 +181,10 @@ extension MypageLikeListVC: UITableViewDelegate {
                 }
             }
         case .community:
-                // TODO: Community Detail로 연결
-                debugPrint("didSelectRowAt")
+            self.navigator?.instantiateVC(destinationViewControllerType: CommunityPostDetailVC.self, useStoryboard: true, storyboardName: "CommunityPostDetailSB", naviType: .push) { postDetailVC in
+                postDetailVC.postID = self.communityData[indexPath.row].id
+                postDetailVC.hidesBottomBarWhenPushed = true
+            }
         }
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageLikeListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageLikeListVC.swift
@@ -276,6 +276,7 @@ extension MypageLikeListVC {
         likeListSegmentControl.snp.makeConstraints {
             $0.top.equalTo(naviView.snp.bottom).offset(10)
             $0.leading.equalToSuperview().inset(16)
+            $0.height.equalTo(36)
             $0.width.equalTo(240)
         }
         

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageLikeListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageLikeListVC.swift
@@ -63,6 +63,7 @@ class MypageLikeListVC: BaseVC {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         hideTabbar()
+        didChangeValue(segment: likeListSegmentControl)
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageLikeListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageLikeListVC.swift
@@ -34,10 +34,14 @@ class MypageLikeListVC: BaseVC {
         $0.layer.borderColor = UIColor.gray0.cgColor
         $0.contentInset = .zero
         $0.separatorColor = .gray0
+        $0.separatorInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
         $0.isScrollEnabled = false
         $0.estimatedRowHeight = 160
         $0.rowHeight = UITableView.automaticDimension
         $0.setBottomEmptyView()
+    }
+    private let emptyView = NadoEmptyView().then {
+        $0.makeRounded(cornerRadius: 16)
     }
     
     // MARK: Properties
@@ -137,6 +141,23 @@ class MypageLikeListVC: BaseVC {
             }
         }
     }
+    
+    /// emptyView의 Text를 분기처리하여 설정하는 메서드
+    func setEmptyView(data: Array<Any>) {
+        if data.isEmpty {
+            emptyView.isHidden = false
+            switch likeListType {
+            case .review:
+                emptyView.setTitleLabel(titleText: "좋아요한 후기가 없습니다.")
+            case .personalQuestion:
+                emptyView.setTitleLabel(titleText: "좋아요한 1:1 질문이 없습니다.")
+            case .community:
+                emptyView.setTitleLabel(titleText: "좋아요한 커뮤니티 글이 없습니다.")
+            }
+        } else {
+            emptyView.isHidden = true
+        }
+    }
 }
 
 // MARK: - UITableViewDelegate
@@ -229,14 +250,17 @@ extension MypageLikeListVC {
                 case .review:
                     if let data = res as? MypageLikeReviewListModel {
                         self.reviewData = data.likeList
+                        self.setEmptyView(data: data.likeList)
                     }
                 case .questionToPerson:
                     if let data = res as? MypageLikeQuestionToPersonListModel {
                         self.questionToPersonData = data.likeList
+                        self.setEmptyView(data: data.likeList)
                     }
                 case .community:
                     if let data = res as? MypageLikeCommunityListModel {
                         self.communityData = data.likeList
+                        self.setEmptyView(data: data.likeList)
                     }
                 }
                 self.activityIndicator.stopAnimating()
@@ -264,7 +288,7 @@ extension MypageLikeListVC {
     private func configureUI() {
         view.backgroundColor = .bgGray
         
-        view.addSubviews([naviView, likeListSegmentControl, likeListSV])
+        view.addSubviews([naviView, likeListSegmentControl, likeListSV, emptyView])
         likeListSV.addSubview(contentView)
         contentView.addSubview(likeListTV)
         
@@ -295,6 +319,12 @@ extension MypageLikeListVC {
             $0.top.equalToSuperview()
             $0.left.right.bottom.equalToSuperview().inset(16)
             $0.height.equalTo(13)
+        }
+        
+        emptyView.snp.makeConstraints {
+            $0.top.equalTo(likeListSegmentControl.snp.bottom).offset(18)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(18)
+            $0.horizontalEdges.equalToSuperview().inset(16)
         }
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
@@ -35,6 +35,9 @@ class MypagePostListVC: BaseVC {
         $0.estimatedRowHeight = 121
         $0.rowHeight = UITableView.automaticDimension
     }
+    private let emptyView = NadoEmptyView().then {
+        $0.makeRounded(cornerRadius: 16)
+    }
     
     // MARK: Properties
     var isPostOrAnswer = true
@@ -104,6 +107,28 @@ class MypagePostListVC: BaseVC {
                     $0.height.equalTo(newSize.height)
                 }
             }
+        }
+    }
+    
+    /// emptyView의 Text를 분기처리하여 설정하는 메서드
+    func setEmptyView(data: Array<Any>) {
+        if data.isEmpty {
+            emptyView.isHidden = false
+            if isPostOrAnswer {
+                if isPersonalQuestionOrCommunity {
+                    emptyView.setTitleLabel(titleText: "내가 쓴 1:1 질문이 없습니다.")
+                } else {
+                    emptyView.setTitleLabel(titleText: "내가 쓴 커뮤니티 글이 없습니다.")
+                }
+            } else {
+                if isPersonalQuestionOrCommunity {
+                    emptyView.setTitleLabel(titleText: "내가 쓴 1:1 질문 답글이 없습니다.")
+                } else {
+                    emptyView.setTitleLabel(titleText: "내가 쓴 커뮤니티 답글이 없습니다.")
+                }
+            }
+        } else {
+            emptyView.isHidden = true
         }
     }
 }
@@ -200,6 +225,7 @@ extension MypagePostListVC {
                     self.personalQuestionData = data.postList
                     self.activityIndicator.stopAnimating()
                     self.postListTV.reloadData()
+                    self.setEmptyView(data: data.postList)
                 }
             case .requestErr(let res):
                 if let message = res as? String {
@@ -227,6 +253,7 @@ extension MypagePostListVC {
                     self.communityData = data.postList
                     self.activityIndicator.stopAnimating()
                     self.postListTV.reloadData()
+                    self.setEmptyView(data: data.postList)
                 }
             case .requestErr(let res):
                 if let message = res as? String {
@@ -258,6 +285,7 @@ extension MypagePostListVC {
                     }
                     self.activityIndicator.stopAnimating()
                     self.postListTV.reloadData()
+                    self.setEmptyView(data: data.postList)
                 }
             case .requestErr(let res):
                 if let message = res as? String {
@@ -281,9 +309,9 @@ extension MypagePostListVC {
     private func configureUI() {
         view.backgroundColor = .bgGray
         
-        view.addSubviews([naviView, postListSegmentControl, postListSV])
+        view.addSubviews([naviView, postListSegmentControl, postListSV, emptyView])
         postListSV.addSubview(contentView)
-        contentView.addSubview(postListTV)
+        contentView.addSubviews([postListTV])
         
         naviView.snp.makeConstraints {
             $0.top.leading.trailing.equalToSuperview()
@@ -312,6 +340,12 @@ extension MypagePostListVC {
             $0.top.equalToSuperview()
             $0.left.right.bottom.equalToSuperview().inset(16)
             $0.height.equalTo(13)
+        }
+        
+        emptyView.snp.makeConstraints {
+            $0.top.equalTo(postListSegmentControl.snp.bottom).offset(18)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(18)
+            $0.horizontalEdges.equalToSuperview().inset(16)
         }
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
@@ -187,8 +187,10 @@ extension MypagePostListVC: UITableViewDelegate {
                 }
             }
         } else {
-            // TODO: Community Detail로 연결
-            debugPrint("didSelectRowAt")
+            self.navigator?.instantiateVC(destinationViewControllerType: CommunityPostDetailVC.self, useStoryboard: true, storyboardName: "CommunityPostDetailSB", naviType: .push) { postDetailVC in
+                postDetailVC.postID = self.communityData[indexPath.row].postID
+                postDetailVC.hidesBottomBarWhenPushed = true
+            }
         }
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
@@ -56,11 +56,11 @@ class MypagePostListVC: BaseVC {
         configureUI()
         setPostListTV()
         setSegmentedControl()
-        isPostOrAnswer ? getMypageMyPersonalQuestionList() : getMypageMyAnswerList()
     }
     
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        isPostOrAnswer ? getMypageMyPersonalQuestionList() : getMypageMyAnswerList()
     }
     
     override func viewWillDisappear(_ animated: Bool) {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
@@ -293,6 +293,7 @@ extension MypagePostListVC {
         postListSegmentControl.snp.makeConstraints {
             $0.top.equalTo(naviView.snp.bottom).offset(10)
             $0.leading.equalToSuperview().inset(16)
+            $0.height.equalTo(36)
             $0.width.equalTo(160)
         }
         

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
@@ -183,12 +183,12 @@ extension MypagePostListVC: UITableViewDelegate {
                 self.navigator?.instantiateVC(destinationViewControllerType: DefaultQuestionChatVC.self, useStoryboard: true, storyboardName: Identifiers.QuestionChatSB, naviType: .push) { questionDetailVC in
                     questionDetailVC.hidesBottomBarWhenPushed = true
                     questionDetailVC.naviStyle = .push
-                    questionDetailVC.postID = self.personalQuestionData[indexPath.row].postID
+                    questionDetailVC.postID = self.isPostOrAnswer ? self.personalQuestionData[indexPath.row].postID : self.personalQuestionDataForAnswer[indexPath.row].id
                 }
             }
         } else {
             self.navigator?.instantiateVC(destinationViewControllerType: CommunityPostDetailVC.self, useStoryboard: true, storyboardName: "CommunityPostDetailSB", naviType: .push) { postDetailVC in
-                postDetailVC.postID = self.communityData[indexPath.row].postID
+                postDetailVC.postID = self.isPostOrAnswer ? self.communityData[indexPath.row].postID : self.communityDataForAnswer[indexPath.row].id
                 postDetailVC.hidesBottomBarWhenPushed = true
             }
         }

--- a/NadoSunbae-iOS/NadoSunbae.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae.xcodeproj/project.pbxproj
@@ -335,6 +335,7 @@
 		C7C4144B27C9392F00296C30 /* MypageSettingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4144A27C9392F00296C30 /* MypageSettingService.swift */; };
 		C7C4144E27C939EE00296C30 /* EditProfileRequestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4144D27C939ED00296C30 /* EditProfileRequestModel.swift */; };
 		C7C4145027C93C4700296C30 /* EditProfileResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C4144F27C93C4700296C30 /* EditProfileResponseModel.swift */; };
+		C7C7759728EE7A9100F72091 /* NadoEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C7759628EE7A9100F72091 /* NadoEmptyView.swift */; };
 		C7CC017A28A8E7F2001D2C18 /* HomeCommunityTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CC017928A8E7F2001D2C18 /* HomeCommunityTVC.swift */; };
 		C7CC017C28A953AC001D2C18 /* HomeRecentPersonalQuestionVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CC017B28A953AC001D2C18 /* HomeRecentPersonalQuestionVC.swift */; };
 		C7E46C06289D0FFE00FBB8C4 /* HomeBannerHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E46C05289D0FFE00FBB8C4 /* HomeBannerHeaderCell.swift */; };
@@ -667,6 +668,7 @@
 		C7C4144A27C9392F00296C30 /* MypageSettingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageSettingService.swift; sourceTree = "<group>"; };
 		C7C4144D27C939ED00296C30 /* EditProfileRequestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileRequestModel.swift; sourceTree = "<group>"; };
 		C7C4144F27C93C4700296C30 /* EditProfileResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileResponseModel.swift; sourceTree = "<group>"; };
+		C7C7759628EE7A9100F72091 /* NadoEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NadoEmptyView.swift; sourceTree = "<group>"; };
 		C7CC017928A8E7F2001D2C18 /* HomeCommunityTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCommunityTVC.swift; sourceTree = "<group>"; };
 		C7CC017B28A953AC001D2C18 /* HomeRecentPersonalQuestionVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRecentPersonalQuestionVC.swift; sourceTree = "<group>"; };
 		C7E46C05289D0FFE00FBB8C4 /* HomeBannerHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeBannerHeaderCell.swift; sourceTree = "<group>"; };
@@ -1369,6 +1371,7 @@
 				778E0F46287A061900BEEEA5 /* NadoMaskedImgView.swift */,
 				33C79DCA287F350100B6C32C /* NadoSegmentedControl.swift */,
 				C709CB1A28B3C6E700F04335 /* NadoStatusBarView.swift */,
+				C7C7759628EE7A9100F72091 /* NadoEmptyView.swift */,
 			);
 			path = Class;
 			sourceTree = "<group>";
@@ -2224,6 +2227,7 @@
 				C783BF9C28A7A202000FE3D8 /* HomeRecentReviewQuestionCVC.swift in Sources */,
 				331364722785B26000E0C118 /* Notification.Name.swift in Sources */,
 				331364B62786179100E0C118 /* UITabBar+.swift in Sources */,
+				C7C7759728EE7A9100F72091 /* NadoEmptyView.swift in Sources */,
 				C71BF22527CCB2070030DCB9 /* BlockListVC.swift in Sources */,
 				779DC5A728DDAB24009B9A43 /* RecentReviewReactor.swift in Sources */,
 				C7CC017C28A953AC001D2C18 /* HomeRecentPersonalQuestionVC.swift in Sources */,


### PR DESCRIPTION
## 🍎 관련 이슈
closed #494

## 🍎 변경 사항 및 이유
* 마이페이지 SegmentedControl 사용된 부분 레이아웃 수정
* 마이페이지의 내가 쓴 글/답글, 좋아요한 목록 emptyView 처리
* 내가 쓴 글/답글, 좋아요한 목록에서 커뮤니티 글 상세페이지로 이동하는 기능 추가
* 기타 버그 수정

## 🍎 PR Point
* **NadoEmptyView** UI Component
  사용법
  ```
    private let emptyView = NadoEmptyView().then {
        $0.makeRounded(cornerRadius: 16)
    }

    /// emptyView의 Text를 분기처리하여 설정하는 메서드
    func setEmptyView(data: Array<Any>) {
        if data.isEmpty {
            emptyView.isHidden = false
            if isPostOrAnswer {
                if isPersonalQuestionOrCommunity {
                    emptyView.setTitleLabel(titleText: "내가 쓴 1:1 질문이 없습니다.")
                } else {
                    emptyView.setTitleLabel(titleText: "내가 쓴 커뮤니티 글이 없습니다.")
                }
            } else {
                if isPersonalQuestionOrCommunity {
                    emptyView.setTitleLabel(titleText: "내가 쓴 1:1 질문 답글이 없습니다.")
                } else {
                    emptyView.setTitleLabel(titleText: "내가 쓴 커뮤니티 답글이 없습니다.")
                }
            }
        } else {
            emptyView.isHidden = true
        }
    }
  ```

분기처리하는 메서드는 자유롭게,. 만들어서 사용하심 됩니다 나는 하나의 뷰에서 모든 걸 해결하느라고 분기가 길어짐 ㅋㅎ


## 📸 ScreenShot

https://user-images.githubusercontent.com/43312096/194382793-54199b38-9dd6-47f4-8655-d552bb350b6b.MP4


https://user-images.githubusercontent.com/43312096/194382883-74d42f34-c96a-4cd2-89cc-273c5cd14ec8.MP4


