### PR TITLE
🔨 [FIX] 커뮤니티 글 작성/수정 QA 대응

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/WritePost/BaseWritePostVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/WritePost/BaseWritePostVC.swift
@@ -12,9 +12,9 @@ import RxSwift
 class BaseWritePostVC: BaseVC {
 
     // MARK: Properties
-    private let questionSV = UIScrollView()
+    let questionSV = UIScrollView()
     private let disposeBag = DisposeBag()
-    private var questionTextViewLineCount: Int = 1
+    var questionTextViewLineCount: Int = 1
     private var majorID: Int = MajorInfo.shared.selectedMajorID ?? UserDefaults.standard.value(forKey: UserDefaults.Keys.FirstMajorID) as! Int
     
     let questionWriteNaviBar = NadoSunbaeNaviBar().then {
@@ -172,6 +172,7 @@ extension BaseWritePostVC {
     }
     
     /// textView의 상태에 따라 스크롤뷰를 Up, Down 하는 메서드
+    @objc
     func scollByTextViewState(textView: UITextView) {
         var contentOffsetY = questionSV.contentOffset.y
         var isLineAdded = true
@@ -200,6 +201,11 @@ extension BaseWritePostVC {
             }
         }
         questionTextViewLineCount = textView.numberOfLines()
+    }
+    
+    /// questionWriteNaviBar의 rightActivateBtn의 활성상태를 설정하는 메서드
+    func setNaviBarRightActivateState(isActivated: Bool) {
+        questionWriteNaviBar.rightActivateBtn.isActivated = isActivated
     }
 }
 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
@@ -33,6 +33,7 @@ class WriteQuestionVC: BaseWritePostVC {
         setUpAlertMsgByEditState()
         setHighlightViewState(textField: questionTitleTextField, highlightView: textHighlightView)
         setActivateBtnState(textField: questionTitleTextField, textView: questionWriteTextView)
+        setNaviBarRightActivateState(isActivated: false)
     }
 }
 
@@ -47,7 +48,6 @@ extension WriteQuestionVC {
             questionWriteTextView.setDefaultStyle(isUsePlaceholder: false, placeholderText: "")
             questionTitleTextField.text = originTitle
             questionWriteTextView.text = originContent
-            questionWriteNaviBar.rightActivateBtn.isActivated = true
         } else {
             questionWriteTextView.setDefaultStyle(isUsePlaceholder: true, placeholderText: "선배에게 1:1 질문을 남겨보세요.\n선배가 답변해 줄 거에요!")
         }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
@@ -81,9 +81,11 @@ extension WriteQuestionVC {
         }
         
         /// dismissBtn Press
