### PR TITLE
🔨 [FIX] 권한 없는 사용자 최근 후기 리스트 진입 불가 문제 해결

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/HomeVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/HomeVC.swift
@@ -181,11 +181,9 @@ extension HomeVC: UITableViewDataSource {
                     subTitleCell.setTitleLabel(title: "최근 후기")
                     subTitleCell.moreBtn.removeTarget(nil, action: nil, for: .allEvents)
                     subTitleCell.moreBtn.press { [weak self] in
-                        self?.divideUserPermission() {
-                            let recentReviewVC = RecentReviewVC()
-                            recentReviewVC.reactor = RecentReviewReactor()
-                            self?.navigationController?.pushViewController(recentReviewVC, animated: true)
-                        }
+                        let recentReviewVC = RecentReviewVC()
+                        recentReviewVC.reactor = RecentReviewReactor()
+                        self?.navigationController?.pushViewController(recentReviewVC, animated: true)
                     }
                     return subTitleCell
                 case 1:

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/RecentReviewVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Home/VC/RecentReviewVC.swift
@@ -62,8 +62,10 @@ extension RecentReviewVC {
         /// 학과 후기 상세 뷰로 이동 
         reviewTV.rx.modelSelected(HomeRecentReviewResponseDataElement.self)
             .subscribe(onNext: { item in
-                self.navigator?.instantiateVC(destinationViewControllerType: ReviewDetailVC.self, useStoryboard: true, storyboardName: "ReviewDetailSB", naviType: .push) { reviewDetailVC in
-                    reviewDetailVC.postId = item.id
+                self.divideUserPermission() {
+                    self.navigator?.instantiateVC(destinationViewControllerType: ReviewDetailVC.self, useStoryboard: true, storyboardName: "ReviewDetailSB", naviType: .push) { reviewDetailVC in
+                        reviewDetailVC.postId = item.id
+                    }
                 }
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
## 🍎 관련 이슈
closed #670

## 🍎 변경 사항 및 이유
권한 없는 사용자의 경우 최근 후기 리스트까지는 조회되도록 권한 판단 위치를 수정해주었습니다.

## 🍎 PR Point
x

## 📸 ScreenShot

https://user-images.githubusercontent.com/63277563/198683699-749b7669-7567-4068-a177-f3a37128f19f.mp4


