### PR TITLE
🔨 [FIX] 404 에러 네트워크 상태코드 분기처리문 수정하기

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIEssentials/BaseAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIEssentials/BaseAPI.swift
@@ -20,7 +20,9 @@ class BaseAPI {
             return .success(decodedData.data ?? "None-Data")
         case 401:
             return .requestErr(false)
-        case 400, 402..<500:
+        case 404:
+            return .requestErr(404)
+        case 400, 402, 403, 405..<500:
             return .requestErr(decodedData.message)
         case 500:
             return .serverErr

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -821,8 +821,12 @@ extension DefaultQuestionChatVC {
                         self?.optionalBindingData()
                     }
                 } else if res is Int {
-                    self?.activityIndicator.stopAnimating()
-                    self?.makeAlert(title: AlertType.deletedPost.alertMessage) { _ in
+                    guard let self = self else { return }
+                    self.activityIndicator.stopAnimating()
+                    
+                    guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
+                    alert.showNadoAlert(vc: self, message: AlertType.deletedPost.alertMessage, confirmBtnTitle: "네", cancelBtnTitle: "", type: .withSingleBtn)
+                    alert.confirmBtn.press(vibrate: true, for: .touchUpInside) { [weak self] in
                         self?.navigationController?.popViewController(animated: true)
                     }
                 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -825,7 +825,7 @@ extension DefaultQuestionChatVC {
                     self.activityIndicator.stopAnimating()
                     
                     guard let alert = Bundle.main.loadNibNamed(NadoAlertVC.className, owner: self, options: nil)?.first as? NadoAlertVC else { return }
-                    alert.showNadoAlert(vc: self, message: AlertType.deletedPost.alertMessage, confirmBtnTitle: "네", cancelBtnTitle: "", type: .withSingleBtn)
+                    alert.showNadoAlert(vc: self, message: AlertType.deletedPost.alertMessage, confirmBtnTitle: "확인", cancelBtnTitle: "", type: .withSingleBtn)
                     alert.confirmBtn.press(vibrate: true, for: .touchUpInside) { [weak self] in
                         self?.navigationController?.popViewController(animated: true)
                     }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #660

## 🍎 변경 사항 및 이유
- 서버에서 이미 글이 삭제되었다는 failure상태를 전하기 위해 404에러 코드를 사용하기 때문에 상태코드 분기처리문에서 404 에러를 대응할 수 있도록 BaseAPI 코드를 수정해주었습니다.

## 🍎 PR Point
- 404 에러 네트워크 상태코드 분기처리문 수정
- 이미 삭제된 글 조회시 나도선배 기본 알럿이 뜨도록 코드 수정

## 📸 ScreenShot


https://user-images.githubusercontent.com/63224278/198534209-9d5b4a77-42b7-4c2c-99eb-c40bcf5fc6d2.MP4