-        questionWriteNaviBar.dismissBtn.press {
+        questionWriteNaviBar.dismissBtn.press { [weak self] in
+            guard let self = self else { return }
+            
             guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
-            alert.showNadoAlert(vc: self, message: self.dismissAlertMsg, confirmBtnTitle: "계속 작성", cancelBtnTitle: "나갈래요")
+            alert.showNadoAlert(vc: self, message: self.dismissAlertMsg, confirmBtnTitle: self.isEditState ? "계속 수정" : "계속 작성", cancelBtnTitle: "나갈래요")
             alert.cancelBtn.press {
                 self.dismiss(animated: true, completion: nil)
             }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityWriteVC.swift
@@ -169,25 +169,30 @@ extension CommunityWriteVC {
             .disposed(by: disposeBag)
         
         questionWriteNaviBar.rightActivateBtn.rx.tap
-            .subscribe(onNext: {
-                self.nadoAlert?.showNadoAlert(vc: self, message: self.confirmAlertMsg, confirmBtnTitle: "네", cancelBtnTitle: "아니요")
+            .subscribe(onNext: { [weak self] in
+                guard let self = self else { return }
+                
+                guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+                alert.showNadoAlert(vc: self, message: self.confirmAlertMsg, confirmBtnTitle: "네", cancelBtnTitle: "아니요")
+                alert.confirmBtn.press {
+                    if self.isEditState {
+                        reactor.action.onNext(.tapQuestionEditBtn(postID: self.postID ?? 0, title: self.questionTitleTextField.text ?? "", content: self.questionWriteTextView.text ?? ""))
+                    } else {
+                        reactor.action.onNext(.tapQuestionWriteBtn(type: self.selectedCategory, majorID: self.majorID ?? MajorIDConstants.regardlessMajorID, answererID: 0, title: self.questionTitleTextField.text ?? "", content: self.questionWriteTextView.text))
+                    }
+                }
             })
             .disposed(by: disposeBag)
         
-        nadoAlert?.confirmBtn.rx.tap.map{
-            if self.isEditState {
-                return CommunityWriteReactor.Action.tapQuestionEditBtn(postID: self.postID ?? 0, title: self.questionTitleTextField.text ?? "", content: self.questionWriteTextView.text ??
-                "")
-            } else {
-                return CommunityWriteReactor.Action.tapQuestionWriteBtn(type: self.selectedCategory, majorID: self.majorID ?? MajorIDConstants.regardlessMajorID, answererID: 0, title: self.questionTitleTextField.text ?? "", content: self.questionWriteTextView.text)
-            }
-        }
-        .bind(to: reactor.action)
-        .disposed(by: disposeBag)
-        
         questionWriteNaviBar.dismissBtn.rx.tap
-            .subscribe(onNext: {
-                self.nadoAlert?.showNadoAlert(vc: self, message: self.dismissAlertMsg, confirmBtnTitle: "계속 작성", cancelBtnTitle: "나갈래요")
+            .subscribe(onNext: { [weak self] in
+                guard let self = self else { return }
+                
+                guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+                alert.showNadoAlert(vc: self, message: self.dismissAlertMsg, confirmBtnTitle: self.isEditState ? "계속 수정" : "계속 작성", cancelBtnTitle: "나갈래요")
+                alert.cancelBtn.press {
+                    self.dismiss(animated: true, completion: nil)
+                }
             })
             .disposed(by: disposeBag)
         

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityWriteVC.swift
@@ -78,6 +78,7 @@ final class CommunityWriteVC: BaseWritePostVC, View {
         setUpCategoryCVByEditState()
         setHighlightViewState(textField: questionTitleTextField, highlightView: textHighlightView)
         setActivateBtnState(textField: questionTitleTextField, textView: questionWriteTextView)
+        setNaviBarRightActivateState(isActivated: false)
     }
     
     func bind(reactor: CommunityWriteReactor) {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityWriteVC.swift
@@ -93,7 +93,7 @@ extension CommunityWriteVC {
         contentView.addSubviews([selectMajorLabel, majorSelectTextField, majorSelectBtn, categoryLabel, categoryCV, questionDescLabel, partitionBar])
         
         selectMajorLabel.snp.makeConstraints {
-            $0.top.equalTo(questionWriteNaviBar.snp.bottom).offset(24)
+            $0.top.equalToSuperview().offset(24)
             $0.leading.equalToSuperview().offset(24)
         }
         
@@ -314,6 +314,36 @@ extension CommunityWriteVC {
         slideVC.selectCommunityDelegate = self
         self.present(slideVC, animated: true)
     }
+    
+    override func scollByTextViewState(textView: UITextView) {
+        var contentOffsetY = questionSV.contentOffset.y
+        var isLineAdded = true
+        
+        if questionTextViewLineCount != textView.numberOfLines() {
+            
+            if questionTextViewLineCount > textView.numberOfLines() {
+                isLineAdded = false
+            } else {
+                isLineAdded = true
+            }
+            
+            if  isLineAdded && textView.numberOfLines() > 2 && questionSV.contentOffset.y < 193 {
+                contentOffsetY += 38
+                questionSV.setContentOffset(CGPoint(x: 0, y: contentOffsetY), animated: true)
+                
+            } else if !isLineAdded && questionTextViewLineCount < 9 && questionSV.contentOffset.y > 0 {
+                
+                if contentOffsetY - 38 > 0 {
+                    contentOffsetY -= 38
+                    questionSV.setContentOffset(CGPoint(x: 0, y: contentOffsetY), animated: true)
+                } else {
+                    contentOffsetY = 0
+                    questionSV.setContentOffset(CGPoint(x: 0, y: 0), animated: true)
+                }
+            }
+        }
+        questionTextViewLineCount = textView.numberOfLines()
+    }
 }
 
 // MARK: - UICollectionViewDelegateFlowLayout
@@ -354,6 +384,10 @@ extension CommunityWriteVC: UITextViewDelegate {
         if textView.textColor == .gray2 {
             textView.text = nil
             textView.textColor = .mainText
+        }
+        
+        UIView.animate(withDuration: 0.5) { [weak self] in
+            self?.questionSV.contentOffset.y = 193
         }
     }
     


### PR DESCRIPTION
## 🍎 관련 이슈
closed #596
closed #600

## 🍎 변경 사항 및 이유
- BaseWritePostVC를 상속받아 사용하는 CommunityWriteVC에서 접근해야할 메서드와 프로퍼티들이 있어서 접근지정자를 변경해주었습니다!

## 🍎 PR Point
- [커뮤니티] 커뮤니티 작성뷰에서 “글을 올리시겠습니까?” 아니요 누르면 자동으로 작성중이던 화면이 닫힘/”페이지를 나가면 작성중인 글이 삭제돼요” 계속 작성을 눌러도 닫힘
- [커뮤니티] 커뮤니티 글 작성시 글이 길어지면 입력 창에 내용이 가림
- [커뮤니티] 글 수정 _ default 시에도 “완료”버튼 색이 칠해져 있음
위 QA들을 해결했습니다!

## 📸 ScreenShot
 커뮤니티 글 작성시 글이 길어지면 입력 창에 내용이 가림 > 부분만 동영상 첨부하겠습니다!

https://user-images.githubusercontent.com/63224278/198057287-0aa101b5-e32a-4f2a-b21d-acb8fc2ec4a6.MP4

