### PR TITLE
✨ [FEAT] 커뮤니티 글 작성 관련 GA 기능 구현하기

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/BaseVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Class/BaseVC.swift
@@ -216,6 +216,20 @@ extension BaseVC {
         }
     }
     
+    /// Firebase Analytics 기본 이벤트 메서드
+    func makeAnalyticsEvent(eventName: GAEventNameType, parameterValue: String) {
+        // TODO: 배포 전 주석 제거
+//        if env() == .production {
+            let parameterName = eventName.hasParameter ? eventName.parameterName : nil
+            
+            if let parameterName = parameterName {
+                FirebaseAnalytics.Analytics.logEvent("\(eventName)", parameters: [parameterName : parameterValue])
+            } else {
+                FirebaseAnalytics.Analytics.logEvent("\(eventName)", parameters: nil)
+            }
+//        }
+    }
+    
     /// Firebase Analytics 화면 조회 이벤트를 발생시키는 메서드
     func makeScreenAnalyticsEvent(screenName: String, screenClass: String) {
         if env() == .production {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Protocol/SendGAEventDelegate.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Protocol/SendGAEventDelegate.swift
@@ -1,0 +1,12 @@
+//
+//  SendGAEventDelegate.swift
+//  NadoSunbae
+//
+//  Created by hwangJi on 2022/11/01.
+//
+
+import Foundation
+
+protocol SendGAEventDelegate {
+    func sendEvent(eventName: GAEventNameType, parameter: String)
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Protocol/SendGAEventDelegate.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Protocol/SendGAEventDelegate.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol SendGAEventDelegate {
-    func sendEvent(eventName: GAEventNameType, parameter: String)
+    func sendEvent(eventName: GAEventNameType, parameterValue: String)
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/GAEventNameType.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/GAEventNameType.swift
@@ -1,0 +1,63 @@
+//
+//  GAEventNameType.swift
+//  NadoSunbae
+//
+//  Created by hwangJi on 2022/11/01.
+//
+
+import Foundation
+
+enum GAEventNameType {
+    case signup_process
+    case write_request_alert
+    case review_process
+    case community_write
+    case review_read
+    case question_read_1on1
+    case senior_click
+    case community_read
+    case question_answered_1on1
+    case mention_function
+    case review_write
+    case question_write_1on1
+    case update_opt
+    case user_post
+    case home_viewmore
+    case banner_click
+    case profile_change
+    case first_login
+    case search_function
+    case alert_opt
+    case remail_button
+    case like_click
+    case bottomsheet_function
+    case new_question_button_1on1
+}
+
+extension GAEventNameType {
+    var parameter: String {
+        switch self {
+        case .signup_process, .review_process, .senior_click:
+            return "journey"
+        case .write_request_alert, .alert_opt:
+            return "choice"
+        case .community_write, .question_read_1on1, .community_read, .mention_function, .review_write, .question_write_1on1, .profile_change, .remail_button:
+            return "type"
+        case .home_viewmore:
+            return "tap"
+        case .banner_click:
+            return "number"
+        case .user_post:
+            return "post_type"
+        default: return ""
+        }
+    }
+    
+    var hasParameter: Bool {
+        switch self {
+        case .review_read, .question_answered_1on1, .update_opt, .first_login, .search_function, .like_click, .bottomsheet_function, .new_question_button_1on1:
+            return false
+        default: return true
+        }
+    }
+}

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/GAEventNameType.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/GAEventNameType.swift
@@ -35,7 +35,7 @@ enum GAEventNameType {
 }
 
 extension GAEventNameType {
-    var parameter: String {
+    var parameterName: String {
         switch self {
         case .signup_process, .review_process, .senior_click:
             return "journey"

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/PostFilterType.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/PostFilterType.swift
@@ -30,4 +30,18 @@ extension PostFilterType {
             return "1:1 질문"
         }
     }
+    
+    var postWriteLogEventParameterValue: String {
+        switch self {
+        case .general:
+            return "c_free_upload"
+        case .questionToEveryone:
+            return "c_question_upload"
+        case .information:
+            return "c_info_upload"
+        case .questionToPerson:
+            return "question_1on1_upload"
+        default: return ""
+        }
+    }
 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/PublicAPI.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Network/APIManagers/PublicAPI.swift
@@ -10,7 +10,7 @@ import Moya
 
 class PublicAPI: BaseAPI {
     static let shared = PublicAPI()
-    var publicProvider = MoyaProvider<PublicService>(plugins: [NetworkLoggerPlugin()])
+    var publicProvider = MoyaProvider<PublicService>()
     
     private override init() {}
     

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityPostDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityPostDetailVC.swift
@@ -485,6 +485,7 @@ extension CommunityPostDetailVC {
                     DispatchQueue.main.async {
                         self.isTextViewEmpty = true
                         self.requestGetDetailInfoData(postID: postID, addLoadBackView: false)
+                        self.makeAnalyticsEvent(eventName: .community_write, parameterValue: "c_comment_write")
                         self.activityIndicator.stopAnimating()
                     }
                 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityPostDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityPostDetailVC.swift
@@ -59,6 +59,7 @@ class CommunityPostDetailVC: BaseVC {
     private var isWriter: Bool?
     private let textViewMaxHeight: CGFloat = 85.adjustedH
     private let whiteBackView = UIView()
+    private var isFirstLoad: Bool = true
     
     // MARK: Life Cycle
     override func viewDidLoad() {
@@ -444,6 +445,13 @@ extension CommunityPostDetailVC {
                     self.userID = UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID)
                     self.isWriter = (self.userID == self.infoDetailData?.writer.writerID) ? true : false
                     self.setUpNaviSubTitle(major: data.post.majorName)
+                    
+                    // 첫번째 로드일 때만 Analytics Event를 보낸다
+                    if self.isFirstLoad {
+                        let parameterValue: String = data.post.type == "질문" ? "c_question_read" : (data.post.type == "정보" ? "c_info_read" : "c_free_read")
+                        self.makeAnalyticsEvent(eventName: .community_read, parameterValue: parameterValue)
+                        self.isFirstLoad = false
+                    }
                     
                     DispatchQueue.main.async {
                         self.infoDetailTV.reloadData()

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Support/AppDelegate.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Support/AppDelegate.swift
@@ -23,7 +23,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         /// 자동 초기화 방지
         Messaging.messaging().isAutoInitEnabled = true
         
-        
         /// 현재 등록 토큰 가져오기
         Messaging.messaging().token { token, error in
             if let error = error {
@@ -41,7 +40,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         ])
         
         #if DEVELOPMENT || QA
-        Analytics.setAnalyticsCollectionEnabled(false)
+        // TODO: 배포 전 수정하기
+        Analytics.setAnalyticsCollectionEnabled(true)
+//        Analytics.setAnalyticsCollectionEnabled(false)
         #endif
         
         return true

--- a/NadoSunbae-iOS/NadoSunbae.xcodeproj/project.pbxproj
+++ b/NadoSunbae-iOS/NadoSunbae.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		331C537C2795F4EF0052B309 /* QuestionPeopleHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 331C537B2795F4EF0052B309 /* QuestionPeopleHeaderView.xib */; };
 		331C537E2795F6260052B309 /* QuestionPeopleHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C537D2795F6260052B309 /* QuestionPeopleHeaderView.swift */; };
 		331C5382279629620052B309 /* BaseQuestionTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C5381279629620052B309 /* BaseQuestionTVC.swift */; };
+		331D0DD3291131BE00A32EE8 /* GAEventNameType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331D0DD2291131BE00A32EE8 /* GAEventNameType.swift */; };
+		331D0DD5291135AA00A32EE8 /* SendGAEventDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331D0DD4291135AA00A32EE8 /* SendGAEventDelegate.swift */; };
 		33286B7B28A4F813006E6FF0 /* CommunitySearchVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33286B7A28A4F813006E6FF0 /* CommunitySearchVC.swift */; };
 		33286B7D28A4FF76006E6FF0 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33286B7C28A4FF76006E6FF0 /* UIImage+.swift */; };
 		3332359928EF374A00F92793 /* ClassroomVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3332359828EF374A00F92793 /* ClassroomVC.swift */; };
@@ -395,6 +397,8 @@
 		331C537B2795F4EF0052B309 /* QuestionPeopleHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = QuestionPeopleHeaderView.xib; sourceTree = "<group>"; };
 		331C537D2795F6260052B309 /* QuestionPeopleHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionPeopleHeaderView.swift; sourceTree = "<group>"; };
 		331C5381279629620052B309 /* BaseQuestionTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseQuestionTVC.swift; sourceTree = "<group>"; };
+		331D0DD2291131BE00A32EE8 /* GAEventNameType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GAEventNameType.swift; sourceTree = "<group>"; };
+		331D0DD4291135AA00A32EE8 /* SendGAEventDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendGAEventDelegate.swift; sourceTree = "<group>"; };
 		33286B7A28A4F813006E6FF0 /* CommunitySearchVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunitySearchVC.swift; sourceTree = "<group>"; };
 		33286B7C28A4FF76006E6FF0 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		3332359828EF374A00F92793 /* ClassroomVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassroomVC.swift; sourceTree = "<group>"; };
@@ -821,6 +825,7 @@
 				3367955D29002E54005E83FC /* ReportPostType.swift */,
 				33463ADF2907E10400323072 /* AlertType.swift */,
 				771F20C829095635000D56CF /* ReviewWriterType.swift */,
+				331D0DD2291131BE00A32EE8 /* GAEventNameType.swift */,
 			);
 			path = Struct;
 			sourceTree = "<group>";
@@ -1844,6 +1849,7 @@
 				3332359C28EF482000F92793 /* SendContentSizeDelegate.swift */,
 				33463AE12908016300323072 /* SendLoadingStatusDelegate.swift */,
 				771F20CC2909D673000D56CF /* SendCellBtnStatusDelegate.swift */,
+				331D0DD4291135AA00A32EE8 /* SendGAEventDelegate.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -2180,6 +2186,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				331D0DD3291131BE00A32EE8 /* GAEventNameType.swift in Sources */,
 				5C3280182797217E00781EBE /* MypageService.swift in Sources */,
 				C7ACE62F27CB71FA0011B23F /* SettingVC.swift in Sources */,
 				5CA73379278A8F4900806B17 /* NadoAlertVC.swift in Sources */,
@@ -2435,6 +2442,7 @@
 				C740A85B27C7C58500C4518A /* EditProfileVC.swift in Sources */,
 				775728B127D6617300148C9A /* OnboardingVC.swift in Sources */,
 				C7ACE63227CB73F80011B23F /* SettingTVC.swift in Sources */,
+				331D0DD5291135AA00A32EE8 /* SendGAEventDelegate.swift in Sources */,
 				33BAFD00278C004700BFF6BE /* ClassroomCommentTVC.swift in Sources */,
 				330DA4352790C3E300FE127F /* UIScrollView+.swift in Sources */,
 				7754A32327947F310093C230 /* ReviewDetailVC.swift in Sources */,

--- a/NadoSunbae-iOS/NadoSunbae.xcodeproj/xcshareddata/xcschemes/NadoSunbae-iOS.xcscheme
+++ b/NadoSunbae-iOS/NadoSunbae.xcodeproj/xcshareddata/xcschemes/NadoSunbae-iOS.xcscheme
@@ -50,6 +50,12 @@
             ReferencedContainer = "container:NadoSunbae.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-FIRAnalyticsVerboseLoggingEnabled"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
## 🍎 관련 이슈
closed #673

## 🍎 변경 사항 및 이유
- GA Event 이름을 관리하는 GAEventNameType을 추가했습니다. (현재 문서에 나와있는 수집 이벤트들 모두 기입)
- Reactor에서 GA Event를 수집하는 Protocol을 채택할 수 있도록 SendGAEventDelegate를 추가했습니다.

## 🍎 PR Point
- GA 이벤트 수집시 기본적으로 사용할 수 있는 메서드를 추가하고, 커뮤니티 글 작성 관련 GA 기능을 구현했습니다.
- 아직 Firebase Dev모드를 연동하지 않아서, GA 수집 테스트를 하는 동안은 Dev모드에서도 GA 수집을 허용하도록 주석처리를 해둔 상태입니다.

GA 이벤트 수집시 함수 사용 예시:

![스크린샷 2022-11-01 21 53 38](https://user-images.githubusercontent.com/63224278/199236712-addf35b2-4193-4ff5-9149-eb3459118762.png)

`GAEventNameType` 에 EventName별 ParameterName까지 변수로 추가해두어서 makeAnalyticsEvent에서 매개변수로 받는 값은 Parameter의 Value값 (사진에서 1) c_question_upload, 2) c_info_upload, 3) c_free_upload, 4) c_comment_upload) 면 됩니다! 따라서 수집하고자 하는 GA의 ParameterValue값을 상황에 따라 전달해주시면 됩니다!

`self.makeAnalyticsEvent(eventName: .community_write, parameterValue: parameterValue)`

## 📸 ScreenShot

