### PR TITLE
✨ [FEAT] 검색, 좋아요, 바텀시트, 선배에게 새질문 관련 GA 이벤트 수집기능 구현

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/GAEventNameType.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/GAEventNameType.swift
@@ -41,7 +41,7 @@ extension GAEventNameType {
             return "journey"
         case .write_request_alert, .alert_opt:
             return "choice"
-        case .community_write, .question_read_1on1, .community_read, .mention_function, .review_write, .question_write_1on1, .profile_change, .remail_button:
+        case .community_write, .question_read_1on1, .community_read, .mention_function, .review_write, .question_write_1on1, .profile_change, .remail_button, .bottomsheet_function:
             return "type"
         case .home_viewmore:
             return "tap"
@@ -57,7 +57,7 @@ extension GAEventNameType {
     
     var hasParameter: Bool {
         switch self {
-        case .review_read, .question_answered_1on1, .update_opt, .first_login, .search_function, .bottomsheet_function, .new_question_button_1on1:
+        case .review_read, .question_answered_1on1, .update_opt, .first_login, .search_function, .new_question_button_1on1:
             return false
         default: return true
         }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/GAEventNameType.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/GAEventNameType.swift
@@ -41,7 +41,7 @@ extension GAEventNameType {
             return "journey"
         case .write_request_alert, .alert_opt:
             return "choice"
-        case .community_write, .question_read_1on1, .community_read, .mention_function, .review_write, .question_write_1on1, .profile_change, .remail_button, .bottomsheet_function:
+        case .community_write, .question_read_1on1, .community_read, .mention_function, .review_write, .question_write_1on1, .profile_change, .remail_button, .bottomsheet_function, .like_click:
             return "type"
         case .home_viewmore:
             return "tap"
@@ -49,8 +49,6 @@ extension GAEventNameType {
             return "number"
         case .user_post:
             return "post_type"
-        case .like_click:
-            return "like_on"
         default: return ""
         }
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/GAEventNameType.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/Struct/GAEventNameType.swift
@@ -49,13 +49,15 @@ extension GAEventNameType {
             return "number"
         case .user_post:
             return "post_type"
+        case .like_click:
+            return "like_on"
         default: return ""
         }
     }
     
     var hasParameter: Bool {
         switch self {
-        case .review_read, .question_answered_1on1, .update_opt, .first_login, .search_function, .like_click, .bottomsheet_function, .new_question_button_1on1:
+        case .review_read, .question_answered_1on1, .update_opt, .first_login, .search_function, .bottomsheet_function, .new_question_button_1on1:
             return false
         default: return true
         }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/HalfModalVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/HalfModalVC.swift
@@ -303,6 +303,10 @@ extension HalfModalVC: UITextFieldDelegate {
     func textFieldDidChange(_ sender: Any?) {
         applySnapshot(filter: searchTextField.text)
     }
+    
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        makeAnalyticsEvent(eventName: .bottomsheet_function, parameterValue: "search_major")
+    }
 }
 
 // MARK: - SendCellBtnStatusDelegate
@@ -378,9 +382,10 @@ extension HalfModalVC {
             switch networkResult {
                 
             case .success(let res):
-                if let _ = res as? FavoriteMajorPostResModel {
+                if let favoriteData = res as? FavoriteMajorPostResModel {
                     self.applySnapshot(filter: self.searchTextField.text?.isEmpty ?? false ? "" : self.searchTextField.text, applyAnimation: false)
                     self.requestGetMajorList(univID: UserDefaults.standard.integer(forKey: UserDefaults.Keys.univID), filterType: "all", userID: UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID))
+                    self.makeAnalyticsEvent(eventName: .bottomsheet_function, parameterValue: favoriteData.isDeleted ? "favorite_off" : "favorite_on")
                 }
             case .requestErr(let res):
                 if let _ = res as? String {

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -381,6 +381,7 @@ extension DefaultQuestionChatVC {
                     configureQuestionFloatingBtn()
                     goToQuestionfloatingBtn.press { [weak self] in
                         guard let self = self else { return }
+                        self.makeAnalyticsEvent(eventName: .new_question_button_1on1, parameterValue: "")
                         self.navigator?.instantiateVC(destinationViewControllerType: WriteQuestionVC.self, useStoryboard: true, storyboardName: Identifiers.WriteQusetionSB, naviType: .present, modalPresentationStyle: .fullScreen) { writeQuestionVC in
                             writeQuestionVC.answererID = self.answererID
                             writeQuestionVC.isFromQuestionDetailVC = true

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/Question/DefaultQuestionChatVC.swift
@@ -908,7 +908,10 @@ extension DefaultQuestionChatVC {
         PublicAPI.shared.postLikeAPI(postID: postID, postType: .post) { networkResult in
             switch networkResult {
             case .success(let res):
-                if let _ = res as? PostLikeResModel {
+                if let likeData = res as? PostLikeResModel {
+                    if likeData.isLiked {
+                        self.makeAnalyticsEvent(eventName: .like_click, parameterValue: "like_on")
+                    }
                     self.requestGetDetailQuestionData(postID: self.postID ?? 0)
                     self.activityIndicator.stopAnimating()
                 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityPostDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunityPostDetailVC.swift
@@ -520,9 +520,12 @@ extension CommunityPostDetailVC {
         PublicAPI.shared.postLikeAPI(postID: postID, postType: postType) { networkResult in
             switch networkResult {
             case .success(let res):
-                if let _ = res as? PostLikeResModel {
+                if let likeData = res as? PostLikeResModel {
                     DispatchQueue.main.async {
                         self.requestGetDetailInfoData(postID: self.postID ?? 0, addLoadBackView: false)
+                    }
+                    if likeData.isLiked {
+                        self.makeAnalyticsEvent(eventName: .like_click, parameterValue: "like_on")
                     }
                     self.activityIndicator.stopAnimating()
                 }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunitySearchVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Community/VC/CommunitySearchVC.swift
@@ -263,6 +263,7 @@ extension CommunitySearchVC: UISearchBarDelegate {
     
     /// searchBarSearchButtonClicked
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        makeAnalyticsEvent(eventName: .search_function, parameterValue: "")
         reactor?.action.onNext(.tapCompleteSearchBtn(searchKeyword: searchBar.searchTextField.text ?? ""))
         view.endEditing(true)
     }

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Notification/VC/NotificationMainVC+TV.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Notification/VC/NotificationMainVC+TV.swift
@@ -58,7 +58,15 @@ extension NotificationMainVC: UITableViewDelegate {
                 }
                 
                 /// 커뮤니티로 이동
-            case 3, 5, 8, 9, 10:
+            case 3, 5, 8, 9:
+                self.navigator?.instantiateVC(destinationViewControllerType: CommunityPostDetailVC.self, useStoryboard: true, storyboardName: "CommunityPostDetailSB", naviType: .push) { postDetailVC in
+                    postDetailVC.postID = self.notificationList[indexPath.section].postID
+                    postDetailVC.hidesBottomBarWhenPushed = true
+                }
+                
+                /// 커뮤니티_특정학과대상 질문글 푸시알림인 경우 GA Event 수집 및 커뮤니티로 이동
+            case 10:
+                self.makeAnalyticsEvent(eventName: .mention_function, parameterValue: "mention_active")
                 self.navigator?.instantiateVC(destinationViewControllerType: CommunityPostDetailVC.self, useStoryboard: true, storyboardName: "CommunityPostDetailSB", naviType: .push) { postDetailVC in
                     postDetailVC.postID = self.notificationList[indexPath.section].postID
                     postDetailVC.hidesBottomBarWhenPushed = true

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Review/VC/ReviewDetailVC.swift
@@ -274,9 +274,11 @@ extension ReviewDetailVC {
         PublicAPI.shared.postLikeAPI(postID: postID, postType: .review) { networkResult in
             switch networkResult {
             case .success(let res):
-                if let _ = res as? PostLikeResModel {
+                if let likeData = res as? PostLikeResModel {
                     self.requestGetReviewPostDetail(postID: postID)
-                    print(res)
+                    if likeData.isLiked {
+                        self.makeAnalyticsEvent(eventName: .like_click, parameterValue: "like_on")
+                    }
                     self.activityIndicator.stopAnimating()
                 }
             case .requestErr(let res):


### PR DESCRIPTION
## 🍎 관련 이슈
closed #683

## 🍎 변경 사항 및 이유
- 파라미터명 없던 like, bottomsheet 파라미터명 -> type으로 추가

## 🍎 PR Point
- 검색, 좋아요, 바텀시트, 선배에게 새질문 관련 GA 이벤트 수집기능을 구현했습니다.
- mention_function event의 mention_active 파라미터를 수집하기 위해 알림탭 분기처리문 중 notificationID 10번일 경우를 수정해주었습니다.

## 📸 ScreenShot

