### PR TITLE
🔨 [QA] 나의 마이페이지로 이동할 때 tab index 변경하기

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -349,7 +349,7 @@ extension DefaultQuestionChatVC {
     /// 마이페이지로 뷰를 전환하는 메서드 (본인 마이페이지일 경우 탭 이동)
     private func goToMypageVC(userID: Int) {
         if userID == UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID) {
-            goToRootOfTab(index: 3)
+            goToRootOfTab(index: 4)
         } else {
             self.navigator?.instantiateVC(destinationViewControllerType: MypageUserVC.self, useStoryboard: true, storyboardName: MypageUserVC.className, naviType: .push) { mypageUserVC in
                 mypageUserVC.targetUserID = userID
@@ -361,7 +361,7 @@ extension DefaultQuestionChatVC {
     /// 알림탭 메인으로 뷰를 전환하는 메서드
     @objc
     private func goToNotificationVC() {
-        goToRootOfTab(index: 2)
+        goToRootOfTab(index: 3)
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionPersonListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/QuestionPersonListVC.swift
@@ -168,7 +168,7 @@ extension QuestionPersonListVC: UICollectionViewDelegate {
         let targetUserID = indexPath.section == 0 ? self.majorUserList.onQuestionUserList[indexPath.row].userID : self.majorUserList.offQuestionUserList[indexPath.row].userID
      
         if targetUserID == UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID) {
-           goToRootOfTab(index: 3)
+           goToRootOfTab(index: 4)
         } else {
             self.navigator?.instantiateVC(destinationViewControllerType: MypageUserVC.self, useStoryboard: true, storyboardName: MypageUserVC.className, naviType: .push) { mypageUserVC in
                 mypageUserVC.targetUserID = targetUserID

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityPostDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityPostDetailVC.swift
@@ -254,7 +254,7 @@ extension CommunityPostDetailVC {
     /// 마이페이지로 뷰를 전환하는 메서드 (본인 마이페이지일 경우 탭 이동)
     private func goToMypageVC(userID: Int) {
         if userID == UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID) {
-            goToRootOfTab(index: 3)
+            goToRootOfTab(index: 4)
         } else {
             self.navigator?.instantiateVC(destinationViewControllerType: MypageUserVC.self, useStoryboard: true, storyboardName: MypageUserVC.className, naviType: .push) { mypageUserVC in
                 mypageUserVC.targetUserID = userID

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/HomeVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/HomeVC.swift
@@ -124,7 +124,7 @@ extension HomeVC: SendRankerDataDelegate {
     func sendRankerData(data: HomeRankingResponseModel.UserList) {
         divideUserPermission {
             if data.id == UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID) {
-                goToRootOfTab(index: 3)
+                goToRootOfTab(index: 4)
             } else {
                 self.navigator?.instantiateVC(destinationViewControllerType: MypageUserVC.self, useStoryboard: true, storyboardName: MypageUserVC.className, naviType: .push) { mypageUserVC in
                     mypageUserVC.targetUserID = data.id

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/RankingVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/RankingVC.swift
@@ -89,9 +89,13 @@ extension RankingVC {
         
         /// 선배 개인프로필 뷰로 이동
         rankingTV.rx.modelSelected(HomeRankingResponseModel.UserList.self)
-            .subscribe(onNext: { item in
-                self.navigator?.instantiateVC(destinationViewControllerType: MypageUserVC.self, useStoryboard: true, storyboardName: MypageUserVC.className, naviType: .push) { mypageUserVC in
-                    mypageUserVC.targetUserID = item.id
+            .subscribe(onNext: { [weak self] item in
+                if item.id == UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID) {
+                    self?.goToRootOfTab(index: 4)
+                } else {
+                    self?.navigator?.instantiateVC(destinationViewControllerType: MypageUserVC.self, useStoryboard: true, storyboardName: MypageUserVC.className, naviType: .push) { mypageUserVC in
+                        mypageUserVC.targetUserID = item.id
+                    }
                 }
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
## 🍎 관련 이슈
closed #563

## 🍎 변경 사항 및 이유
- 이번 업데이트를 진행하면서 탭이 늘어남에 따라 마이페이지, 알림탭에 대한 기존 tabIndex를 변경해주었습니다.
- 선배랭킹 더보기뷰에서 본인 마이페이지로 이동하는 기능이 빠져있어서, 해당 기능을 추가해주었습니다.
 
## 🍎 PR Point
- 나의 마이페이지로 이동할 때 tab index 변경하기

## 📸 ScreenShot
X
