### PR TITLE
🔨 [FIX] 과방 최신 1:1질문 TV, 우리과 선배찾기 CV Empty 상태일 때도 클릭되는 문제 해결

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/PersonalQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/PersonalQuestionVC.swift
@@ -69,7 +69,8 @@ final class PersonalQuestionVC: BaseVC {
         bindrecentQuestionTV()
         bindSeniorCV()
         seeMoreBtn.press { [weak self] in
-            self?.navigator?.instantiateVC(destinationViewControllerType: QuestionPersonListVC.self, useStoryboard: false, storyboardName: QuestionPersonListVC.className, naviType: .push) { _ in
+            self?.navigator?.instantiateVC(destinationViewControllerType: QuestionPersonListVC.self, useStoryboard: false, storyboardName: QuestionPersonListVC.className, naviType: .push) { questionPersonListVC in
+                questionPersonListVC.hidesBottomBarWhenPushed = true
             }
         }
         NotificationCenter.default.addObserver(self, selector: #selector(setUpInitAction), name: Notification.Name.dismissHalfModal, object: nil)
@@ -229,12 +230,17 @@ extension PersonalQuestionVC: View {
     private func bindSeniorCV() {
         availableQuestionPersonCV.rx.modelSelected(QuestionUser.self)
             .subscribe(onNext: { [weak self] item in
-                if item.userID == -2 {
-                    self?.navigator?.instantiateVC(destinationViewControllerType: QuestionPersonListVC.self, useStoryboard: false, storyboardName: QuestionPersonListVC.className, naviType: .push) { _ in }
-                } else {
-                    self?.makeAnalyticsEvent(eventName: .senior_click, parameterValue: "senior_classroom_out")
-                    self?.navigator?.instantiateVC(destinationViewControllerType: MypageUserVC.self, useStoryboard: true, storyboardName: MypageUserVC.className, naviType: .push) { mypageUserVC in
-                        mypageUserVC.targetUserID = item.userID
+                if self?.reactor?.currentState.seniorList.isEmpty == false {
+                    if item.userID == -2 {
+                        self?.navigator?.instantiateVC(destinationViewControllerType: QuestionPersonListVC.self, useStoryboard: false, storyboardName: QuestionPersonListVC.className, naviType: .push) { questionPersonListVC in
+                            questionPersonListVC.hidesBottomBarWhenPushed = true
+                        }
+                    } else {
+                        self?.makeAnalyticsEvent(eventName: .senior_click, parameterValue: "senior_classroom_out")
+                        self?.navigator?.instantiateVC(destinationViewControllerType: MypageUserVC.self, useStoryboard: true, storyboardName: MypageUserVC.className, naviType: .push) { mypageUserVC in
+                            mypageUserVC.targetUserID = item.userID
+                            mypageUserVC.hidesBottomBarWhenPushed = true
+                        }
                     }
                 }
             })

--- a/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/PersonalQuestionVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Screen/Classroom/VC/PersonalQuestionVC.swift
@@ -209,15 +209,17 @@ extension PersonalQuestionVC: View {
     private func bindrecentQuestionTV() {
         recentQuestionTV.rx.modelSelected(PostListResModel.self)
             .subscribe(onNext: { [weak self] item in
-                self?.divideUserPermission() {
-                    guard let postDetailVC = UIStoryboard.init(name: "QuestionChatSB", bundle: nil).instantiateViewController(withIdentifier: DefaultQuestionChatVC.className) as? DefaultQuestionChatVC else { return }
-                    let postDetailNC = UINavigationController(rootViewController: postDetailVC)
-                    postDetailVC.naviStyle = .present
-                    postDetailVC.postID = item.postID
-                    postDetailVC.isAuthorized = item.isAuthorized
-                    postDetailNC.modalPresentationStyle = .fullScreen
-                    postDetailNC.navigationBar.isHidden = true
-                    self?.present(postDetailNC, animated: true)
+                if item.postID != -1 {
+                    self?.divideUserPermission() {
+                        guard let postDetailVC = UIStoryboard.init(name: "QuestionChatSB", bundle: nil).instantiateViewController(withIdentifier: DefaultQuestionChatVC.className) as? DefaultQuestionChatVC else { return }
+                        let postDetailNC = UINavigationController(rootViewController: postDetailVC)
+                        postDetailVC.naviStyle = .present
+                        postDetailVC.postID = item.postID
+                        postDetailVC.isAuthorized = item.isAuthorized
+                        postDetailNC.modalPresentationStyle = .fullScreen
+                        postDetailNC.navigationBar.isHidden = true
+                        self?.present(postDetailNC, animated: true)
+                    }
                 }
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
## 🍎 관련 이슈
closed #694

## 🍎 PR Point
과방탭의 최신 1:1질문 TV, 우리과 선배찾기 CV에서 Empty 상태일 때도 클릭되는 문제를 해결했습니다.

## 📸 ScreenShot
X
