### PR TITLE
🔨 [FIX] 과방 바텀시트 즐겨찾기 추가 시 바로 반영이 되지 않는 문제

### DIFF
--- a/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/HalfModalVC.swift
+++ b/NadoSunbae-iOS/NadoSunbae-iOS/Global/UIComponent/Xib/HalfModalVC.swift
@@ -360,6 +360,7 @@ extension HalfModalVC {
             case .success(let res):
                 if let data = res as? [MajorInfoModel] {
                     MajorInfo.shared.majorList = data
+                    self.setUpMajorList(hasNoMajorOption: self.hasNoMajorOption)
                 }
             case .requestErr(let res):
                 if let _ = res as? String {
@@ -383,7 +384,6 @@ extension HalfModalVC {
                 
             case .success(let res):
                 if let favoriteData = res as? FavoriteMajorPostResModel {
-                    self.applySnapshot(filter: self.searchTextField.text?.isEmpty ?? false ? "" : self.searchTextField.text, applyAnimation: false)
                     self.requestGetMajorList(univID: UserDefaults.standard.integer(forKey: UserDefaults.Keys.univID), filterType: "all", userID: UserDefaults.standard.integer(forKey: UserDefaults.Keys.UserID))
                     self.makeAnalyticsEvent(eventName: .bottomsheet_function, parameterValue: favoriteData.isDeleted ? "favorite_off" : "favorite_on")
                 }


### PR DESCRIPTION
## 🍎 관련 이슈
closed #697

## 🍎 변경 사항 및 이유
과방 및 커뮤니티 바텀시트에서도 동일하게 즐겨찾기 여부가 바로 반영이 되도록 코드를 수정했습니다.

## 🍎 PR Point
- 커뮤니티 탭에서도 확인완료 했습니다.

## 📸 ScreenShot

https://user-images.githubusercontent.com/63277563/201376581-3f3613e5-5e2a-4bc1-9318-964eb679fbe9.mp4


