### PR TITLE
🔨 [FIX] 과방 메인 1:1 질문탭 선배 닉네임 label이 겹쳐보이는 오류 해결

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/CVC/QuestionPersonCVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/CVC/QuestionPersonCVC.swift
@@ -17,6 +17,7 @@ class QuestionPersonCVC: CodeBaseCVC {
     }
     
     private (set) lazy var nicknameLabel = UILabel().then {
+        $0.textAlignment = .center
         $0.textColor = .nadoBlack
         $0.font = .PretendardSB(size: 14.0)
         $0.sizeToFit()
@@ -66,6 +67,7 @@ extension QuestionPersonCVC {
         nicknameLabel.snp.makeConstraints {
             $0.top.equalTo(personProfileImageView.snp.bottom).offset(8)
             $0.centerX.equalTo(personProfileImageView)
+            $0.width.equalTo(68)
         }
         
         majorNameStackView.snp.makeConstraints {


### PR DESCRIPTION
## 🍎 관련 이슈
closed #609

## 🍎 PR Point
-  과방 메인 1:1 질문탭 선배 닉네임 label이 겹쳐보이는 오류를 해결했습니다.
-  과방 메인 1:1 질문탭 선배 닉네임 label이 길 경우 ... 으로 표시되도록 width를 제한했습니다.

## 📸 ScreenShot
<img width=375 src="https://user-images.githubusercontent.com/63224278/198064628-28fb8ec5-a7aa-4a95-95bb-e9aa0d22ed36.png">

