### PR TITLE
🔨 [QA] 후기 수정 시 디폴트로 완료 버튼 비활성화

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/ProfileSetting/VC/EditProfileVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Mypage/ProfileSetting/VC/EditProfileVC.swift
@@ -16,7 +16,7 @@ class EditProfileVC: BaseVC {
         didSet {
             navView.setUpNaviStyle(state: .backDefaultWithNadoBtn)
             navView.configureTitleLabel(title: "프로필 수정")
-            navView.rightActivateBtn.setTitleWithStyle(title: "저장", size: 14)
+            navView.rightActivateBtn.setTitleWithStyle(title: "저장", size: 14, weight: .semiBold)
             navView.backBtn.press {
                 guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
                 

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewWriteVC.swift
@@ -101,7 +101,7 @@ class ReviewWriteVC: BaseVC {
         [oneLineReviewTextView, prosAndConsTextView, learnInfoTextView, recommendClassTextView, badClassTextView, futureTextView, tipTextView].forEach {
             textView in setUpCharCount(textView: textView)
         }
-        setUpDefaultBgImg()
+        setUpDefaultStatus()
         makeDefaultAnalyticsEvent(eventName: "후기작성뷰_진입")
         makeScreenAnalyticsEvent(screenName: "Review Tab", screenClass: ReviewWriteVC.className)
     }
@@ -185,9 +185,10 @@ extension ReviewWriteVC {
         ])
     }
     
-    /// 디폴트로 선택된 배경 이미지 설정 함수
-    private func setUpDefaultBgImg() {
+    /// 디폴트로 선택된 배경 이미지 설정 및 완료버튼 비활성화 상태 설정 함수
+    private func setUpDefaultStatus() {
         self.bgImgCV.selectItem(at: IndexPath(item: bgImgID - 6, section: 0), animated: true, scrollPosition: .left)
+        reviewWriteNaviBar.rightActivateBtn.isActivated = false
     }
     
     /// 조건에 따라 완료버튼 상태 설정하는 함수
@@ -315,6 +316,9 @@ extension ReviewWriteVC: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         self.bgImgID = indexPath.row + 6
+        
+        /// 완료 버튼 활성화 조건 검사 (필수작성항목 모두 채워지고, 선택항목 조건 달성)
+        reviewWriteNaviBar.rightActivateBtn.isActivated = essentialTextViewStatus && choiceTextViewStatus
     }
 }
 


### PR DESCRIPTION
## 🍎 관련 이슈
closed #653

## 🍎 변경 사항 및 이유
후기글 수정 시 완료버튼의 디폴트 상태가 비활성화로 될 수 있도록 수정했습니다.

## 🍎 PR Point
배경 이미지 수정 혹은 텍스트 입력 변화 감지 시 완료 버튼 활성화 조건 검사를 다시해서 조건에 부합하면 활성화되도록 했습니다.
+ 프로필 수정 뷰 저장 버튼 폰트를 수정해주었습니다.

## 📸 ScreenShot

https://user-images.githubusercontent.com/63277563/198516433-a4ce01cb-063d-458f-8804-9b42ee1914f6.mp4


https://user-images.githubusercontent.com/63277563/198516521-fdfc6418-6e0f-4aee-962f-7d15134fb809.mp4


