### PR TITLE
🔨 [FIX] 과방 메인 1:1 질문뷰 무한로딩 버그 해결하기

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/ClassroomVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/ClassroomVC.swift
@@ -70,7 +70,6 @@ final class ClassroomVC: BaseVC {
     
     private var reviewVC: ReviewVC = ReviewVC()
     private var personalQuestionVC: PersonalQuestionVC = PersonalQuestionVC()
-    private let loadingDispatchGroup = DispatchGroup()
     private var segmentChangeActionStatus: Bool = false
     private var filterStatus = false
     private var selectedWriterFilter: ReviewWriterType = .all
@@ -368,13 +367,6 @@ extension ClassroomVC {
         }
     }
     
-    /// loadingDispatchGroup의 count가 0이 되었음을 알리는 메서드
-    private func notifyLoadingDispatchGroupFinished() {
-        loadingDispatchGroup.notify(queue: DispatchQueue.main) {
-            self.activityIndicator.stopAnimating()
-        }
-    }
-    
     /// contentVCContainerView의 높이값을 기반으로 classroomSV의 contentOffset의 y좌표를 설정하는 메서드
     private func setClassroomSVContentYOffsetByHeight(height: CGFloat) {
         let contentYOffset = classroomSV.contentOffset.y
@@ -524,17 +516,6 @@ extension ClassroomVC: SendContentSizeDelegate {
 // MARK: - SendLoadingStatusDelegate
 extension ClassroomVC: SendLoadingStatusDelegate {
     func sendLoadingStatus(loading: Bool) {
-        let dispatchCount = self.loadingDispatchGroup.debugDescription.components(separatedBy: ",").filter({ $0.contains("count") }).first?.components(separatedBy: CharacterSet.decimalDigits.inverted).compactMap({ Int($0)} ).first ?? 0
-        
-        if loading {
-            self.activityIndicator.startAnimating()
-            loadingDispatchGroup.enter()
-        } else {
-            if dispatchCount > 0 {
-                self.loadingDispatchGroup.leave()
-            }
-        }
-        
-        self.notifyLoadingDispatchGroupFinished()
+        loading ? self.activityIndicator.startAnimating() : self.activityIndicator.stopAnimating()
     }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/PersonalQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/PersonalQuestionVC.swift
@@ -161,7 +161,16 @@ extension PersonalQuestionVC: View {
         reactor.state
             .map { $0.loading }
             .subscribe(onNext: { [weak self] loading in
-                self?.loadingDelegate?.sendLoadingStatus(loading: loading)
+                
+                // loading array에 true값이 하나라도 포함되어있다면 loadingStatus: true를 보낸다.
+                if loading.contains(true) {
+                    self?.loadingDelegate?.sendLoadingStatus(loading: true)
+                }
+                
+                // 통신작업이 모두 끝나고 loading array값이 모두 false가 되었다면 loadingStatus: false를 보낸다.
+                if loading.allSatisfy({ $0 == false }) {
+                    self?.loadingDelegate?.sendLoadingStatus(loading: false)
+                }
             })
             .disposed(by: disposeBag)
         
@@ -178,9 +187,12 @@ extension PersonalQuestionVC: View {
             .map { $0.isUpdateAccessToken }
             .distinctUntilChanged()
             .subscribe(onNext: { state in
-                if state {
+
+                if state.contains(true) {
                     self.updateAccessToken { _ in
-                        reactor.action.onNext(reactor.currentState.reRequestAction)
+                        for i in reactor.currentState.reRequestAction {
+                            reactor.action.onNext(i)
+                        }
                     }
                 }
             })


### PR DESCRIPTION
## 🍎 관련 이슈
closed #652

## 🍎 변경 사항 및 이유
- 한 뷰에서 2개의 통신 코드가 끝난 후 일괄적으로 loading상태를 ClassroomVC로 넘겨주기 위해서 reactor 코드를 일부 수정했습니다.
- 엑세스토큰 갱신처리도 동일

## 🍎 PR Point
- 과방 메인 1:1 질문뷰 무한로딩 버그를 해결하고, 엑세스토큰 갱신 버그를 해결했습니다.

## 📸 ScreenShot
X
