### PR TITLE
🔨 [FIX] 과방 메인뷰 (ReviewVC, PersonalQuestionVC) 레이아웃 충돌 이슈 대응

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/ClassroomVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/ClassroomVC.swift
@@ -248,9 +248,17 @@ extension ClassroomVC {
     
     /// contentVCContainerView UI 구성 메서드
     private func configureContentVCContainerView(VC: UIViewController) {
+        let oppositeVC = VC == reviewVC ? personalQuestionVC : reviewVC
+        
+        if self.children.count > 0 {
+            oppositeVC.willMove(toParent: nil)
+            oppositeVC.removeFromParent()
+            oppositeVC.view.removeFromSuperview()
+        }
+        
+        addChild(VC)
         VC.viewWillLayoutSubviews()
         VC.didMove(toParent: self)
-        VC.view.frame.size = CGSize(width: contentVCContainerView.frame.width, height: VC.view.frame.height)
         contentVCContainerView.addSubview(VC.view ?? UIView())
     }
     
@@ -369,7 +377,7 @@ extension ClassroomVC {
     
     /// contentVCContainerView의 높이값을 기반으로 classroomSV의 contentOffset의 y좌표를 설정하는 메서드
     private func setClassroomSVContentYOffsetByHeight(height: CGFloat) {
-        var contentYOffset = classroomSV.contentOffset.y
+        let contentYOffset = classroomSV.contentOffset.y
         
         // yOffset이 192보다 크거나 같을 때
         // 스크롤되어 segmentedControlContainerView가 네비게이션 뷰 bottom에 닿았을 때
@@ -493,8 +501,21 @@ extension ClassroomVC: SendContentSizeDelegate {
                 segmentChangeActionStatus = false
             }
             
+            let screenHeight = UIScreen.main.bounds.height
+            let tabBarHeight = tabBarController?.tabBar.frame.height ?? 0
+            var contentVCHeight: CGFloat?
+            
+            // 컨텐츠 영역이 tabBar에 가려져서 컨텐츠 영역이 제대로 보여지지 않는 경우
+            if height < screenHeight && height + 352 > screenHeight - tabBarHeight {
+                contentVCHeight = height + 47
+            }
+            
+            [reviewVC, personalQuestionVC].forEach {
+                $0.view.frame.size = CGSize(width: contentVCContainerView.frame.width, height: contentVCHeight ?? height)
+            }
+                
             contentVCContainerView.snp.updateConstraints {
-                $0.height.equalTo(height)
+                $0.height.equalTo(contentVCHeight ?? height)
             }
         }
     }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #641

## 🍎 PR Point
- 과방 메인뷰 세그먼트로 뷰 이동시 (ReviewVC, PersonalQuestionVC) 레이아웃 충돌 이슈를 대응했습니다.
- 이제 진짜... 진짜 과방 메인뷰에서 레이아웃 문제될 일은 없을거라고... 생각합니다 ........... 테스트 많이 해봐주세용!!!!

## 📸 ScreenShot
<img width = 375 src="https://user-images.githubusercontent.com/63224278/198401692-882dc2e4-d4ed-496e-8e91-978959607706.gif">
