### PR TITLE
🔨 [FIX] 1:1 질문 상세뷰) 채팅 보내기 UI/UX Interaction을 개선합니다.

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -55,7 +55,7 @@ final class DefaultQuestionChatVC: BaseVC {
             sendAreaTextView.layer.borderWidth = 1
             sendAreaTextView.layer.borderColor = UIColor.gray1.cgColor
             sendAreaTextView.textContainerInset = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 15)
-            configueTextViewPlaceholder()
+            configueTextViewPlaceholder(isPlaceholder: true)
             sendAreaTextView.sizeToFit()
         }
     }
@@ -182,12 +182,11 @@ extension DefaultQuestionChatVC {
     }
     
     /// userType별로 TextView의 placeholder 지정하는 메서드
-    private func configueTextViewPlaceholder() {
+    private func configueTextViewPlaceholder(isPlaceholder: Bool) {
         sendAreaTextView.isEditable = true
-        sendAreaTextView.text = "답글쓰기"
-        sendAreaTextView.endEditing(true)
-        sendAreaTextView.textColor = .gray2
-        sendAreaTextView.backgroundColor = .gray0
+        sendAreaTextView.text = isPlaceholder ? "답글쓰기" : ""
+        sendAreaTextView.textColor = isPlaceholder ? .gray2 : .black
+        sendAreaTextView.backgroundColor = isPlaceholder ? .gray0 : .white
     }
     
     private func scrollTVtoBottom(animate: Bool) {
@@ -642,7 +641,7 @@ extension DefaultQuestionChatVC: UITextViewDelegate {
     /// textViewDidEndEditing
     func textViewDidEndEditing(_ textView: UITextView) {
         if textView.text.isEmpty {
-            configueTextViewPlaceholder()
+            configueTextViewPlaceholder(isPlaceholder: true)
             sendBtn.isEnabled = false
             isTextViewEmpty = true
         }
@@ -808,9 +807,9 @@ extension DefaultQuestionChatVC {
                     if self.isCommentSend == true {
                         self.scrollTVtoBottom(animate: true)
                         self.isCommentSend = false
+                        self.configueTextViewPlaceholder(isPlaceholder: false)
                     }
                     
-                    self.configueTextViewPlaceholder()
                     self.activityIndicator.stopAnimating()
                 }
             case .requestErr(let res):


### PR DESCRIPTION
## 🍎 관련 이슈
closed #676

## 🍎 PR Point
- 1:1 질문 상세뷰의 채팅 보내기 UI/UX Interaction을 개선했습니다. 
- 채팅 보낼 때 endediting(true) 코드가 사용되어 무조건 KeyBoard가 내려가게 구현되어 있었는데, 
지속해서 메시지를 보내고 싶을 경우 키보드를 계속 올려줘야하는 수고로움이 발생해서 해당 UI/UX 인터랙션을 수정해주었습니다. 

- 질문글같은 경우는 정보 댓글과 같은 1회성 댓글이 아닐 것이고 실제 채팅처럼 여러번 보내는 경우도 많을 것이라 판단되어 수정하게 되었습니다~

## 📸 ScreenShot
### 수정 전


https://user-images.githubusercontent.com/63224278/199209816-6650b608-b835-4bb5-8866-eabebe713fe2.MP4



### 수정 후

https://user-images.githubusercontent.com/63224278/199210368-51342c57-3fcd-4136-ac32-cf695d44fe00.MP4



