### PR TITLE
🔨 [FIX] 커뮤니티 글 리스트 클릭 후 뒤로 돌아왔을 때 전체 글로 reload 되는 버그 해결하기

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/PostFilterType.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/PostFilterType.swift
@@ -7,11 +7,11 @@
 
 import Foundation
 
-enum PostFilterType: CaseIterable {
-    case community
-    case general
-    case questionToEveryone // 전체에게 질문 (커뮤니티 질문)
-    case information
+enum PostFilterType: Int, CaseIterable {
+    case community = 0
+    case general = 1
+    case questionToEveryone = 2 // 전체에게 질문 (커뮤니티 질문)
+    case information = 3
     case questionToPerson // 1:1 질문
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityWriteVC.swift
@@ -51,6 +51,7 @@ final class CommunityWriteVC: BaseWritePostVC, View {
     var categoryIndex: Int?
     var originTitle: String?
     var originContent: String?
+    var sendPostTypeDelegate: SendUpdateModalDelegate?
     
     // MARK: Life Cycle
     override func viewDidLoad() {
@@ -196,9 +197,11 @@ extension CommunityWriteVC {
         
         reactor.state
             .map{ $0.writePostSuccess }
-            .subscribe(onNext: { success in
+            .subscribe(onNext: { [weak self] success in
                 if success {
-                    self.dismiss(animated: true, completion: nil)
+                    self?.dismiss(animated: true, completion: {
+                        self?.sendPostTypeDelegate?.sendUpdate(data: (self?.selectedCategory ?? .community) as PostFilterType)
+                    })
                 }
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
## 🍎 관련 이슈
closed #514

## 🍎 변경 사항 및 이유
- CommunityWriteVC에 글쓴 postFilterType을 전달하는 delegate를 추가하여 글쓰기 완료시 뷰가 dismiss되면 CommunityMainVC에서 해당 글 type의 segmentedControl이 클릭되게끔 구현했습니다.

## 🍎 PR Point
- 글쓰기 완료 후 해당 타입으로 segmentedControl을 옮기는 처리를 해주었습니다.
- 커뮤니티 글 리스트 클릭 후 뒤로 돌아왔을 때 전체 글로 reload 되는 버그를 해결했습니다.

## 📸 ScreenShot
`[글쓰기 완료 후]`

https://user-images.githubusercontent.com/63224278/194775038-d0846a0e-2084-4571-9e14-a44cbebe266d.mp4


`[글 리스트 클릭 후 뒤로 돌아왔을 때 reload되는 버그 해결]`

https://user-images.githubusercontent.com/63224278/194775045-1a9908ff-ef99-41a4-bc11-234114c470d0.mp4

