### PR TITLE
✨ [FEAT] 커뮤니티 메인뷰의 scrollView에 refreshControl을 추가합니다. 

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/PostFilterType.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/PostFilterType.swift
@@ -7,11 +7,11 @@
 
 import Foundation
 
-enum PostFilterType: CaseIterable {
-    case community
-    case general
-    case questionToEveryone // 전체에게 질문 (커뮤니티 질문)
-    case information
+enum PostFilterType: Int, CaseIterable {
+    case community = 0
+    case general = 1
+    case questionToEveryone = 2 // 전체에게 질문 (커뮤니티 질문)
+    case information = 3
     case questionToPerson // 1:1 질문
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityMainVC.swift
@@ -50,6 +50,10 @@ final class CommunityMainVC: BaseVC, View {
         $0.addShadow(offset: CGSize(width: 1, height: 1), color: UIColor(red: 68/255, green: 69/255, blue: 75/255, alpha: 0.2), opacity: 1, radius: 0)
     }
     
+    private let refreshControl = UIRefreshControl().then {
+        $0.tintColor = .mainDefault
+    }
+    
     var disposeBag = DisposeBag()
     
     // MARK: Life Cycle
@@ -60,6 +64,7 @@ final class CommunityMainVC: BaseVC, View {
         setUpDelegate()
         bindCommunityTV()
         setUpSegmentAction(type: PostFilterType(rawValue: communitySegmentedControl.selectedSegmentIndex) ?? .community)
+        setUpCommunityTVRefreshControl()
     }
     
     func bind(reactor: CommunityMainReactor) {
@@ -116,6 +121,13 @@ extension CommunityMainVC {
                 return CommunityMainReactor.Action.filterFilled }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+        
+        refreshControl.rx.controlEvent(.valueChanged)
+            .subscribe(onNext: {
+                reactor.action.onNext(.refreshControl(majorID: 0, type: <#T##PostFilterType#>, sort: <#T##String?#>, search: <#T##String?#>))
+            })
+            .disposed(by: disposeBag)
+                       
     }
     
     // MARK: State
@@ -259,6 +271,12 @@ extension CommunityMainVC {
     /// segment Action을 설정하는 메서드
     private func setUpSegmentAction(type: PostFilterType) {
         reactor?.action.onNext(.reloadCommunityTV(type: type))
+    }
+    
+    /// communityTV의 refreshControl을 등록하는 메서드
+    private func setUpCommunityTVRefreshControl() {
+        refreshControl.endRefreshing()
+        communityTV.refreshControl = refreshControl
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityWriteVC.swift
@@ -51,6 +51,7 @@ final class CommunityWriteVC: BaseWritePostVC, View {
     var categoryIndex: Int?
     var originTitle: String?
     var originContent: String?
+    var sendPostTypeDelegate: SendUpdateModalDelegate?
     
     // MARK: Life Cycle
     override func viewDidLoad() {
@@ -196,9 +197,11 @@ extension CommunityWriteVC {
         
         reactor.state
             .map{ $0.writePostSuccess }
-            .subscribe(onNext: { success in
+            .subscribe(onNext: { [weak self] success in
                 if success {
-                    self.dismiss(animated: true, completion: nil)
+                    self?.dismiss(animated: true, completion: {
+                        self?.sendPostTypeDelegate?.sendUpdate(data: (self?.selectedCategory ?? .community) as PostFilterType)
+                    })
                 }
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
## 🍎 관련 이슈
closed #519

## 🍎 변경 사항 및 이유
- 커뮤니티 특성상 유저가 게시글을 상세조회하고 나와서 다른 게시글을 조회할 일이 잦을텐데, 게시글을 상세조회하고 메인뷰로 돌아올 때마다 통신정보를 refresh하게 된다면 나올때마다 scrollOffset이 top으로 설정되는 문제가 생깁니다. 그러나 유저가 게시글 상세조회에서 수정을 하고 메인 리스트로 돌아간다면 유저의 상황판단에 따라 게시글을 리로드하고 싶어질 것입니다.  
- 이러한 문제와 상황을 해결하기 위해 오늘의집 뷰를 참고하여 상세조회 후 뷰에서 나왔을 때마다 reload를 해주는 것이 아니라, 사용자가 원할 때마다 상단 refreshControl을 통해 reload를 할 수 있도록 refreshControl을 추가했습니다.

## 🍎 PR Point
- communitySV에 refreshControl을 추가했습니다.

## 📸 ScreenShot

https://user-images.githubusercontent.com/63224278/194780720-3353c311-2632-4f8c-a814-25b8b19f31c3.mp4


