### PR TITLE
✨ [FEAT] 바텀시트 학과 즐겨찾기 기능 구현

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Protocol/SendCellBtnStatusDelegate.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Protocol/SendCellBtnStatusDelegate.swift
@@ -1,0 +1,12 @@
+//
+//  SendCellBtnStatusDelegate.swift
+//  NadoSunbae
+//
+//  Created by EUNJU on 2022/10/27.
+//
+
+import Foundation
+
+protocol SendCellBtnStatusDelegate: AnyObject {
+    func sendBtnState(indexPath: IndexPath, selectedState: Bool)
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/HalfModalVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/HalfModalVC.swift
@@ -20,7 +20,7 @@ enum Section: CaseIterable {
     case recent
 }
 
-class HalfModalVC: UIViewController {
+class HalfModalVC: BaseVC {
     
     // MARK: Components
     private let titleLabel = UILabel().then {
@@ -162,16 +162,18 @@ extension HalfModalVC {
         majorTV.separatorStyle = .none
         MajorTVC.register(target: majorTV)
         
-        self.dataSource = UITableViewDiffableDataSource<Section, MajorInfoModel>(tableView: self.majorTV) { (tableView, indexPath, majorName) -> UITableViewCell? in
+        self.dataSource = UITableViewDiffableDataSource<Section, MajorInfoModel>(tableView: self.majorTV) { (tableView, indexPath, majorModel) -> UITableViewCell? in
             guard let cell = tableView.dequeueReusableCell(withIdentifier: MajorTVC.className, for: indexPath) as? MajorTVC else { preconditionFailure() }
             
             cell.cellType = self.cellType
-            cell.setData(majorName: majorName)
+            cell.setData(model: majorModel, indexPath: indexPath)
+            cell.sendBtnStatusDelegate = self
+            
             return cell
         }
     }
     
-    private func applySnapshot(filter: String?) {
+    private func applySnapshot(filter: String?, applyAnimation: Bool = true) {
         let filtered = self.majorList.filter { $0.majorName.contains(filter ?? "")}
         
         snapshot = NSDiffableDataSourceSnapshot<Section, MajorInfoModel>()
@@ -183,7 +185,7 @@ extension HalfModalVC {
             filteredList = filtered
             snapshot.appendItems(filtered)
         }
-        self.dataSource.apply(snapshot, animatingDifferences: true)
+        self.dataSource.apply(snapshot, animatingDifferences: applyAnimation)
     }
     
     private func tapCancelBtnAction() {
@@ -296,6 +298,15 @@ extension HalfModalVC: UITextFieldDelegate {
     }
 }
 
+// MARK: - SendCellBtnStatusDelegate
+extension HalfModalVC: SendCellBtnStatusDelegate {
+    func sendBtnState(indexPath: IndexPath, selectedState: Bool) {
+        majorList[indexPath.row].isFavorites = selectedState
+        filteredList[indexPath.row].isFavorites = selectedState
+        registerFavoriteMajor(majorID: majorList[indexPath.row].majorID)
+    }
+}
+
 // MARK: - UITableViewDelegate
 extension HalfModalVC: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -324,5 +335,40 @@ extension HalfModalVC: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         completeBtn.isActivated = true
         completeBtn.titleLabel?.textColor = UIColor.mainDefault
+    }
+}
+
+// MARK: - Network
+extension HalfModalVC {
+    
+    /// 학과 리스트 조회 메서드
+    private func requestGetMajorList(univID: Int, filterType: String, userID: Int) {
+        PublicAPI.shared.getMajorListAPI(univID: univID, filterType: filterType, userID: userID) { networkResult in
+            switch networkResult {
+                
+            case .success(let res):
+                if let data = res as? [MajorInfoModel] {
+                    MajorInfo.shared.majorList = data
+                }
+            default:
+                self.makeAlert(title: AlertType.networkError.alertMessage)
+            }
+        }
+    }
+    
+    /// 즐겨찾기 등록 및 취소 메서드
+    private func registerFavoriteMajor(majorID: Int) {
+        PublicAPI.shared.registerFavoriteMajorAPI(majorID: majorID) { networkResult in
+            switch networkResult {
+                
+            case .success(let res):
+                if let _ = res as? FavoriteMajorPostResModel {
+                    self.applySnapshot(filter: "", applyAnimation: false)
+                    self.requestGetMajorList(univID: UserDefaults.standard.integer(forKey: UserDefaults.Keys.univID), filterType: "all", userID: UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID))
+                }
+            default:
+                self.makeAlert(title: AlertType.networkError.alertMessage)
+            }
+        }
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/HalfModalVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/HalfModalVC.swift
@@ -303,7 +303,7 @@ extension HalfModalVC: SendCellBtnStatusDelegate {
     func sendBtnState(indexPath: IndexPath, selectedState: Bool) {
         majorList[indexPath.row].isFavorites = selectedState
         filteredList[indexPath.row].isFavorites = selectedState
-        registerFavoriteMajor(majorID: majorList[indexPath.row].majorID)
+        registerFavoriteMajor(majorID: filteredList[indexPath.row].majorID)
     }
 }
 
@@ -363,7 +363,7 @@ extension HalfModalVC {
                 
             case .success(let res):
                 if let _ = res as? FavoriteMajorPostResModel {
-                    self.applySnapshot(filter: "", applyAnimation: false)
+                    self.applySnapshot(filter: self.searchTextField.text?.isEmpty ?? false ? "" : self.searchTextField.text, applyAnimation: false)
                     self.requestGetMajorList(univID: UserDefaults.standard.integer(forKey: UserDefaults.Keys.univID), filterType: "all", userID: UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID))
                 }
             default:

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/MajorTVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/MajorTVC.swift
@@ -36,6 +36,8 @@ class MajorTVC: CodeBaseTVC {
     
     // MARK: Properties
     var cellType: MajorCellType = .basic
+    var sendBtnStatusDelegate: SendCellBtnStatusDelegate?
+    private var indexPath: IndexPath?
     
     // MARK: Life Cycle
     override func setViews() {
@@ -49,6 +51,7 @@ class MajorTVC: CodeBaseTVC {
     override func prepareForReuse() {
         super.prepareForReuse()
         starBtn.isHidden = false
+        starBtn.isSelected = false
     }
     
     override func setSelected(_ selected: Bool, animated: Bool) {
@@ -117,18 +120,23 @@ extension MajorTVC {
 extension MajorTVC {
     private func tapStarBtnAction() {
         starBtn.press { [weak self] in
-            self?.starBtn.isSelected.toggle()
+            guard let self = self else { return }
+        
+            self.starBtn.isSelected.toggle()
+            self.sendBtnStatusDelegate?.sendBtnState(indexPath: self.indexPath ?? IndexPath(item: 0, section: 0), selectedState: self.starBtn.isSelected)
         }
     }
     
     /// Label에 학과 이름 setting하는 함수
-    func setData(majorName: MajorInfoModel) {
-        majorNameLabel.text = majorName.majorName
-        starBtn.isHidden = majorName.majorName == "학과 무관" || majorName.majorName == "미진입" ? true : false
+    func setData(model: MajorInfoModel, indexPath: IndexPath) {
+        majorNameLabel.text = model.majorName
+        starBtn.isHidden = model.majorName == "학과 무관" || model.majorName == "미진입" ? true : false
+        starBtn.isSelected = model.isFavorites
+        
+        self.indexPath = indexPath
     }
     
     func setMajorNameLabel(data: String) {
         majorNameLabel.text = data
     }
 }
-

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/PublicAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/PublicAPI.swift
@@ -32,6 +32,24 @@ class PublicAPI: BaseAPI {
         }
     }
     
+    /// [POST] 즐겨찾기 학과 등록 및 취소 API
+    func registerFavoriteMajorAPI(majorID: Int, completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        publicProvider.request(.registerFavoriteMajor(majorID: majorID)) { result in
+            switch result {
+                
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                let networkResult = self.judgeStatus(by: statusCode, data, FavoriteMajorPostResModel.self)
+
+                completion(networkResult)
+                
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
+    
     /// [POST] 차단/차단해제 요청
     func requestBlockUnBlockUser(blockUserID: Int, completion: @escaping (NetworkResult<Any>) -> (Void)) {
         publicProvider.request(.requestBlockUnBlockUser(blockUserID: blockUserID)) { result in

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/PublicAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/PublicAPI.swift
@@ -15,8 +15,8 @@ class PublicAPI: BaseAPI {
     private override init() {}
     
     /// [GET] 학과 리스트 조회  API
-    func getMajorListAPI(univID: Int, filterType: String, completion: @escaping (NetworkResult<Any>) -> (Void)) {
-        publicProvider.request(.getMajorList(univID: univID, filter: filterType)) { result in
+    func getMajorListAPI(univID: Int, filterType: String, userID: Int, completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        publicProvider.request(.getMajorList(univID: univID, filter: filterType, userID: userID)) { result in
             switch result {
                 
             case .success(let response):

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Public/FavoriteMajorPostResModel.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Public/FavoriteMajorPostResModel.swift
@@ -1,0 +1,20 @@
+//
+//  FavoriteMajorPostResModel.swift
+//  NadoSunbae
+//
+//  Created by EUNJU on 2022/10/27.
+//
+
+import Foundation
+
+// MARK: - FavoriteMajorPostResModel
+struct FavoriteMajorPostResModel: Codable {
+    let majorID, userID: Int
+    let isDeleted: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case majorID = "majorId"
+        case userID = "userId"
+        case isDeleted
+    }
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Public/MajorInfoModel.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIModels/Models/Public/MajorInfoModel.swift
@@ -11,9 +11,10 @@ import Foundation
 struct MajorInfoModel: Codable, Hashable {
     let majorID: Int
     let majorName: String
+    var isFavorites: Bool
 
     enum CodingKeys: String, CodingKey {
         case majorID = "majorId"
-        case majorName
+        case majorName, isFavorites
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/PublicService.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/MoyaTarget/PublicService.swift
@@ -9,7 +9,8 @@ import Foundation
 import Moya
 
 enum PublicService {
-    case getMajorList(univID: Int, filter: String)
+    case getMajorList(univID: Int, filter: String, userID: Int)
+    case registerFavoriteMajor(majorID: Int)
     case requestBlockUnBlockUser(blockUserID: Int)
     case requestReport(reportedTargetID: Int, postType: ReportPostType, reason: String)
     case getAppLink
@@ -30,8 +31,10 @@ extension PublicService: TargetType {
     
     var path: String {
         switch self {
-        case .getMajorList(let univID, _):
+        case .getMajorList(let univID, _, _):
             return "/major/university/\(univID)"
+        case .registerFavoriteMajor:
+            return "/favorites"
         case .requestBlockUnBlockUser:
             return "/block"
         case .requestReport:
@@ -59,7 +62,7 @@ extension PublicService: TargetType {
         switch self {
         case .getMajorList, .getAppLink, .getPostList, .getPostDetail:
             return .get
-        case .requestBlockUnBlockUser, .requestReport, .requestWritePost, .likePost:
+        case .requestBlockUnBlockUser, .requestReport, .requestWritePost, .likePost, .registerFavoriteMajor:
             return .post
         case .editPost, .editPostComment:
             return .put
@@ -70,9 +73,14 @@ extension PublicService: TargetType {
     
     var task: Task {
         switch self {
-        case .getMajorList(_, let filter):
-            let body = ["filter": filter]
+        case .getMajorList(_, let filter, let userID):
+            let body: [String: Any] = [
+                "filter": filter,
+                "userId": userID
+            ]
             return .requestParameters(parameters: body, encoding: URLEncoding.queryString)
+        case .registerFavoriteMajor(let majorID):
+            return .requestParameters(parameters: ["majorId": majorID], encoding: JSONEncoding.default)
         case .requestBlockUnBlockUser(let blockUserID):
             return .requestParameters(parameters: ["blockedUserId": blockUserID], encoding: JSONEncoding.default)
         case .requestReport(let reportedTargetID, let postType, let reason):
@@ -125,7 +133,7 @@ extension PublicService: TargetType {
     
     var headers: [String: String]? {
         switch self {
-        case .requestBlockUnBlockUser, .requestReport, .getPostList, .requestWritePost, .getPostDetail, .editPost, .editPostComment, .likePost, .deletePost:
+        case .requestBlockUnBlockUser, .requestReport, .getPostList, .requestWritePost, .getPostDetail, .editPost, .editPostComment, .likePost, .deletePost, .registerFavoriteMajor:
             let accessToken = UserToken.shared.accessToken ?? ""
             return ["accessToken": accessToken]
         default:

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/HomeVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/HomeVC.swift
@@ -33,7 +33,7 @@ final class HomeVC: BaseVC {
             self.configureUI()
             self.setBackgroundTV()
             self.getRecentCommunityList()
-            self.requestGetMajorList(univID: UserDefaults.standard.integer(forKey: UserDefaults.Keys.univID), filterType: "all")
+            self.requestGetMajorList(univID: UserDefaults.standard.integer(forKey: UserDefaults.Keys.univID), filterType: "all", userID: UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID))
         }
     }
     
@@ -376,8 +376,8 @@ extension HomeVC {
     }
 
     /// 학과 리스트 조회 메서드
-    private func requestGetMajorList(univID: Int, filterType: String) {
-        PublicAPI.shared.getMajorListAPI(univID: univID, filterType: filterType) { networkResult in
+    func requestGetMajorList(univID: Int, filterType: String, userID: Int) {
+        PublicAPI.shared.getMajorListAPI(univID: univID, filterType: filterType, userID: userID) { networkResult in
             switch networkResult {
                 
             case .success(let res):
@@ -391,7 +391,7 @@ extension HomeVC {
                     self.makeAlert(title: AlertType.networkError.alertMessage)
                 } else if res is Bool {
                     self.updateAccessToken { _ in
-                        self.requestGetMajorList(univID: UserDefaults.standard.integer(forKey: UserDefaults.Keys.univID), filterType: "all")
+                        self.requestGetMajorList(univID: UserDefaults.standard.integer(forKey: UserDefaults.Keys.univID), filterType: "all", userID: UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID))
                     }
                 }
             default:

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/SignUpMajorInfo/VC/SignUpModalVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/SignUp/SignUpMajorInfo/VC/SignUpModalVC.swift
@@ -70,13 +70,13 @@ class SignUpModalVC: BaseVC {
     private func setData(enterType: SignUpMajorInfoEnterType) {
         switch enterType {
         case .firstMajor:
-            requestGetMajorList(univID: univID, filterType: "firstMajor")
+            requestGetMajorList(univID: univID, filterType: "firstMajor", userID: 0)
             applySnapshotForMajor(filter: "")
         case .firstMajorStart, .secondMajorStart:
             setStartList()
             applySnapshotForStart()
         case .secondMajor:
-            requestGetMajorList(univID: univID, filterType: "secondMajor")
+            requestGetMajorList(univID: univID, filterType: "secondMajor", userID: 0)
             applySnapshotForMajor(filter: "")
         }
     }
@@ -96,7 +96,8 @@ class SignUpModalVC: BaseVC {
             self.dataSourceForMajor = UITableViewDiffableDataSource<Section, MajorInfoModel>(tableView: self.majorTV) { (tableView, indexPath, data) -> UITableViewCell? in
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: MajorTVC.className, for: indexPath) as? MajorTVC else { preconditionFailure() }
                 cell.cellType = self.cellType
-                cell.setData(majorName: data)
+                cell.setData(model: data, indexPath: indexPath)
+                
                 return cell
             }
         case .firstMajorStart, .secondMajorStart:
@@ -173,18 +174,18 @@ class SignUpModalVC: BaseVC {
 extension SignUpModalVC {
     
     /// 학과 정보 리스트 조회
-    func requestGetMajorList(univID: Int, filterType: String) {
+    func requestGetMajorList(univID: Int, filterType: String, userID: Int) {
         self.activityIndicator.startAnimating()
-        PublicAPI.shared.getMajorListAPI(univID: univID, filterType: filterType) { networkResult in
+        PublicAPI.shared.getMajorListAPI(univID: univID, filterType: filterType, userID: userID) { networkResult in
             switch networkResult {
             case .success(let res):
                 DispatchQueue.main.async {
                     if let data = res as? [MajorInfoModel] {
                         for i in 0..<data.count {
-                            self.majorList.append(MajorInfoModel(majorID: data[i].majorID, majorName: data[i].majorName))
+                            self.majorList.append(MajorInfoModel(majorID: data[i].majorID, majorName: data[i].majorName, isFavorites: data[i].isFavorites))
                         }
-                        self.activityIndicator.stopAnimating()
                         self.applySnapshotForMajor(filter: "")
+                        self.activityIndicator.stopAnimating()
                     }
                 }
             case .requestErr(let msg):

--- a/NadoSunbae-iOS/NadoSunbae.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		771F2081290235D9000D56CF /* ReviewReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771F2080290235D9000D56CF /* ReviewReactor.swift */; };
 		771F20C929095635000D56CF /* ReviewWriterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771F20C829095635000D56CF /* ReviewWriterType.swift */; };
 		771F20CB2909B306000D56CF /* FavoriteMajorPostResModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771F20CA2909B306000D56CF /* FavoriteMajorPostResModel.swift */; };
+		771F20CD2909D673000D56CF /* SendCellBtnStatusDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771F20CC2909D673000D56CF /* SendCellBtnStatusDelegate.swift */; };
 		7754A3142790182A0093C230 /* ReviewWriteSB.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7754A3132790182A0093C230 /* ReviewWriteSB.storyboard */; };
 		7754A31627901FE50093C230 /* ReviewWriteVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7754A31527901FE50093C230 /* ReviewWriteVC.swift */; };
 		7754A318279028250093C230 /* ReviewNC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7754A317279028250093C230 /* ReviewNC.swift */; };
@@ -551,6 +552,7 @@
 		771F2080290235D9000D56CF /* ReviewReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewReactor.swift; sourceTree = "<group>"; };
 		771F20C829095635000D56CF /* ReviewWriterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewWriterType.swift; sourceTree = "<group>"; };
 		771F20CA2909B306000D56CF /* FavoriteMajorPostResModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteMajorPostResModel.swift; sourceTree = "<group>"; };
+		771F20CC2909D673000D56CF /* SendCellBtnStatusDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendCellBtnStatusDelegate.swift; sourceTree = "<group>"; };
 		7754A3132790182A0093C230 /* ReviewWriteSB.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ReviewWriteSB.storyboard; sourceTree = "<group>"; };
 		7754A31527901FE50093C230 /* ReviewWriteVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewWriteVC.swift; sourceTree = "<group>"; };
 		7754A317279028250093C230 /* ReviewNC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewNC.swift; sourceTree = "<group>"; };
@@ -1841,6 +1843,7 @@
 				C7A81AC428ED681600642B70 /* SendRankerDataDelegate.swift */,
 				3332359C28EF482000F92793 /* SendContentSizeDelegate.swift */,
 				33463AE12908016300323072 /* SendLoadingStatusDelegate.swift */,
+				771F20CC2909D673000D56CF /* SendCellBtnStatusDelegate.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -2236,6 +2239,7 @@
 				77A7592A2798028900A8E48B /* PublicAPI.swift in Sources */,
 				77A7593C2799C81B00A8E48B /* ReviewPostDetailData.swift in Sources */,
 				C71BF24027CD0CEB0030DCB9 /* MailCompleteVC.swift in Sources */,
+				771F20CD2909D673000D56CF /* SendCellBtnStatusDelegate.swift in Sources */,
 				5C32801C2797292B00781EBE /* MypageAPI.swift in Sources */,
 				5CF0EC2C279317FA00AF63E4 /* MypageUserVC+TV.swift in Sources */,
 				33F5080028E723E60037D632 /* WritePostReqModel.swift in Sources */,

--- a/NadoSunbae-iOS/NadoSunbae.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae.xcodeproj/project.pbxproj
@@ -213,6 +213,7 @@
 		5CF0EC2C279317FA00AF63E4 /* MypageUserVC+TV.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF0EC2B279317FA00AF63E4 /* MypageUserVC+TV.swift */; };
 		771F2081290235D9000D56CF /* ReviewReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771F2080290235D9000D56CF /* ReviewReactor.swift */; };
 		771F20C929095635000D56CF /* ReviewWriterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771F20C829095635000D56CF /* ReviewWriterType.swift */; };
+		771F20CB2909B306000D56CF /* FavoriteMajorPostResModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771F20CA2909B306000D56CF /* FavoriteMajorPostResModel.swift */; };
 		7754A3142790182A0093C230 /* ReviewWriteSB.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7754A3132790182A0093C230 /* ReviewWriteSB.storyboard */; };
 		7754A31627901FE50093C230 /* ReviewWriteVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7754A31527901FE50093C230 /* ReviewWriteVC.swift */; };
 		7754A318279028250093C230 /* ReviewNC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7754A317279028250093C230 /* ReviewNC.swift */; };
@@ -549,6 +550,7 @@
 		5CF0EC2B279317FA00AF63E4 /* MypageUserVC+TV.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MypageUserVC+TV.swift"; sourceTree = "<group>"; };
 		771F2080290235D9000D56CF /* ReviewReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewReactor.swift; sourceTree = "<group>"; };
 		771F20C829095635000D56CF /* ReviewWriterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewWriterType.swift; sourceTree = "<group>"; };
+		771F20CA2909B306000D56CF /* FavoriteMajorPostResModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteMajorPostResModel.swift; sourceTree = "<group>"; };
 		7754A3132790182A0093C230 /* ReviewWriteSB.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ReviewWriteSB.storyboard; sourceTree = "<group>"; };
 		7754A31527901FE50093C230 /* ReviewWriteVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewWriteVC.swift; sourceTree = "<group>"; };
 		7754A317279028250093C230 /* ReviewNC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewNC.swift; sourceTree = "<group>"; };
@@ -1797,6 +1799,7 @@
 				779DC5AC28EA942A009B9A43 /* ContentListData.swift */,
 				330ADB0728E353F80099E8D7 /* WritePostReqModel.swift */,
 				330ADB0928E358190099E8D7 /* WritePostResModel.swift */,
+				771F20CA2909B306000D56CF /* FavoriteMajorPostResModel.swift */,
 			);
 			path = Public;
 			sourceTree = "<group>";
@@ -2284,6 +2287,7 @@
 				C71BF22927CCB9550030DCB9 /* BlockListTVC.swift in Sources */,
 				5CC0BFE12798A3C300B96905 /* SignService.swift in Sources */,
 				33CBEBFF28FC3FCE002D0C84 /* AvailableQuestionPersonTVC.swift in Sources */,
+				771F20CB2909B306000D56CF /* FavoriteMajorPostResModel.swift in Sources */,
 				778E0F47287A061900BEEEA5 /* NadoMaskedImgView.swift in Sources */,
 				779DC5A528DCC004009B9A43 /* RecentReviewVC.swift in Sources */,
 				C783BF9F28A7A449000FE3D8 /* HomeRecentReviewResponseModel.swift in Sources */,


### PR DESCRIPTION
## 🍎 관련 이슈
closed #614

## 🍎 변경 사항 및 이유
학과 즐겨찾기 기능을 구현했습니다.

## 🍎 PR Point
- 스타버튼을 누를때 마다 즐겨찾기 등록/취소 요청이 되도록 API를 연결했습니다.
- 즐겨찾기 등록 후 바텀시트를 내렸다가 다시 올리면 내가 즐겨찾기한 학과가 상단에 배치되도록 즐겨찾기 등록/취소 요청 성공 시에 학과리스트 get 통신을 한번 더 해서 싱글톤의 majorList가 업데이트 될 수 있도록 했습니다.
- 학과 리스트 요청 시 즐겨찾기 정보를 받아오기 위해 userID를 보내는 것이 필요해서 학과 리스트 요청 네트워크 코드를 수정했습니다. 회원가입 시에 요청하는 경우에는 userID가 없고, 어떤 값을 보내도 상관없기 때문에 디폴트로 0을 넣어주었습니다.

## 📸 ScreenShot

- 즐겨찾기 기본 동작 및 검색으로 필터링 했을 때도 정상 요청

https://user-images.githubusercontent.com/63277563/198195580-fe9c0285-cc99-4a5d-b6a3-5cf064bc565e.mp4

- 다른 탭의 바텀시트에 즐겨찾기 정보 저장됨

https://user-images.githubusercontent.com/63277563/198195647-38436a12-09fc-407a-b775-f1dbfe029689.mp4

