### PR TITLE
🔨 [FIX] 랭킹 뷰 리로드 되지 않는 문제 해결

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/Reactor/RankingReactor.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/Reactor/RankingReactor.swift
@@ -16,7 +16,7 @@ final class RankingReactor: Reactor {
     enum Action {
         case tapCloseBtn
         case tapQuestionMarkBtn
-        case viewDidLoad
+        case reloadRankingList
     }
     
     enum Mutation {
@@ -35,7 +35,7 @@ final class RankingReactor: Reactor {
         var showAlert: Bool = false
         var alertMessage: String = ""
         var isUpdateAccessToken: Bool = false
-        var reRequestAction: Action = .viewDidLoad
+        var reRequestAction: Action = .reloadRankingList
     }
 }
 
@@ -47,7 +47,7 @@ extension RankingReactor {
             return Observable.concat(Observable.just(.setInfoContentViewStatus(isHidden: true)))
         case .tapQuestionMarkBtn:
             return Observable.concat(Observable.just(.setInfoContentViewStatus(isHidden: false)))
-        case .viewDidLoad:
+        case .reloadRankingList:
             return Observable.concat([
                 Observable.just(.setLoading(loading: true)),
                 self.requestRankingList()
@@ -95,7 +95,7 @@ extension RankingReactor {
                         observer.onNext(Mutation.setLoading(loading: false))
                         observer.onCompleted()
                     } else if res is Bool {
-                        observer.onNext(.setUpdateAccessTokenAction(action: .viewDidLoad))
+                        observer.onNext(.setUpdateAccessTokenAction(action: .reloadRankingList))
                         observer.onNext(Mutation.setUpdateAccessTokenState(state: true))
                     }
                 default:

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/RankingVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/RankingVC.swift
@@ -58,6 +58,7 @@ final class RankingVC: BaseVC, View {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         hideTabbar()
+        reactor?.action.onNext(.reloadRankingList)
     }
     
     func bind(reactor: RankingReactor) {
@@ -71,7 +72,7 @@ extension RankingVC {
     
     // MARK: Action
     private func bindAction(_ reactor: RankingReactor) {
-        reactor.action.onNext(.viewDidLoad)
+        reactor.action.onNext(.reloadRankingList)
         
         naviView.backBtn.rx.tap
             .bind { self.navigationController?.popViewController(animated: true) }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #649

## 🍎 변경 사항 및 이유
차단한 유저가 랭킹 리스트에서 사라지지 않는 문제가 있어 서버에 요청하고, 해당리스트가 리로드 될 수 있도록 했습니다.

## 🍎 PR Point
- viewWillAppear에서 한번 더 통신해주는 방식으로 리로드 시켜주었습니다!

## 📸 ScreenShot

https://user-images.githubusercontent.com/63277563/198498061-b51e0b92-dadc-45f0-af75-19333a35756a.mp4

