### PR TITLE
🔨 [FIX] 커뮤니티 탭 학과 바텀시트 필터 적용 시 학과가 제대로 선택되지 않는 문제 해결

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/HalfModalVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/HalfModalVC.swift
@@ -63,6 +63,7 @@ class HalfModalVC: BaseVC {
     var hasNoMajorOption: Bool = true
     var isSecondMajorSheet: Bool = false
     var selectFilterIndex: Int = 0
+    var filteredIndex: Int = 0
     
     // MARK: Life Cycle
     override func viewDidLoad() {
@@ -258,7 +259,13 @@ extension HalfModalVC {
                     selectFilterIndex = 0
                 }
                 
-                self.majorTV.selectRow(at: IndexPath(row: selectFilterIndex == 0 ? selectFilterIndex : selectFilterIndex - 1, section: 0), animated: false, scrollPosition: .top)
+                for i in 0...filteredList.count - 1 {
+                    if filteredList[i].majorID == selectFilterIndex {
+                        filteredIndex = i
+                    }
+                }
+                
+                self.majorTV.selectRow(at: IndexPath(row: filteredIndex, section: 0), animated: false, scrollPosition: .top)
                 completeBtn.isActivated = true
                 completeBtn.titleLabel?.textColor = UIColor.mainDefault
             }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #667

## 🍎 변경 사항 및 이유
커뮤니티 탭 학과 바텀시트 필터 적용 후 다시 바텀시트를 present하면 학과가 제대로 선택되지 않는 문제를 해결했습니다.

## 🍎 PR Point
- 문제원인: CommunityVC에서 `slideVC.selectFilterIndex = reactor?.currentState.filterMajorID ?? MajorIDConstants.regardlessMajorID` 이렇게 선택된 majorID를 halfModalVC로 전달해주고 있는데, 이 값은 majorID이기 때문에 즐겨찾기, 검색 시 변동에 따라 해당 majorID가 위치하는 셀 인덱스는 계속해서 바뀝니다! 그래서 전달받은 majorID값이 인덱스 몇번에 위치하고 있는지 아래와 같이 찾아 그 인덱스가 선택될 수 있도록 코드를 수정했습니다.

```Swift
for i in 0...filteredList.count - 1 {
       if filteredList[i].majorID == selectFilterIndex {
               filteredIndex = i
       }
}
                
self.majorTV.selectRow(at: IndexPath(row: filteredIndex, section: 0), animated: false, scrollPosition: .top)
```

## 📸 ScreenShot

https://user-images.githubusercontent.com/63277563/198549828-9b530543-ee1f-4c9d-b9e5-cd9778bdbdf5.mp4

