### PR TITLE
🔨 [FIX] 신고 누적자 및 부적절한 후기 작성자 권한 제한

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/BaseVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/BaseVC.swift
@@ -167,13 +167,13 @@ extension BaseVC {
     }
     
     /// 신고, 부적절 후기 사용, 후기 미등록자, 일반유저 권한 최종 분기처리 메서드
-    func divideUserPermission(defaultAction: () -> Void) {
+    func divideUserPermission(isReviewBtn: Bool = false, defaultAction: () -> Void) {
         if UserPermissionInfo.shared.isUserReported {
             self.showRestrictionAlert(permissionStatus: .report)
         } else if UserPermissionInfo.shared.isReviewInappropriate {
             self.showRestrictionAlert(permissionStatus: .inappropriate)
         } else if !(UserPermissionInfo.shared.isReviewed) {
-            self.showRestrictionAlert(permissionStatus: .review)
+            isReviewBtn ? defaultAction() : self.showRestrictionAlert(permissionStatus: .review)
         } else {
             // 아무런 제한이 없을 때 실행되는 action
             defaultAction()

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/BaseVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/BaseVC.swift
@@ -167,13 +167,13 @@ extension BaseVC {
     }
     
     /// 신고, 부적절 후기 사용, 후기 미등록자, 일반유저 권한 최종 분기처리 메서드
-    func divideUserPermission(isReviewBtn: Bool = false, defaultAction: () -> Void) {
+    func divideUserPermission(isExceptionOfNoReview: Bool = false, defaultAction: () -> Void) {
         if UserPermissionInfo.shared.isUserReported {
             self.showRestrictionAlert(permissionStatus: .report)
         } else if UserPermissionInfo.shared.isReviewInappropriate {
             self.showRestrictionAlert(permissionStatus: .inappropriate)
         } else if !(UserPermissionInfo.shared.isReviewed) {
-            isReviewBtn ? defaultAction() : self.showRestrictionAlert(permissionStatus: .review)
+            isExceptionOfNoReview ? defaultAction() : self.showRestrictionAlert(permissionStatus: .review)
         } else {
             // 아무런 제한이 없을 때 실행되는 action
             defaultAction()

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/ClassroomVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/ClassroomVC.swift
@@ -364,7 +364,9 @@ extension ClassroomVC {
     private func tapReviewWriteBtnAction() {
         reviewWriteBtn.press { [weak self] in
             guard let self = self else { return }
-            self.navigator?.instantiateVC(destinationViewControllerType: ReviewWriteVC.self, useStoryboard: true, storyboardName: "ReviewWriteSB", naviType: .present, modalPresentationStyle: .fullScreen) { destination in }
+            self.divideUserPermission(isReviewBtn: true) {
+                self.navigator?.instantiateVC(destinationViewControllerType: ReviewWriteVC.self, useStoryboard: true, storyboardName: "ReviewWriteSB", naviType: .present, modalPresentationStyle: .fullScreen) { destination in }
+            }
         }
     }
     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/ClassroomVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/ClassroomVC.swift
@@ -364,7 +364,7 @@ extension ClassroomVC {
     private func tapReviewWriteBtnAction() {
         reviewWriteBtn.press { [weak self] in
             guard let self = self else { return }
-            self.divideUserPermission(isReviewBtn: true) {
+            self.divideUserPermission(isExceptionOfNoReview: true) {
                 self.navigator?.instantiateVC(destinationViewControllerType: ReviewWriteVC.self, useStoryboard: true, storyboardName: "ReviewWriteSB", naviType: .present, modalPresentationStyle: .fullScreen) { destination in }
             }
         }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/HomeVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/HomeVC.swift
@@ -178,9 +178,11 @@ extension HomeVC: UITableViewDataSource {
                     subTitleCell.setTitleLabel(title: "최근 후기")
                     subTitleCell.moreBtn.removeTarget(nil, action: nil, for: .allEvents)
                     subTitleCell.moreBtn.press { [weak self] in
-                        let recentReviewVC = RecentReviewVC()
-                        recentReviewVC.reactor = RecentReviewReactor()
-                        self?.navigationController?.pushViewController(recentReviewVC, animated: true)
+                        self?.divideUserPermission() {
+                            let recentReviewVC = RecentReviewVC()
+                            recentReviewVC.reactor = RecentReviewReactor()
+                            self?.navigationController?.pushViewController(recentReviewVC, animated: true)
+                        }
                     }
                     return subTitleCell
                 case 1:


### PR DESCRIPTION
## 🍎 관련 이슈
closed #635

## 🍎 변경 사항 및 이유
- 신고 누적자 및 부적절한 후기 작성자 권한을 제한했습니다.

## 🍎 PR Point
- 신고 누적자의 경우 `과방 - 후기작성버튼클릭 시` 후기 작성 불가
- 부적절한 후기 작성자의 경우 후기를 먼저 작성해야 다른 권한이 생김 -> 후기 작성 버튼 클릭 시에는 제한 알럿이 뜨지않고 바로 후기 작성 뷰로 넘어가도록 baseVC의 판단 함수로직을 후기 작성 버튼 클릭 시에만 디폴트액션으로 넘어가도록 수정했습니다 @hwangJi-dev 확인부탁드립니다!
- 부적절한 후기작성자 - 홈탭에서도 후기 열람 막음

## 📸 ScreenShot
- 신고 누적자: 후기 작성 불가

https://user-images.githubusercontent.com/63277563/198505239-919515d6-8e29-4280-bc4a-1e7516d2aa00.mp4



- 부적절 후기 작성자: 후기작성 버튼 클릭 시에만 그냥 넘어감

https://user-images.githubusercontent.com/63277563/198504840-a756e255-d482-49e0-8067-c52f8c6d64a8.mp4

- 부적절 후기 작성자: 홈 탭에서도 후기 뷰 접근 불가

https://user-images.githubusercontent.com/63277563/198504860-064b976e-fe2a-478b-b2fb-ecda5a46247c.mp4



