### PR TITLE
🔨 [FIX] 알림 탭 Empty뷰 처리

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Notification/GetNotiListResponseData.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Notification/GetNotiListResponseData.swift
@@ -21,18 +21,14 @@ struct NotificationList: Codable {
     var notificationID: Int
     var sender: Sender
     var isRead: Bool
-    var content: String
-    var createdAt: String
+    var content, createdAt: String
     var postID: Int
     var commentID: Int?
     var notificationTypeID: Int
 
     enum CodingKeys: String, CodingKey {
         case notificationID = "notificationId"
-        case sender = "sender"
-        case isRead = "isRead"
-        case content = "content"
-        case createdAt = "createdAt"
+        case sender, isRead, content, createdAt
         case postID = "postId"
         case commentID = "commentId"
         case notificationTypeID = "notificationTypeId"
@@ -41,12 +37,12 @@ struct NotificationList: Codable {
     // MARK: - Sender
     struct Sender: Codable {
         var senderID: Int
-        var senderName: String
+        var nickname: String
         var profileImageID: Int
 
         enum CodingKeys: String, CodingKey {
             case senderID = "senderId"
-            case senderName = "senderName"
+            case nickname
             case profileImageID = "profileImageId"
         }
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Notification/Cell/NotificationTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Notification/Cell/NotificationTVC.swift
@@ -51,10 +51,10 @@ extension NotificationTVC {
         redCircleImgView.isHidden = data.isRead
         profileImgView.image = UIImage(named: "profileImage\(data.sender.profileImageID)")
         
-        titleLabel.text = getTitleLabelText(notiTypeInt: data.notificationTypeID, nickname: data.sender.senderName)
+        titleLabel.text = getTitleLabelText(notiTypeInt: data.notificationTypeID, nickname: data.sender.nickname)
         contentLabel.text = "\(data.content)"
         timeLabel.text = data.createdAt.serverTimeToString(forUse: .forNotification)
-        titleLabel.setTextColor(targetStringList: ["마이페이지", "\(data.notificationTypeID.getNotiType().rawValue)", "1:1 질문글", "작성하신 1:1 질문글", "작성하신 커뮤니티 글", "답글을 작성하신 커뮤니티 글", "커뮤니티에 \(data.sender.senderName) 질문글"], color: .mainDefault)
+        titleLabel.setTextColor(targetStringList: ["마이페이지", "\(data.notificationTypeID.getNotiType().rawValue)", "1:1 질문글", "작성하신 1:1 질문글", "작성하신 커뮤니티 글", "답글을 작성하신 커뮤니티 글", "커뮤니티에 \(data.sender.nickname) 질문글"], color: .mainDefault)
     }
     
     private func getTitleLabelText(notiTypeInt: Int, nickname: String?) -> String {


### PR DESCRIPTION

## 🍎 관련 이슈
closed #581 

## 🍎 변경 사항 및 이유
* 엠티 뷰가 문제가 아니라 Notification 모델 변경에 따른 통신 문제였어서 모델을 수정했습니다~!


## 📸 ScreenShot
| 모델명 수정 후 정상적으로 통신하는 모습.. | 알림 없을 때 |
| - | - |
| ![IMG_9928](https://user-images.githubusercontent.com/43312096/197960739-c694c08a-e277-4c07-b937-e13371b871c2.PNG) | ![IMG_9929](https://user-images.githubusercontent.com/43312096/197960811-422002e5-9588-47d1-aa3a-863310b80af4.PNG) |

