### PR TITLE
✨ [FEAT] 과방 1:1 질문뷰 emptyView 구현

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/CVC/AvailableQuestionPersonEmptyCVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/CVC/AvailableQuestionPersonEmptyCVC.swift
@@ -1,0 +1,34 @@
+//
+//  AvailableQuestionPersonEmptyCVC.swift
+//  NadoSunbae
+//
+//  Created by hwangJi on 2022/10/24.
+//
+
+import UIKit
+import Then
+import SnapKit
+
+final class AvailableQuestionPersonEmptyCVC: CodeBaseCVC {
+    // MARK: Property
+    private let emptyLabel = UILabel().then {
+        $0.text = "등록된 선배가 없습니다."
+        $0.textColor = .gray2
+        $0.font = .PretendardR(size: 14.0)
+    }
+    
+    override func setupViews() {
+        configureUI()
+    }
+}
+
+// MARK: - UI
+extension AvailableQuestionPersonEmptyCVC {
+    private func configureUI() {
+        self.addSubview(emptyLabel)
+        
+        emptyLabel.snp.makeConstraints {
+            $0.centerX.centerY.equalToSuperview()
+        }
+    }
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/QuestionToPerson/QuestionEmptyTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/QuestionToPerson/QuestionEmptyTVC.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class QuestionEmptyTVC: UITableViewCell {
+final class QuestionEmptyTVC: UITableViewCell {
 
     // MARK: Properties
     private var emptyQuestionLabel = UILabel().then {
@@ -42,7 +42,8 @@ extension QuestionEmptyTVC {
         
         emptyQuestionLabel.snp.makeConstraints {
             $0.centerX.equalTo(contentView)
-            $0.centerY.equalTo(contentView)
+            $0.top.equalToSuperview().offset(45)
+            $0.bottom.equalToSuperview().inset(45)
         }
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Reactor/PersonalQuestionReactor.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Reactor/PersonalQuestionReactor.swift
@@ -61,7 +61,7 @@ extension PersonalQuestionReactor {
         case .requestSeniorList(let seniorList):
             newState.seniorList = seniorList
         case .requestRecentQuestionList(let recentQuestionList):
-            newState.recentQuestionList = recentQuestionList
+            newState.recentQuestionList = recentQuestionList.isEmpty ? makeEmptyPostListResModel() : recentQuestionList
         }
         
         return newState
@@ -113,7 +113,7 @@ extension PersonalQuestionReactor {
                     if let data = res as? MajorUserListDataModel {
                         var questionUserList = data.onQuestionUserList
                         if questionUserList.count > 8 {
-                            questionUserList = Array(data.onQuestionUserList.suffix(from: 8))
+                            questionUserList = Array(data.onQuestionUserList.prefix(upTo: 8))
                             questionUserList.append(QuestionUser())
                         }
                         observer.onNext(Mutation.requestSeniorList(seniorList: questionUserList))
@@ -141,5 +141,9 @@ extension PersonalQuestionReactor {
             }
             return Disposables.create()
         }
+    }
+    
+    private func makeEmptyPostListResModel() -> [PostListResModel] {
+        return [PostListResModel(postID: -1, type: "", title: "", content: "", createdAt: "", majorName: "", writer: CommunityWriter(writerID: 0, nickname: ""), isAuthorized: false, commentCount: 0, like: Like(isLiked: false, likeCount: 0))]
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		3332359D28EF482000F92793 /* SendContentSizeDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3332359C28EF482000F92793 /* SendContentSizeDelegate.swift */; };
 		33393ADF27D4E85E007F2585 /* NSLayoutConstraint+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33393ADE27D4E85E007F2585 /* NSLayoutConstraint+.swift */; };
 		3341DB6C27D7D728007E65B6 /* SendBlockedInfoDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3341DB6B27D7D728007E65B6 /* SendBlockedInfoDelegate.swift */; };
+		33463ADA290662B000323072 /* AvailableQuestionPersonEmptyCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33463AD9290662B000323072 /* AvailableQuestionPersonEmptyCVC.swift */; };
 		334D2E0427914C8800A4CA23 /* WriteQuestionSB.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 334D2E0327914C8800A4CA23 /* WriteQuestionSB.storyboard */; };
 		335D91AB28D05758000C05EF /* QuestionToPersonHeaderTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335D91AA28D05758000C05EF /* QuestionToPersonHeaderTVC.swift */; };
 		335D91AF28D062FF000C05EF /* SeeMoreQuestionPersonCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335D91AE28D062FF000C05EF /* SeeMoreQuestionPersonCVC.swift */; };
