### PR TITLE
🔨 [FIX] 커뮤니티 글 리스트 행간 조정하기

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/Cell/TVC/CommunityTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/Cell/TVC/CommunityTVC.swift
@@ -28,6 +28,7 @@ extension CommunityTVC {
         categoryLabel.snp.makeConstraints {
             $0.top.leading.equalToSuperview().offset(16)
             $0.trailing.equalToSuperview().offset(-16)
+            $0.height.equalTo(18)
         }
         
         questionTitleLabel.snp.removeConstraints()
@@ -48,6 +49,8 @@ extension CommunityTVC {
         categoryLabel.text = data.type
         questionTitleLabel.text = data.title
         questionContentLabel.text = data.content
+        questionContentLabel.setLineSpacing(lineSpacing: 5.0)
+        questionContentLabel.layoutIfNeeded()
         nicknameLabel.text = data.writer.nickname
         questionTimeLabel.text = data.createdAt.serverTimeToString(forUse: .forDefault)
         commentCountLabel.text = "\(data.commentCount)"


### PR DESCRIPTION
## 🍎 관련 이슈
closed #512

## 🍎 변경 사항 및 이유

## 🍎 PR Point
커뮤니티 글 리스트 행간 조정 QA를 반영했습니다.

## 📸 ScreenShot
`이전`
<img width="375" alt="스크린샷 2022-10-10 02 51 57" src="https://user-images.githubusercontent.com/63224278/194772593-5c98e75b-edb3-4cc8-9181-c02b341a2984.png">

`반영 후`
<img width=375 src="https://user-images.githubusercontent.com/63224278/194772564-494a4ed0-7266-4db3-95b7-72b2ae5bf145.png">