### PR TITLE
🔨 [QA] 선배랭킹 뷰의 목록 30개까지로 제한

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/Reactor/RankingReactor.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/Reactor/RankingReactor.swift
@@ -85,7 +85,15 @@ extension RankingReactor {
                 switch networkResult {
                 case .success(let res):
                     if let data = res as? HomeRankingResponseModel {
-                        observer.onNext(Mutation.requestRankingList(rankingList: data.userList))
+                        var rankingList: [HomeRankingResponseModel.UserList] = []
+                        if data.userList.count > 30 {
+                            for i in 0...29 {
+                                rankingList.append(data.userList[i])
+                            }
+                        } else {
+                            rankingList = data.userList
+                        }
+                        observer.onNext(Mutation.requestRankingList(rankingList: rankingList))
                         observer.onNext(Mutation.setLoading(loading: false))
                         observer.onCompleted()
                     }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #634

## 🍎 변경 사항 및 이유
홈 탭의 선배랭킹 뷰의 셀 개수를 최대 30개로 제한했습니다.

## 🍎 PR Point
x

## 📸 ScreenShot

https://user-images.githubusercontent.com/63277563/198445844-a93b58eb-609e-48b8-8228-3d834b9e2268.mp4


