### PR TITLE
🔨 [FIX] 1:1 질문 상세보기 "이 선배에게 질문하기" 버튼을 통해 질문창으로 이동후 dismiss 버튼 눌렀을 때 root로 이동되지 않도록 수정

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/PersonalQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/PersonalQuestionVC.swift
@@ -197,12 +197,14 @@ extension PersonalQuestionVC: View {
         recentQuestionTV.rx.modelSelected(PostListResModel.self)
             .subscribe(onNext: { [weak self] item in
                 self?.divideUserPermission() {
-                    self?.navigator?.instantiateVC(destinationViewControllerType: DefaultQuestionChatVC.self, useStoryboard: true, storyboardName: "QuestionChatSB", naviType: .push) { postDetailVC in
-                        postDetailVC.hidesBottomBarWhenPushed = true
-                        postDetailVC.naviStyle = .push
-                        postDetailVC.postID = item.postID
-                        postDetailVC.isAuthorized = item.isAuthorized
-                    }
+                    guard let postDetailVC = UIStoryboard.init(name: "QuestionChatSB", bundle: nil).instantiateViewController(withIdentifier: DefaultQuestionChatVC.className) as? DefaultQuestionChatVC else { return }
+                    let postDetailNC = UINavigationController(rootViewController: postDetailVC)
+                    postDetailVC.naviStyle = .present
+                    postDetailVC.postID = item.postID
+                    postDetailVC.isAuthorized = item.isAuthorized
+                    postDetailNC.modalPresentationStyle = .fullScreen
+                    postDetailNC.navigationBar.isHidden = true
+                    self?.present(postDetailNC, animated: true)
                 }
             })
             .disposed(by: disposeBag)

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -381,7 +381,6 @@ extension DefaultQuestionChatVC {
                             writeQuestionVC.answererID = self.answererID
                             writeQuestionVC.isFromQuestionDetailVC = true
                         }
-                        self.navigationController?.popToRootViewController(animated: true)
                     }
                 }
             }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -244,7 +244,7 @@ extension DefaultQuestionChatVC {
             case .present:
                 questionNaviBar.setUpNaviStyle(state: .dismissWithCustomRightBtn)
                 questionNaviBar.dismissBtn.press(vibrate: true, for: .touchUpInside) {
-                    self.dismiss(animated: true)
+                    self.view.window?.rootViewController?.presentedViewController!.dismiss(animated: true, completion: nil)
                 }
             }
             questionNaviBar.rightCustomBtn.isHidden = true

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/WriteQuestionVC.swift
@@ -160,13 +160,14 @@ extension WriteQuestionVC {
                     self.dismiss(animated: true) { [weak self] in
                         guard let self = self else { return }
                         if self.isFromQuestionDetailVC {
-                            let questionChatSB = UIStoryboard(name: "QuestionChatSB", bundle: nil)
-                            guard let questionChatVC = questionChatSB.instantiateViewController(withIdentifier: DefaultQuestionChatVC.className) as? DefaultQuestionChatVC else { return }
+                            guard let questionChatVC = UIStoryboard(name: "QuestionChatSB", bundle: nil).instantiateViewController(withIdentifier: DefaultQuestionChatVC.className) as? DefaultQuestionChatVC else { return }
+                            let questionChatNC = UINavigationController(rootViewController: questionChatVC)
                             questionChatVC.naviStyle = .present
                             questionChatVC.postID = data.post.id
                             questionChatVC.isAuthorized = true
-                            questionChatVC.modalPresentationStyle = .fullScreen
-                            presentingVC.present(questionChatVC, animated: true, completion: nil)
+                            questionChatNC.modalPresentationStyle = .fullScreen
+                            questionChatNC.navigationBar.isHidden = true
+                            presentingVC.present(questionChatNC, animated: false, completion: nil)
                         }
                     }
                 }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #612

## 🍎 PR Point
- 1:1 질문 상세보기 "이 선배에게 질문하기" 버튼을 통해 질문창으로 이동후 dismiss 버튼 눌렀을 때 root로 이동되지 않도록 수정

## 📸 ScreenShot
`이 선배에게 질문하기 클릭하여 새로운 질문 작성 후 X 버튼 클릭시 root로 dismiss`

https://user-images.githubusercontent.com/63224278/198079069-12b2893b-c336-438a-bba0-4c9e2c92c4a8.mp4

<br>

`1:1 질문 작성뷰에서 X 버튼 클릭시 root로 이동하지 않고 한번 dismiss되도록 수정`

https://user-images.githubusercontent.com/63224278/198079151-7093620c-cd33-4e69-843e-d44d09577033.mp4

