### PR TITLE
🔨 [FIX] 삭제된 댓글에 대해서 삭제 기능 다시 가능한 문제 해결하기

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/Cell/TVC/PostDetail/InfoCommentTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/Cell/TVC/PostDetail/InfoCommentTVC.swift
@@ -73,6 +73,11 @@ extension InfoCommentTVC {
         setLabelSizeToFit()
     }
     
+    /// infoBtn을 숨김처리하는 메서드 (isDeleted에 따라)
+    func hideInfoBtn(isDeleted: Bool) {
+        infoBtn.isHidden = isDeleted ? true : false
+    }
+    
     /// label sizeToFit 일괄 적용 메서드
     func setLabelSizeToFit() {
         [nicknameLabel, majorInfoLabel, commentDateLabel].forEach {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/Cell/TVC/PostDetail/InfoCommentTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/Cell/TVC/PostDetail/InfoCommentTVC.swift
@@ -26,6 +26,7 @@ class InfoCommentTVC: BaseTVC {
             commentTextView.textColor = .gray4
         }
     }
+    @IBOutlet weak var infoBtn: UIButton!
     @IBOutlet var commentDateLabel: UILabel!
     @IBOutlet var writerImgView: UIImageView!
     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/Cell/TVC/PostDetail/InfoCommentTVC.xib
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/Cell/TVC/PostDetail/InfoCommentTVC.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -21,7 +22,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="InfoCommentTVC" rowHeight="204" id="fh7-8u-a0h" customClass="InfoCommentTVC" customModule="NadoSunbae_iOS" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="InfoCommentTVC" rowHeight="204" id="fh7-8u-a0h" customClass="InfoCommentTVC" customModule="NadoSunbae" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="204"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="fh7-8u-a0h" id="htk-89-fzd">
@@ -45,13 +46,13 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="본전명 18-1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WQD-Tl-WV6">
-                        <rect key="frame" x="56" y="37" width="58" height="15"/>
+                        <rect key="frame" x="56" y="37" width="57.5" height="14"/>
                         <fontDescription key="fontDescription" name="Pretendard-Medium" family="Pretendard" pointSize="12"/>
                         <color key="textColor" name="gray2"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="댓글내용 오토레이아웃 어케 걸지,,,, 댓글내용 오토레이아웃 어케 걸지,,,,댓글내용 오토레이아웃 어케 걸지,,,,댓글내용 오토레이아웃 어케 걸지,,,,댓글내용 오토레이아웃 어케 걸지,,,,댓글내용 오토레이아웃 어케 걸지,,,," textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="3ks-MP-Tdt">
-                        <rect key="frame" x="56" y="60" width="248" height="114"/>
+                        <rect key="frame" x="56" y="59" width="248" height="116"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="30" id="b2d-EM-EvF"/>
                         </constraints>
@@ -60,7 +61,7 @@
                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                     </textView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="오후 12:11" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oTA-58-wpP">
-                        <rect key="frame" x="56" y="182" width="50" height="15"/>
+                        <rect key="frame" x="56" y="183" width="50" height="14"/>
                         <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="12"/>
                         <color key="textColor" name="gray2"/>
                         <nil key="highlightedColor"/>
@@ -132,6 +133,7 @@
             <connections>
                 <outlet property="commentDateLabel" destination="oTA-58-wpP" id="ifR-SR-YgV"/>
                 <outlet property="commentTextView" destination="3ks-MP-Tdt" id="5ml-BI-SJZ"/>
+                <outlet property="infoBtn" destination="6S1-Ac-BEa" id="9gk-3w-77P"/>
                 <outlet property="majorInfoLabel" destination="WQD-Tl-WV6" id="7Qk-r3-hwu"/>
                 <outlet property="nicknameLabel" destination="rKz-xJ-yQq" id="gKX-AJ-qGz"/>
                 <outlet property="profileImgView" destination="E7S-Ue-Mte" id="iu2-JL-QoP"/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityPostDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityPostDetailVC.swift
@@ -307,6 +307,7 @@ extension CommunityPostDetailVC: UITableViewDataSource {
         else {
             /// 정보글 댓글 Cell
             infoCommentCell.bindData(model: infoDetailCommentData[indexPath.row - 2])
+            infoCommentCell.hideInfoBtn(isDeleted: (infoDetailCommentData[indexPath.row - 2].isDeleted == true) ? true : false)
             infoCommentCell.tapMoreInfoBtnAction = { [unowned self] in
                 if userID == infoDetailCommentData[indexPath.row - 2].writer.writerID {
                     makeAlertWithCancel(okTitle: "삭제", okAction: { [weak self] _ in


### PR DESCRIPTION
## 🍎 관련 이슈
closed #522

## 🍎 PR Point
- 삭제된 댓글에 대해서 삭제 기능 다시 가능한 문제를 해결하기 위해 infoCommentTVC에 hideInfoBtn 메서드를 구현하여 삭제상태의 cell일 경우 infoBtn을 숨겨주도록 구현했습니다.

## 📸 ScreenShot

https://user-images.githubusercontent.com/63224278/194781424-e3ebe126-6ca3-40da-bb3c-94dd73143296.mp4


