### PR TITLE
🔨 [FIX] 과방 메인 후기 / 1:1 질문 이동시 레이아웃 오류 대응

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Protocol/SendContentSizeDelegate.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Protocol/SendContentSizeDelegate.swift
@@ -8,5 +8,5 @@
 import UIKit
 
 protocol SendContentSizeDelegate {
-    func sendContentSize(height: CGFloat)
+    func sendContentSize(height: CGFloat, comeFrom: String)
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/QuestionToPerson/QuestionEmptyTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/Cell/TVC/QuestionToPerson/QuestionEmptyTVC.swift
@@ -11,7 +11,7 @@ final class QuestionEmptyTVC: UITableViewCell {
 
     // MARK: Properties
     private var emptyQuestionLabel = UILabel().then {
-        $0.text = "등록된 전체 질문이 없습니다."
+        $0.text = "등록된 1:1 질문이 없습니다."
         $0.textColor = .gray2
         $0.font = .PretendardR(size: 14.0)
         $0.sizeToFit()

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/PersonalQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/PersonalQuestionVC.swift
@@ -80,7 +80,7 @@ final class PersonalQuestionVC: BaseVC {
     }
     
     override func viewWillLayoutSubviews() {
-        contentSizeDelegate?.sendContentSize(height: recentQuestionTV.contentSize.height + 264)
+        contentSizeDelegate?.sendContentSize(height: recentQuestionTV.contentSize.height + 264, comeFrom: self.className)
         recentQuestionTV.snp.updateConstraints {
             $0.height.equalTo(recentQuestionTV.contentSize.height)
         }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/ReviewVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/ReviewVC.swift
@@ -129,13 +129,13 @@ extension ReviewVC: View {
 extension ReviewVC {
     private func configureUI() {
         view.addSubviews([reviewTV, emptyView])
+        view.backgroundColor = .paleGray
         
         reviewTV.separatorStyle = .none
         reviewTV.backgroundColor = .paleGray
         
         reviewTV.snp.makeConstraints {
             $0.top.leading.trailing.equalToSuperview()
-            $0.height.equalTo(460)
         }
         
         emptyView.snp.makeConstraints {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/ReviewVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/ReviewVC.swift
@@ -44,7 +44,8 @@ final class ReviewVC: BaseVC {
     }
     
     override func viewWillLayoutSubviews() {
-        contentSizeDelegate?.sendContentSize(height: reviewTV.contentSize.height + 24)
+        contentSizeDelegate?.sendContentSize(height: reviewTV.contentSize.height + 24, comeFrom: self.className)
+        
         reviewTV.snp.updateConstraints {
             $0.height.equalTo(reviewTV.contentSize.height)
         }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #591

## 🍎 변경 사항 및 이유
- 기존에 segment를 누를때마다 reviewVC와 personalVC를 add하고 remove해주었는데, 그 방식을 사용하다 보니 layout constraint간의 충돌이 발생해서 처음부터 reviewVC, personalQuestionVC를 addChild해주고 segment가 눌릴 때마다 해당 VC를 didMove해주는 방식으로 구현방식을 변경하게 되었습니다.
- reviewVC와 personalQuestionVC의 contentSize를 전달하는 방식으로 같은 delegate를 사용하고 있어서 어느 VC에서 온 건지 구분이 필요했기에 SendContentSizeDelegate 함수에서 `comeFrom` 파라미터를 추가했습니다.

## 🍎 PR Point
- 과방 메인 후기 / 1:1 질문 이동시 레이아웃 오류를 대응했습니다.
- 사용자의 매끄러운 UI 경험을 위해서 이미 header가 고정된 상태일 때 ReviewVC, PersonalQuestionVC의 contentSize가 둘다 스크린사이즈의 height값보다 크다면 header가 고정된채로 top으로 이동되게 구현해주었습니다. 

## 📸 ScreenShot
| contentSize가 screenSize보다 클때 | contentSize가 screenSize보다 작을때 | 
| - | - |
| ![Simulator Screen Recording - iPhone 14 Pro - 2022-10-27 at 06 04 47](https://user-images.githubusercontent.com/63224278/198137615-4202c0a5-06f4-4efe-861a-8121de8330d4.gif) | ![Simulator Screen Recording - iPhone 14 Pro - 2022-10-27 at 06 06 04](https://user-images.githubusercontent.com/63224278/198137897-0db5425c-b165-4196-bba1-bf743a4e21e8.gif) |

