### PR TITLE
🔨 [FIX] 홈-커뮤니티, 마이페이지 TableView Height 못 잡는 문제 수정

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/TVC/HomeCommunityTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/TVC/HomeCommunityTVC.swift
@@ -25,6 +25,7 @@ final class HomeCommunityTVC: BaseTVC {
     // MARK: Properties
     var communityList: [PostListResModel] = []
     var didSelectItem: ((Int) -> ())?
+    private let contentSizeObserverKeyPath = "contentSize"
     
     // MARK: Initialization
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -37,11 +38,6 @@ final class HomeCommunityTVC: BaseTVC {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        updateRecentPostTVHeight()
-    }
-    
     private func setRecentPostTV() {
         recentPostTV.dataSource = self
         recentPostTV.delegate = self
@@ -51,12 +47,17 @@ final class HomeCommunityTVC: BaseTVC {
         recentPostTV.removeSeparatorsOfEmptyCellsAndLastCell()
     }
     
-    func updateRecentPostTVHeight() {
-        self.recentPostTV.reloadData()
-        self.recentPostTV.snp.updateConstraints {
-            $0.height.equalTo(self.recentPostTV.contentSize.height)
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        debugPrint(#function)
+        if (keyPath == contentSizeObserverKeyPath) {
+            if let newValue = change?[.newKey] {
+                let newSize  = newValue as! CGSize
+                self.recentPostTV.layoutIfNeeded()
+                self.recentPostTV.snp.updateConstraints {
+                    $0.height.equalTo(newSize.height)
+                }
+            }
         }
-        self.recentPostTV.layoutIfNeeded()
     }
 }
 
@@ -84,7 +85,7 @@ extension HomeCommunityTVC: UITableViewDelegate {
 extension HomeCommunityTVC {
     private func configureUI() {
         contentView.addSubviews([recentPostTV])
-        
+        recentPostTV.addObserver(self, forKeyPath: contentSizeObserverKeyPath, options: .new, context: nil)
         recentPostTV.snp.makeConstraints {
             $0.top.equalToSuperview().inset(4)
             $0.horizontalEdges.equalToSuperview().inset(16)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/HomeVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/HomeVC.swift
@@ -227,7 +227,6 @@ extension HomeVC: UITableViewDataSource {
                 case 1:
                     guard let communityCell = tableView.dequeueReusableCell(withIdentifier: HomeCommunityTVC.className) as? HomeCommunityTVC else { return HomeCommunityTVC() }
                     communityCell.communityList = self.communityList
-                    communityCell.updateRecentPostTVHeight()
                     communityCell.didSelectItem = { postID in
                         self.navigator?.instantiateVC(destinationViewControllerType: CommunityPostDetailVC.self, useStoryboard: true, storyboardName: "CommunityPostDetailSB", naviType: .push) { postDetailVC in
                             postDetailVC.postID = postID

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageLikeListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageMain/VC/LikeList/MypageLikeListVC.swift
@@ -75,6 +75,7 @@ class MypageLikeListVC: BaseVC {
         self.likeListTV.removeObserver(self, forKeyPath: contentSizeObserverKeyPath)
     }
     
+    // MARK: Functions
     private func setlikeListTV() {
         likeListTV.dataSource = self
         likeListTV.delegate = self

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
@@ -342,7 +342,8 @@ extension MypagePostListVC {
         
         postListSV.snp.makeConstraints {
             $0.top.equalTo(postListSegmentControl.snp.bottom).offset(18)
-            $0.left.right.bottom.equalToSuperview()
+            $0.left.right.equalToSuperview()
+            $0.bottom.equalTo(view.safeAreaLayoutGuide)
         }
         
         contentView.snp.makeConstraints {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypagePostList/VC/MypagePostListVC.swift
@@ -58,7 +58,7 @@ class MypagePostListVC: BaseVC {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        isPostOrAnswer ? getMypageMyPersonalQuestionList() : getMypageMyAnswerList()
+        isPostOrAnswer ? (isPersonalQuestionOrCommunity ? getMypageMyPersonalQuestionList() : getMypageCommunityPostList()) : getMypageMyAnswerList()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -85,7 +85,7 @@ class MypagePostListVC: BaseVC {
     
     @objc private func didChangeValue(segment: UISegmentedControl) {
         isPersonalQuestionOrCommunity = postListSegmentControl.selectedSegmentIndex == 0
-        isPostOrAnswer ? (isPersonalQuestionOrCommunity ?  getMypageMyPersonalQuestionList() : getMypageCommunityPostList()) : getMypageMyAnswerList()
+        isPostOrAnswer ? (isPersonalQuestionOrCommunity ? getMypageMyPersonalQuestionList() : getMypageCommunityPostList()) : getMypageMyAnswerList()
     }
     
     private func makeScreenAnalyticsForMyPostList() {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/SB/MypageUserVC.storyboard
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/SB/MypageUserVC.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -20,7 +21,7 @@
         <!--Mypage UserVC-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController storyboardIdentifier="MypageUserVC" id="Y6W-OH-hqX" customClass="MypageUserVC" customModule="NadoSunbae_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="MypageUserVC" id="Y6W-OH-hqX" customClass="MypageUserVC" customModule="NadoSunbae" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="948"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -32,7 +33,7 @@
                                     <constraint firstAttribute="height" constant="104" id="RQW-of-mQA"/>
                                 </constraints>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fn2-Vh-Q2Y" customClass="NadoSunbaeNaviBar" customModule="NadoSunbae_iOS" customModuleProvider="target">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fn2-Vh-Q2Y" customClass="NadoSunbaeNaviBar" customModule="NadoSunbae" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="48" width="375" height="56"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
@@ -43,7 +44,7 @@
                                 <rect key="frame" x="0.0" y="104" width="375" height="810"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uJl-mK-oSe" userLabel="Content View">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="787.33333333333337"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="387.33333333333331"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1KN-MV-zEV">
                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="32"/>
@@ -228,10 +229,10 @@
                                                 </connections>
                                             </button>
                                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="kXs-pO-uLu">
-                                                <rect key="frame" x="24" y="267.33333333333326" width="327" height="500"/>
+                                                <rect key="frame" x="24" y="267.33333333333331" width="327" height="100"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="500" id="9Eh-OO-Be7"/>
+                                                    <constraint firstAttribute="height" constant="100" id="9Eh-OO-Be7"/>
                                                 </constraints>
                                                 <inset key="separatorInset" minX="8" minY="0.0" maxX="8" maxY="0.0"/>
                                                 <sections/>

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC+TV.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/MypageUser/VC/MypageUserVC+TV.swift
@@ -25,13 +25,6 @@ extension MypageUserVC: UITableViewDataSource {
 
 // MARK: - UITableViewDelegate
 extension MypageUserVC: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return UITableView.automaticDimension
-    }
-    
-    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 80
-    }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         


### PR DESCRIPTION


## 🍎 관련 이슈
closed #592

## 🍎 변경 사항 및 이유
* 홈 뷰에서 최근 커뮤니티 글 테이블뷰 마지막 부분이 잘리던 문제를 수정하였습니다.
* 마이페이지 > 내가 쓴 글에서 특정 개수의 데이터가 있을 때 스크롤 안 되던 문제를 해결했습니다.
* 마이페이지 > 내가 쓴 글 > 커뮤니티 > 커뮤니티 상세보기에 진입했다가 뒤로 돌아갔을 때 제대로 로드되지 않던 문제를 수정했습니다.
* 선배 개인페이지 1:1 질문에서 테이블뷰 마지막 부분이 잘리던 문제를 수정하였습니다.

## 🍎 PR Point
* 테이블뷰 높이 개빡친다..:)


