### PR TITLE
✅ [CHORE] 테이블뷰 마지막 셀 separator 숨김 처리

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/BaseTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/BaseTVC.swift
@@ -20,6 +20,16 @@ class BaseTVC: UITableViewCell {
         // Configure the view for the selected state
     }
     
+    /// 마지막 셀의 separator를 제거하는 함수, cellForRowAt에서 호출한다.
+    func removeBottomSeparator(isLast: Bool) {
+        if isLast {
+            self.addAboveTheBottomBorderWithColor()
+        } else {
+            if self.layer.sublayers?.last?.bounds.height == 1 {
+                self.layer.sublayers?.last?.removeFromSuperlayer()
+            }
+        }
+    }
 }
 
 // MARK: - TVRegisterable

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/UITableView+.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/UITableView+.swift
@@ -24,4 +24,12 @@ extension UITableView {
     func removeSeparatorsOfEmptyCellsAndLastCell() {
         tableFooterView = UIView(frame: CGRect(origin: .zero, size: CGSize(width: 0, height: 1)))
     }
+    
+    /// tableView의 indexPath가 마지막 셀인지 검사하는 함수
+    func isLast(for indexPath: IndexPath) -> Bool {
+        let indexOfLastSection = numberOfSections > 0 ? numberOfSections - 1 : 0
+        let indexOfLastRowInLastSection = numberOfRows(inSection: indexOfLastSection) - 1
+        
+        return indexPath.section == indexOfLastSection && indexPath.row == indexOfLastRowInLastSection
+    }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/UIView+.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Extension/UIView+.swift
@@ -123,4 +123,14 @@ extension UIView {
         let generator = UIImpactFeedbackGenerator(style: degree)
         generator.impactOccurred()
     }
+    
+    /// view의 하단에 white color의 줄을 긋는 함수
+    func addAboveTheBottomBorderWithColor() {
+        DispatchQueue.main.async {
+            let border = CALayer()
+            border.backgroundColor = UIColor.white.cgColor
+            border.frame = CGRect(x: 0, y: self.frame.size.height - 1, width: self.frame.size.width, height: 1)
+            self.layer.addSublayer(border)
+        }
+    }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/HomeRecentPersonalQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/HomeRecentPersonalQuestionVC.swift
@@ -70,6 +70,7 @@ extension HomeRecentPersonalQuestionVC: UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: EntireQuestionListTVC.className, for: indexPath) as? EntireQuestionListTVC else { return EntireQuestionListTVC() }
         cell.setPostData(data: questionList[indexPath.row])
         cell.layoutSubviews()
+        cell.removeBottomSeparator(isLast: tableView.isLast(for: indexPath))
         return cell
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
@@ -149,10 +149,12 @@ extension MypagePostListVC: UITableViewDataSource {
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: EntireQuestionListTVC.className, for: indexPath) as? EntireQuestionListTVC else { return EntireQuestionListTVC() }
                 cell.setPostData(data: personalQuestionData[indexPath.row])
                 cell.layoutSubviews()
+                cell.removeBottomSeparator(isLast: tableView.isLast(for: indexPath))
                 return cell
             } else {
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: CommunityTVC.className, for: indexPath) as? CommunityTVC else { return CommunityTVC() }
                 cell.setCommunityData(data: communityData[indexPath.row])
+                cell.removeBottomSeparator(isLast: tableView.isLast(for: indexPath))
                 return cell
             }
         } else {
@@ -162,11 +164,13 @@ extension MypagePostListVC: UITableViewDataSource {
                 // TODO: MypageResModel에도 isAuthorized값 넣어달라고 요청하기.
                 cell.setPostData(data: PostListResModel(postID: data.id, type: data.type, title: data.title, content: data.content, createdAt: data.createdAt, majorName: data.majorName, writer: CommunityWriter(writerID: data.writer.id, nickname: data.writer.nickname), isAuthorized: true, commentCount: data.commentCount, like: data.like))
                 cell.layoutSubviews()
+                cell.removeBottomSeparator(isLast: tableView.isLast(for: indexPath))
                 return cell
             } else {
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: CommunityTVC.className, for: indexPath) as? CommunityTVC else { return CommunityTVC() }
                 let data = communityDataForAnswer[indexPath.row]
                 cell.setCommunityData(data: PostListResModel(postID: data.id, type: data.type, title: data.title, content: data.content, createdAt: data.createdAt, majorName: data.majorName, writer: CommunityWriter(writerID: data.writer.id, nickname: data.writer.nickname), isAuthorized: true, commentCount: data.commentCount, like: data.like))
+                cell.removeBottomSeparator(isLast: tableView.isLast(for: indexPath))
                 return cell
             }
         }


### PR DESCRIPTION

## 🍎 관련 이슈
closed #538

## 🍎 변경 사항 및 이유
* 테이블 뷰의 마지막 셀 separator를 숨김 처리하는 함수를 추가합니다.
* 홈탭, 마이페이지탭에 적용합니다.

## 🍎 PR Point
* 적용법
  * 해당 tableView의 cellForRowAt에서, `cell.removeBottomSeparator(isLast: tableView.isLast(for: indexPath))` 함수 호출

## 📸 ScreenShot
<img width="487" alt="스크린샷 2022-10-13 오전 10 15 11" src="https://user-images.githubusercontent.com/43312096/195476370-ce34a98d-bb9e-4271-af1f-ccdaad4034e2.png"> 
