### PR TITLE
✨ [FEAT] 업데이트 알럿 기능 추가

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/BaseVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/BaseVC.swift
@@ -93,22 +93,41 @@ extension BaseVC {
     }
     
     /// 앱 최신 버전 조회 후 alert 띄우는 함수
-    func getLatestVersion() {
+    func getLatestVersion(completion: @escaping () -> ()) {
         getLatestVersion { response in
-            if AppVersion.shared.latestVersion != AppVersion.shared.currentVersion {
-                guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
-                alert.confirmBtn.press {
-                    if let url = URL(string: "itms-apps://itunes.apple.com/app/1605763068"), UIApplication.shared.canOpenURL(url) {
-                        UIApplication.shared.open(url, options: [:], completionHandler: nil)
-                    }
+            guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+            alert.view.backgroundColor = .init(white: 1, alpha: 0.5)
+            alert.confirmBtn.press {
+                if let url = URL(string: "itms-apps://itunes.apple.com/app/1605763068"), UIApplication.shared.canOpenURL(url) {
+                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
                 }
-                alert.showNadoAlert(vc: self, message:
-        """
-        유저들의 의견을 반영하여
-        사용성을 개선했어요.
-        지금 바로 업데이트해보세요!
-        """
-                                    , confirmBtnTitle: "업데이트", cancelBtnTitle: "다음에 하기")
+            }
+            alert.cancelBtn.press {
+                completion()
+            }
+            if env() == .development || env() == .qa {
+                completion()
+            } else {
+                
+                /// 앞자리가 최신 버전과 다르다면 강제 업데이트 알럿
+                if AppVersion.shared.latestVersion.prefix(1) != AppVersion.shared.currentVersion.prefix(1) {
+                    alert.showNadoAlert(vc: self, message:
+            """
+            안정적인 서비스 이용을 위해
+            최신 버전으로 업데이트해주세요.
+            """
+                                        , confirmBtnTitle: "나도선배 앱 업데이트", cancelBtnTitle: "", type: .withSingleBtn)
+                } else if AppVersion.shared.latestVersion != AppVersion.shared.currentVersion {
+                    alert.showNadoAlert(vc: self, message:
+            """
+            유저들의 의견을 반영하여
+            사용성을 개선했어요.
+            지금 바로 업데이트해보세요!
+            """
+                                        , confirmBtnTitle: "업데이트", cancelBtnTitle: "다음에 하기")
+                } else {
+                    completion()
+                }
             }
         }
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/MypageSettingService.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/MypageSettingService.swift
@@ -25,7 +25,7 @@ extension MypageSettingService: TargetType {
         case .editProfile:
             return "/user/mypage"
         case .getLatestVersion:
-            return "/user/mypage/app-version/recent"
+            return "/app/version/recent"
         case .getBlockList:
             return "/block/list"
         case .requestResetPW:

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/HomeVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/HomeVC.swift
@@ -28,10 +28,12 @@ final class HomeVC: BaseVC {
     // MARK: Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureUI()
-        setBackgroundTV()
-        getRecentCommunityList()
-        requestGetMajorList(univID: UserDefaults.standard.integer(forKey: UserDefaults.Keys.univID), filterType: "all")
+        getLatestVersion {
+            self.configureUI()
+            self.setBackgroundTV()
+            self.getRecentCommunityList()
+            self.requestGetMajorList(univID: UserDefaults.standard.integer(forKey: UserDefaults.Keys.univID), filterType: "all")
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewMainVC.swift
@@ -38,7 +38,7 @@ class ReviewMainVC: BaseVC {
     // MARK: Life Cycle Part
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.getLatestVersion()
+//        self.getLatestVersion()
         registerTVC()
         setUpTV()
         initImgList()


### PR DESCRIPTION

## 🍎 관련 이슈
closed #534

## 🍎 변경 사항 및 이유
* 업데이트 알럿 - 강제 업데이트 알럿을 추가합니다.
* 업데이트 알럿 띄우는 시점을 홈 탭 진입 시로 변경하였습니다.

## 🍎 PR Point
* `getLatestVersion` 함수 탈출 클로저로 변경 이유
  * 업데이트 알럿이 뜨는 시점에는 홈 메인 뷰의 다른 네트워킹 요청 함수를 실행할 필요가 없음. 알럿을 타고 앱스토어에 들어가 업데이트할 가능성도 있기 때문에 불필요한 로딩을 없애기 위함. 특히 강제 업데이트 알럿이 띄워졌을 때에는, 홈 메인 뷰의 다른 네트워킹 요청 함수를 실행할 필요가 더욱 없음. 따라서, `getLatestVersion` 함수에서 `completion`을 통해 탈출하는 경우(**버전 확인 OK**일 때, **다음에 하기** 버튼 눌렀을 때, **dev/qa 환경**이라 알럿이 필요없을 때)에만 다음 작업을 진행시키기 위해 탈출 클로저를 이용함.
* @jane1choi 후기탭에 있던 getLatestVersion 함수 우선 주석 처리했는데, 없애도 될까여?!
* 현재 서버에는 iOS가 1.X 버전이고, 우리는 2.0.0 버전이라서 무조건 강제 업데이트 알럿이 뜨는 상황이기 때문에 해당 부분은 production 환경에서만 돌아가도록 처리하였습니다.
## 📸 ScreenShot
| 소규모 업데이트 알럿 | 대규모 업데이트 알럿|
| - | - |
|  ![RPReplay_Final1665509990](https://user-images.githubusercontent.com/43312096/195165288-1674ef67-f6c4-477b-9f20-70b9ca4cddb0.gif) | ![RPReplay_Final1665510010](https://user-images.githubusercontent.com/43312096/195165516-0f9d9e4b-29e9-4d18-9ebc-fae6f9587148.gif) |
