### PR TITLE
🔨 [FIX] 커뮤니티 학과 필터 설정 후 다른 탭으로 이동 후 다시 돌아오면 필터 기능 풀려있는 이슈 대응

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/Reactor/CommunityMainReactor.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/Reactor/CommunityMainReactor.swift
@@ -65,6 +65,7 @@ extension CommunityMainReactor {
                 Observable.just(.setLoading(loading: true)),
                 Observable.just(.setFilterBtnState(selected: fill)),
                 Observable.just(.setFilterMajorID(majorID: majorID)),
+                Observable.just(.setTapSegmentState(state: true)),
                 self.requestCommunityList(majorID: majorID, type: type, sort: "recent", search: "")
             ])
         case .requestNewCommunityList(let majorID, let type, let sort, let search):

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/Reactor/CommunityMainReactor.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/Reactor/CommunityMainReactor.swift
@@ -30,7 +30,7 @@ final class CommunityMainReactor: Reactor {
         case setFilterBtnState(selected: Bool)
         case setFilterMajorID(majorID: Int)
         case setRefreshLoading(loading: Bool)
-        case setTapSegmentState(state: Bool)
+        case setAnimateToTopState(state: Bool)
         case setAlertState(showState: Bool, message: String = AlertType.networkError.alertMessage)
         case updateAccessToken(state: Bool, action: Action)
     }
@@ -43,7 +43,7 @@ final class CommunityMainReactor: Reactor {
         var majorList: [MajorInfoModel] = []
         var filterBtnSelected: Bool = false
         var filterMajorID: Int = MajorIDConstants.allMajorID
-        var toSetContentOffsetZero: Bool = true
+        var animateToTopState: Bool = true
         var showAlert: Bool = false
         var alertMessage: String = ""
         var isUpdateAccessToken: Bool = false
@@ -65,7 +65,7 @@ extension CommunityMainReactor {
                 Observable.just(.setLoading(loading: true)),
                 Observable.just(.setFilterBtnState(selected: fill)),
                 Observable.just(.setFilterMajorID(majorID: majorID)),
-                Observable.just(.setTapSegmentState(state: true)),
+                Observable.just(.setAnimateToTopState(state: true)),
                 self.requestCommunityList(majorID: majorID, type: type, sort: "recent", search: "")
             ])
         case .requestNewCommunityList(let majorID, let type, let sort, let search):
@@ -83,7 +83,7 @@ extension CommunityMainReactor {
         case .tapSegmentedControl(let majorID, let type, let sort, let search):
             return Observable.concat([
                 Observable.just(.setLoading(loading: true)),
-                Observable.just(.setTapSegmentState(state: true)),
+                Observable.just(.setAnimateToTopState(state: true)),
                 self.requestCommunityList(majorID: majorID, type: type, sort: sort, search: search)
             ])
         }
@@ -106,8 +106,8 @@ extension CommunityMainReactor {
             newState.refreshLoading = loading
         case .setFilterMajorID(let majorID):
             newState.filterMajorID = majorID
-        case .setTapSegmentState(let state):
-            newState.toSetContentOffsetZero = state
+        case .setAnimateToTopState(let state):
+            newState.animateToTopState = state
         case .setAlertState(let showState, let message):
             newState.showAlert = showState
             newState.alertMessage = message
@@ -132,7 +132,7 @@ extension CommunityMainReactor {
                             observer.onNext(Mutation.requestCommunityList(communityList: data))
                             observer.onNext(Mutation.setRefreshLoading(loading: false))
                             observer.onNext(Mutation.setLoading(loading: false))
-                            observer.onNext(Mutation.setTapSegmentState(state: false))
+                            observer.onNext(Mutation.setAnimateToTopState(state: false))
                             observer.onCompleted()
                         }
                     case .requestErr(let res):

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityMainVC.swift
@@ -71,7 +71,7 @@ final class CommunityMainVC: BaseVC, View {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        reactor?.action.onNext(.requestNewCommunityList(type: PostFilterType(rawValue: communitySegmentedControl.selectedSegmentIndex) ?? .community))
+        reactor?.action.onNext(.requestNewCommunityList(majorID: reactor?.currentState.filterMajorID, type: PostFilterType(rawValue: communitySegmentedControl.selectedSegmentIndex) ?? .community, sort: "recent", search: ""))
     }
     
     func bind(reactor: CommunityMainReactor) {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityMainVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityMainVC.swift
@@ -178,7 +178,7 @@ extension CommunityMainVC {
                     self?.setEmptyLabelIsHidden(isHidden: true)
                 } else {
                     self?.activityIndicator.stopAnimating()
-                    if reactor.currentState.toSetContentOffsetZero {
+                    if reactor.currentState.animateToTopState {
                         self?.communitySV.contentOffset.y = 0
                     }
                     self?.setEmptyLabelIsHidden(isHidden: reactor.currentState.communityList.isEmpty ? false : true)


### PR DESCRIPTION
## 🍎 관련 이슈
closed #625

## 🍎 변경 사항 및 이유
- 변수명 직관적으로 수정

## 🍎 PR Point
- 커뮤니티 학과 필터 설정 후 다른 탭으로 이동 후 다시 돌아오면 필터 기능 풀려있는 이슈를 대응했습니다.

## 📸 ScreenShot


https://user-images.githubusercontent.com/63224278/198109678-6569244b-9eb3-44ba-8959-bc807d2a068d.mp4

