### PR TITLE
🔨 [QA] 홈 - 커뮤니티, 최근 1:1 게시글 개수 제한 오류 수정

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/TVC/HomeRecentReviewQuestionTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/TVC/HomeRecentReviewQuestionTVC.swift
@@ -128,8 +128,14 @@ extension HomeRecentReviewQuestionTVC {
             case .success(let res):
                 if let data = res as? HomeRecentReviewResponseData {
                     self.recentReviewList = []
-                    for i in 0..<5 {
-                        self.recentReviewList.append(data[i])
+                    if data.count >= 5 {
+                        for i in 0..<5 {
+                            self.recentReviewList.append(data[i])
+                        }
+                    } else {
+                        for i in 0..<data.count {
+                            self.recentReviewList.append(data[i])
+                        }
                     }
                     self.recentCV.reloadData()
                 }
@@ -144,8 +150,15 @@ extension HomeRecentReviewQuestionTVC {
             switch networkResult {
             case .success(let res):
                 if let data = res as? [PostListResModel] {
-                    for i in 0..<5 {
-                        self.recentPersonalQuestionList.append(data[i])
+                    self.recentPersonalQuestionList = []
+                    if data.count >= 5 {
+                        for i in 0..<5 {
+                            self.recentPersonalQuestionList.append(data[i])
+                        }
+                    } else {
+                        for i in 0..<data.count {
+                            self.recentPersonalQuestionList.append(data[i])
+                        }
                     }
                     self.recentCV.reloadData()
                 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/HomeVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/HomeVC.swift
@@ -346,8 +346,10 @@ extension HomeVC {
             switch networkResult {
             case .success(let res):
                 if let data = res as? [PostListResModel] {
-                    for i in 0..<3 {
-                        self.communityList.append(data[i])
+                    if data.count >= 3 {
+                        for i in 0..<3 {
+                            self.communityList.append(data[i])
+                        }
                     }
                     self.backgroundTV.reloadData()
                 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/HomeVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/HomeVC.swift
@@ -346,6 +346,7 @@ extension HomeVC {
             switch networkResult {
             case .success(let res):
                 if let data = res as? [PostListResModel] {
+                    self.communityList = []
                     if data.count >= 3 {
                         for i in 0..<3 {
                             self.communityList.append(data[i])


### PR DESCRIPTION

## 🍎 관련 이슈
closed #585

## 🍎 변경 사항 및 이유
* [전체]중앙, 서울여대 계정으로 로그인시 앱충돌 발생 해결
* [홈화면] 최근1대1 질문 홈 뷰에서 5개만 노출 

## 🍎 PR Point
* 로그인 시 앱 충돌나던 게 홈에서 기본적으로 띄워야 할 데이터 개수가 부족해서 그러는 건데요...! 저번에 물어봤을 때 (기획인지 서버인지 기억안남) 릴리즈 시 무조건 더미데이터 넣어서 릴리즈한다고 했어가지고 이런 상황이 발생하지는 않겠지만..!! 그래서 엠티뷰도 없거든여?? 아무튼 그래서 충돌 안 나게만 처리해 두었습니다!

## 📸 ScreenShot

| 중앙대 | 서울여대 | 최근 1:1 질문 노출 개수 |
| - | - | - |
|  ![EC265FE9-BEFB-4C1E-894C-F9AEE43B8EFC_4_5005_c](https://user-images.githubusercontent.com/43312096/197955664-6265551d-92e3-42e7-a402-a8e0add2b358.jpeg) |  ![94D0873F-D96F-470E-A04B-1637EB02707A_4_5005_c](https://user-images.githubusercontent.com/43312096/197955623-b7ca1462-4ca8-4161-9d78-0fda9c519a72.jpeg) |  ![RPReplay_Final1666767028](https://user-images.githubusercontent.com/43312096/197956698-18ac9992-5d6b-4e31-ba63-db238de41246.gif)  |
