### PR TITLE
🔨 [QA] 커뮤니티 글 작성뷰에서 '질문’ 선택시 빠진 문구 추가하기

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityWriteVC.swift
@@ -40,6 +40,13 @@ final class CommunityWriteVC: BaseWritePostVC, View {
         $0.showsHorizontalScrollIndicator = false
     }
     
+    private let questionDescLabel = UILabel().then {
+        $0.text = "특정 학과 선택시 해당 학과 유저들에게 알림이 갑니다."
+        $0.font = .PretendardR(size: 12.0)
+        $0.textColor = .mainDark
+        $0.isHidden = true
+    }
+    
     private let partitionBar = UIView().then {
         $0.backgroundColor = .gray0
     }
@@ -83,7 +90,7 @@ final class CommunityWriteVC: BaseWritePostVC, View {
 extension CommunityWriteVC {
     private func configureUI() {
         view.backgroundColor = .white
-        contentView.addSubviews([selectMajorLabel, majorSelectTextField, majorSelectBtn, categoryLabel, categoryCV, partitionBar])
+        contentView.addSubviews([selectMajorLabel, majorSelectTextField, majorSelectBtn, categoryLabel, categoryCV, questionDescLabel, partitionBar])
         
         selectMajorLabel.snp.makeConstraints {
             $0.top.equalTo(questionWriteNaviBar.snp.bottom).offset(24)
@@ -111,6 +118,11 @@ extension CommunityWriteVC {
             $0.leading.equalTo(categoryLabel)
             $0.trailing.equalToSuperview().offset(-24)
             $0.height.equalTo(20)
+        }
+        
+        questionDescLabel.snp.makeConstraints {
+            $0.top.equalTo(categoryCV.snp.bottom).offset(7)
+            $0.leading.equalTo(categoryLabel)
         }
         
         partitionBar.snp.makeConstraints {
@@ -310,10 +322,13 @@ extension CommunityWriteVC: UICollectionViewDelegateFlowLayout {
         switch indexPath.row {
         case 0:
             selectedCategory = .general
+            questionDescLabel.isHidden = true
         case 1:
             selectedCategory = .questionToEveryone
+            questionDescLabel.isHidden = false
         default:
             selectedCategory = .information
+            questionDescLabel.isHidden = true
         }
     }
 }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #556

## 🍎 PR Point
- 커뮤니티 글 작성뷰에서 카테고리 '질문’ 선택시 빠진 문구를 추가했습니다.

## 📸 ScreenShot
https://user-images.githubusercontent.com/63224278/197358845-d8f8b0ab-5499-43b3-9f23-7670b735f6d0.mp4