@@ -409,6 +410,7 @@
 		3332359C28EF482000F92793 /* SendContentSizeDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendContentSizeDelegate.swift; sourceTree = "<group>"; };
 		33393ADE27D4E85E007F2585 /* NSLayoutConstraint+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLayoutConstraint+.swift"; sourceTree = "<group>"; };
 		3341DB6B27D7D728007E65B6 /* SendBlockedInfoDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendBlockedInfoDelegate.swift; sourceTree = "<group>"; };
+		33463AD9290662B000323072 /* AvailableQuestionPersonEmptyCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailableQuestionPersonEmptyCVC.swift; sourceTree = "<group>"; };
 		334D2E0327914C8800A4CA23 /* WriteQuestionSB.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = WriteQuestionSB.storyboard; sourceTree = "<group>"; };
 		335D91AA28D05758000C05EF /* QuestionToPersonHeaderTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionToPersonHeaderTVC.swift; sourceTree = "<group>"; };
 		335D91AE28D062FF000C05EF /* SeeMoreQuestionPersonCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeeMoreQuestionPersonCVC.swift; sourceTree = "<group>"; };
@@ -1086,6 +1088,7 @@
 		331C53782795C7B50052B309 /* CVC */ = {
 			isa = PBXGroup;
 			children = (
+				33463AD9290662B000323072 /* AvailableQuestionPersonEmptyCVC.swift */,
 				331C53762795B9CA0052B309 /* QuestionPersonCVC.swift */,
 				335D91AE28D062FF000C05EF /* SeeMoreQuestionPersonCVC.swift */,
 				336216B028D1DBFD00FEA3E9 /* AvailableQuestionPersonCVC.swift */,
@@ -2337,6 +2340,7 @@
 				331364A62785D90D00E0C118 /* NotificationMainVC.swift in Sources */,
 				5CC0BFD6279873B400B96905 /* ReadNotificationDataModel.swift in Sources */,
 				33856370278DC74D003C60A6 /* BaseTVC.swift in Sources */,
+				33463ADA290662B000323072 /* AvailableQuestionPersonEmptyCVC.swift in Sources */,
 				77AEEB452789AF380016880B /* MajorTVC.swift in Sources */,
 				5CC0BFDF2798A3B900B96905 /* SignAPI.swift in Sources */,
 				33C79DD22881B50D00B6C32C /* CommunityPostList.swift in Sources */,


### PR DESCRIPTION
## 🍎 관련 이슈
closed #568

## 🍎 변경 사항 및 이유
- rx의 datasource는 item이 들어오지 않으면 (empty이면) 반환되지 않는 특성이 있어서, emptyView를 어떻게 구현할지 고민하다가, 만약 현재 넘어온 list가 빈 리스트라면 map을 통해서 서버에서 값이 들어올리 없는 id값을 가진 한개의 데이터 리스트를 넘겨주도록 구현해주었습니다.
- 따라서 서버에서 값이 들어올리 없는 id값이고, index가 0번이라면 => EmptyView를 띄울 상황이므로 emptyCell을 return해주었습니다. 
- 과방메인에서 질문가능한 선배 8명을 추출하는 로직에 문제가 있어 코드를 수정해주었습니다.

## 🍎 PR Point
- 과방 1:1 질문뷰의 질문가능선배 Collectionview, 최근1:1질문 TableView의 emptyView를 구현했습니다.

## 📸 ScreenShot
<img width=375 src="https://user-images.githubusercontent.com/63224278/197466529-e5abeae1-20d9-46d8-b57a-457b1742cf9a.png">
